### PR TITLE
fix: surface Claude Keychain access guidance

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-json.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-json.json
@@ -1,0 +1,62 @@
+{
+  "generatedAt": "2026-07-07T18:14:42.622Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "cache",
+      "plan": "pro",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 84,
+          "percentRemaining": 16,
+          "resetsAt": "2026-07-07T18:00:00.000Z"
+        }
+      ],
+      "state": {
+        "status": "stale",
+        "stale": true,
+        "refreshedAt": "2026-07-07T16:00:00.000Z",
+        "error": "Claude sign-in required",
+        "sourcesTried": [
+          "oauth-file",
+          "keychain",
+          "cache"
+        ],
+        "reason": "keychain_access_required",
+        "remedyCommand": "quota-axi --allow-keychain-prompt"
+      }
+    },
+    {
+      "provider": "codex",
+      "label": "Codex",
+      "source": "cli-rpc",
+      "plan": "pro",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 8,
+          "percentRemaining": 92,
+          "resetsAt": "2026-07-07T20:00:00.000Z"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-07T16:10:00.000Z",
+        "sourcesTried": [
+          "cli-rpc"
+        ]
+      }
+    }
+  ],
+  "help": [
+    "Tell your user: run `quota-axi --allow-keychain-prompt` once and approve Keychain access (\"Always Allow\") so quota-axi can read claude's live quota."
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-json.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-json.json
@@ -22,11 +22,7 @@
         "stale": true,
         "refreshedAt": "2026-07-07T16:00:00.000Z",
         "error": "Claude sign-in required",
-        "sourcesTried": [
-          "oauth-file",
-          "keychain",
-          "cache"
-        ],
+        "sourcesTried": ["oauth-file", "keychain", "cache"],
         "reason": "keychain_access_required",
         "remedyCommand": "quota-axi --allow-keychain-prompt"
       }
@@ -50,9 +46,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-07T16:10:00.000Z",
-        "sourcesTried": [
-          "cli-rpc"
-        ]
+        "sourcesTried": ["cli-rpc"]
       }
     }
   ],

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-toon.txt
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-toon.txt
@@ -1,0 +1,17 @@
+$ quota-axi
+bin: quota-axi
+description: Report local agent-provider quota windows for routing-aware agents
+generatedAt: "2026-07-07T18:14:42.620Z"
+providers[2]{provider,plan,source,status,refreshedAt}:
+  claude,pro,cache,stale,"2026-07-07T16:00:00.000Z"
+  codex,pro,cli-rpc,fresh,"2026-07-07T16:10:00.000Z"
+windows[2]{provider,id,label,percentRemaining,resetsAt,state}:
+  claude,five_hour,session,16,"2026-07-07T18:00:00.000Z",stale
+  codex,five_hour,session,92,"2026-07-07T20:00:00.000Z",fresh
+advice[1]{provider,reason,remedyCommand}:
+  claude,keychain_access_required,quota-axi --allow-keychain-prompt
+help[4]:
+  Tell your user: run `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow") so quota-axi can read claude's live quota.
+  Run `quota-axi --provider claude --json` for JSON output
+  Run `quota-axi --full` to include account and source-attempt details
+  Run `quota-axi auth` to inspect local auth source availability without printing secrets

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-provider-probe-audit.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-provider-probe-audit.json
@@ -13,16 +13,8 @@
       "credentialPresent": true
     },
     "securityCalls": [
-      [
-        "find-generic-password",
-        "-s",
-        "Claude Code-credentials"
-      ],
-      [
-        "find-generic-password",
-        "-s",
-        "Claude Code-credentials"
-      ]
+      ["find-generic-password", "-s", "Claude Code-credentials"],
+      ["find-generic-password", "-s", "Claude Code-credentials"]
     ],
     "requestedPasswordValue": false
   },
@@ -30,12 +22,7 @@
     "quotaStatus": "fresh",
     "quotaSource": "oauth",
     "securityCalls": [
-      [
-        "find-generic-password",
-        "-s",
-        "Claude Code-credentials",
-        "-w"
-      ]
+      ["find-generic-password", "-s", "Claude Code-credentials", "-w"]
     ],
     "requestedPasswordValue": true
   }

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-provider-probe-audit.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-provider-probe-audit.json
@@ -1,0 +1,42 @@
+{
+  "defaultNoPrompt": {
+    "authKeychainSource": {
+      "source": "keychain",
+      "status": "skipped",
+      "error": "keychain_prompt_required",
+      "credentialPresent": true
+    },
+    "quotaKeychainAttempt": {
+      "source": "keychain",
+      "status": "skipped",
+      "error": "keychain_prompt_required",
+      "credentialPresent": true
+    },
+    "securityCalls": [
+      [
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials"
+      ],
+      [
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials"
+      ]
+    ],
+    "requestedPasswordValue": false
+  },
+  "allowKeychainPrompt": {
+    "quotaStatus": "fresh",
+    "quotaSource": "oauth",
+    "securityCalls": [
+      [
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials",
+        "-w"
+      ]
+    ],
+    "requestedPasswordValue": true
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,9 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Provider adapter behavior (retry-after handling, snake/camel field tolerance, window parsing) is an original, clean-room implementation derived only from the vendors' own OAuth/HTTP behavior; quota-axi carries no vendored or attributed third-party adapter code.
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
-- JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits.
-- macOS Claude Keychain reads are skipped by default because they can prompt.
-- `--allow-keychain-prompt` is the only v1 opt-in for that behavior.
+- JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
+- macOS Claude Keychain value reads are skipped by default because they can prompt; quota-axi may still run a non-secret Keychain item presence check so it only suggests access when a credential item exists.
+- `--allow-keychain-prompt` is the only opt-in that permits reading the Claude Keychain value, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
 - Codex uses `$CODEX_HOME/auth.json` or `~/.codex/auth.json` OAuth before the CLI fallback.
 - Codex `auth.json` support is OAuth-token only; never treat `OPENAI_API_KEY` as valid quota auth or send API keys to ChatGPT quota endpoints.
 - Never launch the Claude CLI to probe quota, because that would spend the quota being measured.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 ```
 
 - **Live first** - direct provider usage calls use 15 second request timeouts, Codex JSON-RPC reads use short per-call timeouts, and stale cache fallback is per provider.
-- **No default Keychain prompt** - macOS Claude Keychain reads are skipped unless `--allow-keychain-prompt` is passed.
+- **No default Keychain prompt** - macOS Claude Keychain value reads are skipped unless `--allow-keychain-prompt` is passed.
 - **Partial success is success** - one provider can fail while another returns fresh or stale data, and the process still exits 0. Exit code 1 means every provider failed, and 2 means a usage error.
 - **No token equivalence** - quota-axi does not claim that one provider percentage equals another provider percentage.
 
@@ -203,10 +203,11 @@ Quota reports contain `providers`, each with `provider`, `label`, `source`, `win
 With `--full`, providers can also include `account` identity and per-source `attempts`.
 Provider `state` includes `status`, `stale`, `sourcesTried`, optional `refreshedAt`, optional `error`, optional `retryAfter`, optional `reason`, and optional `remedyCommand`.
 When stale or unavailable quota is likely fixable by a one-time macOS Keychain grant, `state.reason` is `keychain_access_required`, `state.remedyCommand` is `quota-axi --allow-keychain-prompt`, and JSON includes an agent-directed `help` entry.
+Default TOON output includes the same condition in an `advice` block with `provider`, `reason`, and `remedyCommand`, plus the agent-directed help line.
 Quota windows include `id`, `label`, `kind`, optional percentages, optional reset fields, optional `windowSeconds`, and optional credit-spend fields.
 Account identity and per-source `attempts` are omitted unless `--full` is passed.
 Provider statuses are `fresh`, `stale`, `unavailable`, `auth_required`, `rate_limited`, or `error`.
-Provider sources are `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`; v1 emits `oauth`, `cli-rpc`, `cache`, and `unavailable`.
+Provider sources are `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`; current provider adapters emit `oauth`, `cli-rpc`, `cache`, and `unavailable`.
 Window kinds are `session`, `weekly`, `monthly`, `model`, `credits`, or `unknown`.
 Source attempts use `success`, `failed`, or `skipped`.
 Source attempts can include `credentialPresent` when a non-secret probe confirms a credential item exists.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ It is data only: it never routes, recommends, proxies, intercepts, logs in, impo
 
 ## Quick Start
 
+**macOS + Claude note:** Claude Code keeps its live token in the macOS Keychain.
+quota-axi will not read that token unless the user grants permission, so Claude quota reads can stay stale until the user grants access after on-disk credentials expire.
+Run `quota-axi --allow-keychain-prompt` once and approve Keychain access with "Always Allow" so future non-interactive quota reads can refresh live Claude data.
+
 ```sh
 $ npx -y quota-axi
 bin: ~/.npm/_npx/.../quota-axi
@@ -52,7 +56,7 @@ help[3]:
 $ quota-axi --provider claude --json
 {
   "generatedAt": "2026-03-15T16:42:03.000Z",
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "providers": [
     {
       "provider": "claude",
@@ -194,10 +198,11 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ## Output Model
 
-`--json` emits `schemaVersion: 1`.
+`--json` emits `schemaVersion: 2`.
 Quota reports contain `providers`, each with `provider`, `label`, `source`, `windows`, `state`, optional `plan`, and optional `credits`.
 With `--full`, providers can also include `account` identity and per-source `attempts`.
-Provider `state` includes `status`, `stale`, `sourcesTried`, optional `refreshedAt`, optional `error`, and optional `retryAfter`.
+Provider `state` includes `status`, `stale`, `sourcesTried`, optional `refreshedAt`, optional `error`, optional `retryAfter`, optional `reason`, and optional `remedyCommand`.
+When stale or unavailable quota is likely fixable by a one-time macOS Keychain grant, `state.reason` is `keychain_access_required`, `state.remedyCommand` is `quota-axi --allow-keychain-prompt`, and JSON includes an agent-directed `help` entry.
 Quota windows include `id`, `label`, `kind`, optional percentages, optional reset fields, optional `windowSeconds`, and optional credit-spend fields.
 Account identity and per-source `attempts` are omitted unless `--full` is passed.
 Provider statuses are `fresh`, `stale`, `unavailable`, `auth_required`, `rate_limited`, or `error`.

--- a/README.md
+++ b/README.md
@@ -209,18 +209,21 @@ Provider statuses are `fresh`, `stale`, `unavailable`, `auth_required`, `rate_li
 Provider sources are `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`; v1 emits `oauth`, `cli-rpc`, `cache`, and `unavailable`.
 Window kinds are `session`, `weekly`, `monthly`, `model`, `credits`, or `unknown`.
 Source attempts use `success`, `failed`, or `skipped`.
+Source attempts can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 Claude can report `five_hour`, `seven_day`, optional `seven_day_opus`, and optional `extra_usage` windows.
 When the account's usage response includes a scoped `limits` list, quota-axi surfaces every active window it describes instead, including model-scoped ones (e.g. Fable) as a `model:<slug>` window.
 Codex can report `five_hour` and `weekly` windows plus optional credit balance data, plus any additional model- or feature-scoped rate limits the account has as `model:<id>:5h` / `model:<id>:7d` windows, and an optional code-review rate limit as `code_review_five_hour` / `code_review_weekly`.
 `auth --json` emits `generatedAt`, `schemaVersion: 1`, and `auth`, where each provider report has `provider` and `sources`.
 Auth source entries include `source`, optional `path`, `status`, and optional `error`.
+Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 Auth source statuses are `available`, `missing`, `invalid`, `expired`, or `skipped`.
 Auth source names are `oauth-file`, `keychain`, `auth-json`, and `cli-rpc`.
 
 ## Security Posture
 
 quota-axi reads `~/.claude/.credentials.json` for Claude.
-On macOS, it reads `Claude Code-credentials` from Keychain only with `--allow-keychain-prompt`; when enabled, the Keychain credential is tried before file credentials.
+On macOS, it reads the `Claude Code-credentials` Keychain value only with `--allow-keychain-prompt`; when enabled, the Keychain credential is tried before file credentials.
+Without that flag, quota-axi may perform a non-secret Keychain item presence check so it only suggests Keychain access when a Claude credential item exists.
 For Codex, it reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback.
 Codex `auth.json` support is OAuth-token only; API key values such as `OPENAI_API_KEY` are treated as invalid for quota usage calls and are not sent to ChatGPT usage endpoints.
 It may run `codex -s read-only -a untrusted app-server` for Codex JSON-RPC fallback.

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -34,7 +34,8 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
    secret values.
-6. If quota output reports `reason: keychain_access_required`, tell your user to run
+6. On macOS, Claude Keychain value reads are skipped by default.
+   If quota output reports `reason: keychain_access_required`, tell your user to run
    `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow").
 
 ## Usage

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -34,8 +34,8 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
    secret values.
-6. On macOS, Claude Keychain reads are skipped by default; pass `--allow-keychain-prompt`
-   to permit a Keychain prompt.
+6. If quota output reports `reason: keychain_access_required`, tell your user to run
+   `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow").
 
 ## Usage
 

--- a/src/advice.ts
+++ b/src/advice.ts
@@ -1,0 +1,87 @@
+import type {
+  ProviderQuota,
+  QuotaAxiResponse,
+  SourceAttempt,
+} from "./types.js";
+
+export const KEYCHAIN_ACCESS_REASON = "keychain_access_required";
+export const KEYCHAIN_ACCESS_REMEDY_COMMAND =
+  "quota-axi --allow-keychain-prompt";
+
+const BLOCKED_CREDENTIAL_ERRORS = new Set([
+  "credentials_expired",
+  "credentials_missing",
+]);
+
+export function annotateQuotaAdvice(
+  response: Omit<QuotaAxiResponse, "schemaVersion">,
+): QuotaAxiResponse {
+  const providers = response.providers.map(annotateProviderAdvice);
+  const help = providers
+    .filter(hasKeychainAccessAdvice)
+    .map(keychainAccessHelpLine);
+  return {
+    generatedAt: response.generatedAt,
+    schemaVersion: 2,
+    providers,
+    ...(help.length > 0 ? { help } : {}),
+  };
+}
+
+export function quotaHelpLines(response: QuotaAxiResponse): string[] {
+  return [
+    ...(response.help ?? []),
+    "Run `quota-axi --provider claude --json` for JSON output",
+    "Run `quota-axi --full` to include account and source-attempt details",
+    "Run `quota-axi auth` to inspect local auth source availability without printing secrets",
+  ];
+}
+
+function annotateProviderAdvice(provider: ProviderQuota): ProviderQuota {
+  if (!needsKeychainAccessAdvice(provider)) return provider;
+  return {
+    ...provider,
+    state: {
+      ...provider.state,
+      reason: KEYCHAIN_ACCESS_REASON,
+      remedyCommand: KEYCHAIN_ACCESS_REMEDY_COMMAND,
+    },
+  };
+}
+
+function needsKeychainAccessAdvice(provider: ProviderQuota): boolean {
+  const attempts = provider.attempts ?? [];
+  return (
+    provider.state.status !== "fresh" &&
+    !attempts.some((attempt) => attempt.status === "success") &&
+    attempts.some(isBlockedCredentialAttempt) &&
+    attempts.some(isPromptBlockedKeychainAttempt)
+  );
+}
+
+function isBlockedCredentialAttempt(attempt: SourceAttempt): boolean {
+  return (
+    attempt.source !== "keychain" &&
+    attempt.status === "skipped" &&
+    Boolean(attempt.error && BLOCKED_CREDENTIAL_ERRORS.has(attempt.error))
+  );
+}
+
+function isPromptBlockedKeychainAttempt(attempt: SourceAttempt): boolean {
+  return (
+    attempt.source === "keychain" &&
+    attempt.status === "skipped" &&
+    attempt.error === "keychain_prompt_required"
+  );
+}
+
+function hasKeychainAccessAdvice(provider: ProviderQuota): boolean {
+  return (
+    provider.state.reason === KEYCHAIN_ACCESS_REASON &&
+    provider.state.remedyCommand === KEYCHAIN_ACCESS_REMEDY_COMMAND
+  );
+}
+
+function keychainAccessHelpLine(provider: ProviderQuota): string {
+  return `Tell your user: run \`${KEYCHAIN_ACCESS_REMEDY_COMMAND}\` once and approve Keychain access ("Always Allow") so quota-axi can read ${provider.provider}'s live quota.`;
+}

--- a/src/advice.ts
+++ b/src/advice.ts
@@ -71,7 +71,8 @@ function isPromptBlockedKeychainAttempt(attempt: SourceAttempt): boolean {
   return (
     attempt.source === "keychain" &&
     attempt.status === "skipped" &&
-    attempt.error === "keychain_prompt_required"
+    attempt.error === "keychain_prompt_required" &&
+    attempt.credentialPresent === true
   );
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { annotateQuotaAdvice } from "./advice.js";
 import { writeCachedProviders } from "./cache.js";
 import { nowIso } from "./lib/time.js";
 import { PROVIDERS, parseProviders } from "./providers/index.js";
@@ -166,11 +167,10 @@ async function fetchQuota(
   const results = await Promise.all(
     providers.map((provider) => PROVIDERS[provider].fetchQuota(options)),
   );
-  return {
+  return annotateQuotaAdvice({
     generatedAt: nowIso(),
-    schemaVersion: 1,
     providers: results,
-  };
+  });
 }
 
 async function inspectAuth(

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -27,6 +27,7 @@ const OAUTH_BETA = "oauth-2025-04-20";
 const CLAUDE_CODE_USER_AGENT = "claude-code/2.1.202";
 const API_TIMEOUT_MS = 15_000;
 const KEYCHAIN_PROMPT_TIMEOUT_MS = 60_000;
+const KEYCHAIN_PRESENCE_TIMEOUT_MS = 5_000;
 const KEYCHAIN_ITEM_NOT_FOUND_EXIT_CODE = 44;
 const CREDENTIAL_FILE = join(homedir(), ".claude", ".credentials.json");
 const KEYCHAIN_SERVICE = "Claude Code-credentials";
@@ -51,6 +52,7 @@ type CredentialState =
   | AvailableCredentialState
   | UnavailableCredentialState
   | SkippedCredentialState;
+type KeychainItemPresence = "present" | "missing" | "unknown";
 
 type RawUsageWindow = {
   utilization?: unknown;
@@ -109,11 +111,13 @@ export async function fetchQuota(
   for (const state of credentialStates) {
     if (state.status === "available") continue;
     if (state.status === "skipped") {
-      attempts.push({
+      const attempt: SourceAttempt = {
         source: state.source.source,
         status: "skipped",
         error: state.source.error,
-      });
+      };
+      if (state.source.credentialPresent) attempt.credentialPresent = true;
+      attempts.push(attempt);
       if (finalError === "Claude quota unavailable")
         finalError = state.source.error ?? finalError;
       continue;
@@ -311,20 +315,55 @@ async function readCredentialStates(
 
   if (process.platform === "darwin") {
     if (!options.allowKeychainPrompt) {
-      states.push({
-        status: "skipped",
-        source: {
-          source: "keychain",
-          status: "skipped",
-          error: "keychain_prompt_required",
-        },
-      });
+      states.push(await readSkippedKeychainCredentialState());
     } else {
       states.push(await readKeychainCredentialState());
     }
   }
 
   return states;
+}
+
+async function readSkippedKeychainCredentialState(): Promise<CredentialState> {
+  const presence = await readKeychainItemPresence();
+  if (presence === "present") {
+    return {
+      status: "skipped",
+      source: {
+        source: "keychain",
+        status: "skipped",
+        error: "keychain_prompt_required",
+        credentialPresent: true,
+      },
+    };
+  }
+  if (presence === "missing") {
+    return {
+      status: "missing",
+      source: { source: "keychain", status: "missing" },
+    };
+  }
+  return {
+    status: "skipped",
+    source: {
+      source: "keychain",
+      status: "skipped",
+      error: "keychain_presence_check_failed",
+    },
+  };
+}
+
+async function readKeychainItemPresence(): Promise<KeychainItemPresence> {
+  try {
+    await execFileText(
+      "security",
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE],
+      KEYCHAIN_PRESENCE_TIMEOUT_MS,
+    );
+    return "present";
+  } catch (error) {
+    return isKeychainItemNotFound(error) ? "missing" : "unknown";
+  }
 }
 
 async function readKeychainCredentialState(): Promise<CredentialState> {
@@ -355,6 +394,13 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
   }
 }
 
+function isKeychainItemNotFound(error: unknown): boolean {
+  return (
+    (error as { code?: number | string | null }).code ===
+    KEYCHAIN_ITEM_NOT_FOUND_EXIT_CODE
+  );
+}
+
 function keychainFailureState(error: unknown): CredentialState {
   const failure = error as {
     killed?: boolean;
@@ -371,7 +417,7 @@ function keychainFailureState(error: unknown): CredentialState {
       },
     };
   }
-  if (failure.code === KEYCHAIN_ITEM_NOT_FOUND_EXIT_CODE) {
+  if (isKeychainItemNotFound(error)) {
     return {
       status: "missing",
       source: { source: "keychain", status: "missing" },

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,4 +1,5 @@
 import { encode } from "@toon-format/toon";
+import { quotaHelpLines } from "./advice.js";
 import { collapseHome } from "./lib/fs.js";
 import type {
   AuthProviderReport,
@@ -43,6 +44,14 @@ export function renderQuotaToon(
     encode({ providers }),
     encode({ windows }),
   ];
+  const advice = response.providers
+    .filter((provider) => provider.state.reason && provider.state.remedyCommand)
+    .map((provider) => ({
+      provider: provider.provider,
+      reason: provider.state.reason,
+      remedyCommand: provider.state.remedyCommand,
+    }));
+  if (advice.length > 0) blocks.push(encode({ advice }));
 
   if (full) {
     const accounts = response.providers.map((provider) => ({
@@ -58,13 +67,7 @@ export function renderQuotaToon(
     blocks.push(encode({ attempts }));
   }
 
-  blocks.push(
-    renderHelp([
-      "Run `quota-axi --provider claude --json` for JSON output",
-      "Run `quota-axi --full` to include account and source-attempt details",
-      "Run `quota-axi auth` to inspect local auth source availability without printing secrets",
-    ]),
-  );
+  blocks.push(renderHelp(quotaHelpLines(response)));
   return blocks.filter(Boolean).join("\n");
 }
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -66,7 +66,8 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing
    secret values.
-6. If quota output reports \`reason: keychain_access_required\`, tell your user to run
+6. On macOS, Claude Keychain value reads are skipped by default.
+   If quota output reports \`reason: keychain_access_required\`, tell your user to run
    \`quota-axi --allow-keychain-prompt\` once and approve Keychain access ("Always Allow").
 
 ## Usage

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -66,8 +66,8 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing
    secret values.
-6. On macOS, Claude Keychain reads are skipped by default; pass \`--allow-keychain-prompt\`
-   to permit a Keychain prompt.
+6. If quota output reports \`reason: keychain_access_required\`, tell your user to run
+   \`quota-axi --allow-keychain-prompt\` once and approve Keychain access ("Always Allow").
 
 ## Usage
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export type SourceAttempt = {
   source: string;
   status: "success" | "failed" | "skipped";
   error?: string;
+  credentialPresent?: boolean;
 };
 
 export type ProviderQuota = {
@@ -89,6 +90,7 @@ export type AuthSourceReport = {
   path?: string;
   status: "available" | "missing" | "invalid" | "expired" | "skipped";
   error?: string;
+  credentialPresent?: boolean;
 };
 
 export type AuthProviderReport = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export type ProviderStatus =
   | "rate_limited"
   | "error";
 
+export type ProviderStateReason = "keychain_access_required";
+
 export type QuotaWindow = {
   id: string;
   label: string;
@@ -57,6 +59,8 @@ export type ProviderQuota = {
     refreshedAt?: string;
     error?: string;
     retryAfter?: string;
+    reason?: ProviderStateReason;
+    remedyCommand?: string;
     sourcesTried: string[];
   };
   attempts?: SourceAttempt[];
@@ -64,8 +68,9 @@ export type ProviderQuota = {
 
 export type QuotaAxiResponse = {
   generatedAt: string;
-  schemaVersion: 1;
+  schemaVersion: 2;
   providers: ProviderQuota[];
+  help?: string[];
 };
 
 export type ProviderOptions = {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,14 +5,20 @@ import { afterEach, describe, expect, it } from "vitest";
 import { main, parseArgs } from "../src/cli.js";
 import { PROVIDERS } from "../src/providers/index.js";
 import { redactedResponse } from "../src/render.js";
-import type { QuotaAxiResponse } from "../src/types.js";
+import type {
+  ProviderAdapter,
+  ProviderQuota,
+  QuotaAxiResponse,
+} from "../src/types.js";
 
 const originalClaudeProvider = PROVIDERS.claude;
+const originalCodexProvider = PROVIDERS.codex;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
 afterEach(() => {
   PROVIDERS.claude = originalClaudeProvider;
+  PROVIDERS.codex = originalCodexProvider;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -89,13 +95,147 @@ describe("CLI quota rendering", () => {
     expect(output).not.toContain("error:");
     expect(process.exitCode).toBeUndefined();
   });
+
+  it("surfaces keychain access advice in TOON when stale quota is blocked by a skipped keychain prompt", async () => {
+    useTempCache();
+    PROVIDERS.claude = providerWithQuota(staleClaudeQuota());
+    PROVIDERS.codex = providerWithQuota(freshCodexQuota());
+    const chunks: string[] = [];
+
+    await main({
+      argv: [],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = chunks.join("");
+    expect(output).toContain("advice[1]{provider,reason,remedyCommand}:");
+    expect(output).toContain(
+      "claude,keychain_access_required,quota-axi --allow-keychain-prompt",
+    );
+    expect(output).toContain(
+      'Tell your user: run `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow") so quota-axi can read claude\'s live quota.',
+    );
+    expect(output).not.toContain("codex,keychain_access_required");
+  });
+
+  it("surfaces keychain access advice in JSON when stale quota is blocked by a skipped keychain prompt", async () => {
+    useTempCache();
+    PROVIDERS.claude = providerWithQuota(staleClaudeQuota());
+    PROVIDERS.codex = providerWithQuota(freshCodexQuota());
+    const chunks: string[] = [];
+
+    await main({
+      argv: ["--json"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = JSON.parse(chunks.join("")) as QuotaAxiResponse;
+    const claude = output.providers.find(
+      (provider) => provider.provider === "claude",
+    );
+    const codex = output.providers.find(
+      (provider) => provider.provider === "codex",
+    );
+    expect(output.schemaVersion).toBe(2);
+    expect(claude?.state.reason).toBe("keychain_access_required");
+    expect(claude?.state.remedyCommand).toBe(
+      "quota-axi --allow-keychain-prompt",
+    );
+    expect(output.help).toContain(
+      'Tell your user: run `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow") so quota-axi can read claude\'s live quota.',
+    );
+    expect(codex?.state.reason).toBeUndefined();
+    expect(codex?.state.remedyCommand).toBeUndefined();
+  });
+
+  it("does not surface keychain access advice when a provider is fresh", async () => {
+    useTempCache();
+    PROVIDERS.claude = providerWithQuota({
+      ...freshClaudeQuota(),
+      attempts: [
+        {
+          source: "keychain",
+          status: "skipped",
+          error: "keychain_prompt_required",
+        },
+        { source: "oauth", status: "success" },
+      ],
+    });
+    PROVIDERS.codex = providerWithQuota(freshCodexQuota());
+    const chunks: string[] = [];
+
+    await main({
+      argv: ["--json"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = JSON.parse(chunks.join("")) as QuotaAxiResponse;
+    expect(output.help).toBeUndefined();
+    expect(
+      output.providers.find((provider) => provider.provider === "claude")?.state
+        .reason,
+    ).toBeUndefined();
+  });
+
+  it("does not surface keychain access advice when keychain auth is missing", async () => {
+    useTempCache();
+    PROVIDERS.claude = providerWithQuota({
+      ...staleClaudeQuota(),
+      attempts: [
+        {
+          source: "oauth-file",
+          status: "skipped",
+          error: "credentials_missing",
+        },
+        { source: "keychain", status: "skipped", error: "credentials_missing" },
+      ],
+    });
+    PROVIDERS.codex = providerWithQuota(freshCodexQuota());
+    const chunks: string[] = [];
+
+    await main({
+      argv: ["--json"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = JSON.parse(chunks.join("")) as QuotaAxiResponse;
+    expect(output.help).toBeUndefined();
+    expect(
+      output.providers.find((provider) => provider.provider === "claude")?.state
+        .reason,
+    ).toBeUndefined();
+  });
 });
 
 describe("response redaction", () => {
   it("hides account identity and attempts unless --full is set", () => {
     const response: QuotaAxiResponse = {
       generatedAt: "2026-07-06T18:10:00Z",
-      schemaVersion: 1,
+      schemaVersion: 2,
       providers: [
         {
           provider: "claude",
@@ -120,3 +260,97 @@ describe("response redaction", () => {
     );
   });
 });
+
+function providerWithQuota(quota: ProviderQuota): ProviderAdapter {
+  return {
+    id: quota.provider,
+    label: quota.label,
+    async fetchQuota() {
+      return quota;
+    },
+    async inspectAuth() {
+      return { provider: quota.provider, sources: [] };
+    },
+  };
+}
+
+function useTempCache(): void {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-cli-cache-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+}
+
+function freshClaudeQuota(): ProviderQuota {
+  return {
+    provider: "claude",
+    label: "Claude",
+    source: "oauth",
+    plan: "pro",
+    windows: [
+      {
+        id: "five_hour",
+        label: "session",
+        kind: "session",
+        percentUsed: 10,
+        percentRemaining: 90,
+      },
+    ],
+    state: {
+      status: "fresh",
+      stale: false,
+      refreshedAt: "2026-07-06T18:10:00Z",
+      sourcesTried: ["oauth"],
+    },
+    attempts: [{ source: "oauth", status: "success" }],
+  };
+}
+
+function staleClaudeQuota(): ProviderQuota {
+  return {
+    ...freshClaudeQuota(),
+    source: "cache",
+    state: {
+      status: "stale",
+      stale: true,
+      refreshedAt: "2026-07-06T18:10:00Z",
+      error: "Claude sign-in required",
+      sourcesTried: ["oauth-file", "keychain", "cache"],
+    },
+    attempts: [
+      {
+        source: "oauth-file",
+        status: "skipped",
+        error: "credentials_expired",
+      },
+      {
+        source: "keychain",
+        status: "skipped",
+        error: "keychain_prompt_required",
+      },
+    ],
+  };
+}
+
+function freshCodexQuota(): ProviderQuota {
+  return {
+    provider: "codex",
+    label: "Codex",
+    source: "cli-rpc",
+    plan: "pro",
+    windows: [
+      {
+        id: "five_hour",
+        label: "session",
+        kind: "session",
+        percentUsed: 0,
+        percentRemaining: 100,
+      },
+    ],
+    state: {
+      status: "fresh",
+      stale: false,
+      refreshedAt: "2026-07-06T18:10:00Z",
+      sourcesTried: ["cli-rpc"],
+    },
+    attempts: [{ source: "cli-rpc", status: "success" }],
+  };
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -229,6 +229,45 @@ describe("CLI quota rendering", () => {
         .reason,
     ).toBeUndefined();
   });
+
+  it("does not surface keychain access advice without confirmed keychain item presence", async () => {
+    useTempCache();
+    PROVIDERS.claude = providerWithQuota({
+      ...staleClaudeQuota(),
+      attempts: [
+        {
+          source: "oauth-file",
+          status: "skipped",
+          error: "credentials_expired",
+        },
+        {
+          source: "keychain",
+          status: "skipped",
+          error: "keychain_prompt_required",
+        },
+      ],
+    });
+    PROVIDERS.codex = providerWithQuota(freshCodexQuota());
+    const chunks: string[] = [];
+
+    await main({
+      argv: ["--json"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = JSON.parse(chunks.join("")) as QuotaAxiResponse;
+    expect(output.help).toBeUndefined();
+    expect(
+      output.providers.find((provider) => provider.provider === "claude")?.state
+        .reason,
+    ).toBeUndefined();
+  });
 });
 
 describe("response redaction", () => {
@@ -325,6 +364,7 @@ function staleClaudeQuota(): ProviderQuota {
         source: "keychain",
         status: "skipped",
         error: "keychain_prompt_required",
+        credentialPresent: true,
       },
     ],
   };

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -6,15 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 let tempDir: string | undefined;
 
 beforeEach(() => {
   vi.resetModules();
+  usePlatform("linux");
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.doUnmock("../../src/lib/process.js");
   vi.useRealTimers();
+  if (originalPlatform)
+    Object.defineProperty(process, "platform", originalPlatform);
   if (originalHome === undefined) delete process.env.HOME;
   else process.env.HOME = originalHome;
   if (originalUserProfile === undefined) delete process.env.USERPROFILE;
@@ -31,6 +36,13 @@ function useTempHome(): string {
   process.env.USERPROFILE = tempDir;
   process.env.XDG_CACHE_HOME = join(tempDir, "cache");
   return tempDir;
+}
+
+function usePlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
 }
 
 describe("Claude credential-state reporting", () => {
@@ -140,6 +152,72 @@ describe("Claude credential-state reporting", () => {
       status: "skipped",
       error: "credentials_missing",
     });
+  });
+
+  it("marks a skipped keychain prompt only after confirming the keychain item exists", async () => {
+    usePlatform("darwin");
+    useTempHome();
+    const execFileText = vi.fn(async () => "");
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+
+    const { fetchQuota, inspectAuth } =
+      await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", "Claude Code-credentials"],
+      expect.any(Number),
+    );
+    expect(execFileText).not.toHaveBeenCalledWith(
+      "security",
+      expect.arrayContaining(["-w"]),
+      expect.any(Number),
+    );
+    expect(auth.sources).toContainEqual({
+      source: "keychain",
+      status: "skipped",
+      error: "keychain_prompt_required",
+      credentialPresent: true,
+    });
+    expect(result.attempts).toContainEqual({
+      source: "keychain",
+      status: "skipped",
+      error: "keychain_prompt_required",
+      credentialPresent: true,
+    });
+  });
+
+  it("does not mark keychain prompt required when the keychain item is missing", async () => {
+    usePlatform("darwin");
+    useTempHome();
+    const missing = Object.assign(new Error("not found"), { code: 44 });
+    const execFileText = vi.fn(async () => {
+      throw missing;
+    });
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+
+    const { fetchQuota, inspectAuth } =
+      await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(auth.sources).toContainEqual({
+      source: "keychain",
+      status: "missing",
+    });
+    expect(result.attempts).toContainEqual({
+      source: "keychain",
+      status: "skipped",
+      error: "credentials_missing",
+    });
+    expect(result.attempts).not.toContainEqual(
+      expect.objectContaining({
+        source: "keychain",
+        error: "keychain_prompt_required",
+      }),
+    );
   });
 
   it("surfaces malformed file credentials as invalid auth", async () => {


### PR DESCRIPTION
## Intent

Improve quota-axi's agent-facing UX when a provider cannot refresh live quota because on-disk credentials are missing or expired while a macOS Keychain source exists but was skipped for keychain_prompt_required. The default quota output and --json path must surface precise, structured, machine-actionable keychain_access_required guidance with remedyCommand quota-axi --allow-keychain-prompt, plus an agent-directed help line telling the agent to relay the one-time Always Allow Keychain grant to the user. The no-prompt-by-default contract and --allow-keychain-prompt behavior must stay unchanged, detection must be based on existing source-attempt states and avoid false positives for fresh providers or providers with no keychain auth, tests must cover TOON and JSON shapes, and the README Quick Start should prominently explain the macOS Claude Keychain requirement because Claude Code keeps its live token there and quota-axi will not read it without permission.

## What Changed

- Added structured Keychain access advice when Claude quota refresh cannot proceed because macOS Keychain access was skipped despite confirmed Keychain credential presence.
- Rendered the advice in both compact TOON and `--json` output, including `keychain_access_required`, `remedyCommand`, and agent-facing guidance to relay the one-time Keychain grant.
- Updated Claude auth probing, README/skill docs, and coverage for no-prompt defaults, `--allow-keychain-prompt`, and false-positive cases without Keychain credentials.

## Risk Assessment

✅ Low: The change is focused on annotating existing quota results and the follow-up gates Keychain advice on confirmed item presence, with no material correctness or security issues found in the reviewed paths.

## Testing

Inspected the target diff, ran the targeted and full Vitest suites plus the generated skill drift check, captured reviewer-visible TOON/JSON CLI evidence and a Keychain probe audit, removed the transient Vitest cache, and all validation passed.

- Evidence: [Default TOON quota output with keychain advice](https://github.com/kunchenguid/quota-axi/blob/26d5e34f9a68641dac893ff509cf8268ff1ed312/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-toon.txt)
- Evidence: [--json quota output with structured keychain advice](https://github.com/kunchenguid/quota-axi/blob/26d5e34f9a68641dac893ff509cf8268ff1ed312/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-advice-json.json)
- Evidence: [Claude Keychain probe audit](https://github.com/kunchenguid/quota-axi/blob/26d5e34f9a68641dac893ff509cf8268ff1ed312/.no-mistakes/evidence/fm/quota-axi-keychain-advice-a4/keychain-provider-probe-audit.json)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/advice.ts:58` - The advice predicate treats any skipped `keychain_prompt_required` attempt as evidence that Keychain access will fix the provider, but Claude adds that skipped attempt on every macOS no-prompt run before it can know whether a Keychain item actually exists. With missing or expired file credentials and no Claude Keychain credential, default output will still emit `keychain_access_required` and keep telling the user to grant Keychain access. Gate this on real keychain availability evidence, or otherwise avoid emitting the structured remedy for the no-keychain case.

🔧 Fix: Gate Keychain advice on confirmed presence
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm test -- test/cli.test.ts test/providers/claude-auth.test.ts`
- `pnpm run build:skill -- --check`
- `pnpm test`
- <code>Generated evidence with a one-off `pnpm exec tsx` harness invoking `main()` for default TOON and `--json` quota output using stale Claude plus fresh Codex provider fixtures.</code>
- <code>Generated provider evidence with the same `pnpm exec tsx` harness using a fake `security` executable to verify default macOS Keychain probing omits `-w`, while `allowKeychainPrompt` uses `-w` and refreshes quota through the mocked OAuth response.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
