### PR TITLE
fix: reuse granted Claude Keychain access on plain calls

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/01-plain-without-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/01-plain-without-marker.json
@@ -1,0 +1,39 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.464Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "unavailable",
+      "windows": [],
+      "state": {
+        "status": "auth_required",
+        "stale": false,
+        "error": "Claude sign-in required",
+        "sourcesTried": [
+          "oauth-file",
+          "keychain"
+        ],
+        "reason": "keychain_access_required",
+        "remedyCommand": "quota-axi --allow-keychain-prompt"
+      },
+      "attempts": [
+        {
+          "source": "oauth-file",
+          "status": "skipped",
+          "error": "credentials_missing"
+        },
+        {
+          "source": "keychain",
+          "status": "skipped",
+          "error": "keychain_prompt_required",
+          "credentialPresent": true
+        }
+      ]
+    }
+  ],
+  "help": [
+    "Tell your user: run `quota-axi --allow-keychain-prompt` once and approve Keychain access (\"Always Allow\") so quota-axi can read claude's live quota."
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/01-plain-without-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/01-plain-without-marker.json
@@ -11,10 +11,7 @@
         "status": "auth_required",
         "stale": false,
         "error": "Claude sign-in required",
-        "sourcesTried": [
-          "oauth-file",
-          "keychain"
-        ],
+        "sourcesTried": ["oauth-file", "keychain"],
         "reason": "keychain_access_required",
         "remedyCommand": "quota-axi --allow-keychain-prompt"
       },

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/02-bootstrap-with-allow-keychain-prompt.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/02-bootstrap-with-allow-keychain-prompt.json
@@ -1,0 +1,41 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.476Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 12,
+          "resetsAt": "2035-01-01T05:00:00.000Z",
+          "percentRemaining": 88
+        }
+      ],
+      "attempts": [
+        {
+          "source": "oauth-file",
+          "status": "skipped",
+          "error": "credentials_missing"
+        },
+        {
+          "source": "oauth",
+          "status": "success"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-08T01:25:14.476Z",
+        "sourcesTried": [
+          "oauth-file",
+          "oauth"
+        ]
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/02-bootstrap-with-allow-keychain-prompt.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/02-bootstrap-with-allow-keychain-prompt.json
@@ -31,10 +31,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-08T01:25:14.476Z",
-        "sourcesTried": [
-          "oauth-file",
-          "oauth"
-        ]
+        "sourcesTried": ["oauth-file", "oauth"]
       }
     }
   ]

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/03-plain-after-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/03-plain-after-marker.json
@@ -31,10 +31,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-08T01:25:14.480Z",
-        "sourcesTried": [
-          "oauth-file",
-          "oauth"
-        ]
+        "sourcesTried": ["oauth-file", "oauth"]
       }
     }
   ]

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/03-plain-after-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/03-plain-after-marker.json
@@ -1,0 +1,41 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.480Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 7,
+          "resetsAt": "2035-01-01T05:00:00.000Z",
+          "percentRemaining": 93
+        }
+      ],
+      "attempts": [
+        {
+          "source": "oauth-file",
+          "status": "skipped",
+          "error": "credentials_missing"
+        },
+        {
+          "source": "oauth",
+          "status": "success"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-08T01:25:14.480Z",
+        "sourcesTried": [
+          "oauth-file",
+          "oauth"
+        ]
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-bootstrap.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-bootstrap.json
@@ -19,10 +19,7 @@
       "state": {
         "status": "fresh",
         "stale": false,
-        "sourcesTried": [
-          "oauth-file",
-          "oauth"
-        ],
+        "sourcesTried": ["oauth-file", "oauth"],
         "refreshedAt": "2026-07-08T01:25:14.476Z"
       }
     }

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-bootstrap.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-bootstrap.json
@@ -1,0 +1,30 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.476Z",
+  "schemaVersion": 1,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 12,
+          "percentRemaining": 88,
+          "resetsAt": "2035-01-01T05:00:00.000Z"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "sourcesTried": [
+          "oauth-file",
+          "oauth"
+        ],
+        "refreshedAt": "2026-07-08T01:25:14.476Z"
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-plain-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-plain-marker.json
@@ -1,0 +1,30 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.480Z",
+  "schemaVersion": 1,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 7,
+          "percentRemaining": 93,
+          "resetsAt": "2035-01-01T05:00:00.000Z"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "sourcesTried": [
+          "oauth-file",
+          "oauth"
+        ],
+        "refreshedAt": "2026-07-08T01:25:14.480Z"
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-plain-marker.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-plain-marker.json
@@ -19,10 +19,7 @@
       "state": {
         "status": "fresh",
         "stale": false,
-        "sourcesTried": [
-          "oauth-file",
-          "oauth"
-        ],
+        "sourcesTried": ["oauth-file", "oauth"],
         "refreshedAt": "2026-07-08T01:25:14.480Z"
       }
     }

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/keychain-default-read-e2e.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/keychain-default-read-e2e.mjs
@@ -1,10 +1,24 @@
 import { randomUUID } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 const root = process.cwd();
-const evidenceDir = join(root, ".no-mistakes", "evidence", "fm", "quota-axi-keychain-default-read-k7");
+const evidenceDir = join(
+  root,
+  ".no-mistakes",
+  "evidence",
+  "fm",
+  "quota-axi-keychain-default-read-k7",
+);
 const runtimeDir = join(evidenceDir, "runtime");
 const fakeBin = join(runtimeDir, "bin");
 const fakeHome = join(runtimeDir, "home");
@@ -41,7 +55,10 @@ process.env.USERPROFILE = fakeHome;
 process.env.XDG_CACHE_HOME = xdgCacheHome;
 process.env.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
 process.env.SECURITY_CALL_LOG = callLog;
-Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+Object.defineProperty(process, "platform", {
+  configurable: true,
+  value: "darwin",
+});
 
 const observedAuthorization = [];
 let fetchCount = 0;
@@ -51,7 +68,7 @@ globalThis.fetch = async (_url, init = {}) => {
   const authorization =
     headers instanceof Headers
       ? headers.get("authorization")
-      : headers.authorization ?? headers.Authorization;
+      : (headers.authorization ?? headers.Authorization);
   observedAuthorization.push(authorization === `Bearer ${fakeToken}`);
   const utilization = fetchCount === 1 ? 12 : 7;
   return new Response(
@@ -95,7 +112,11 @@ const withoutMarker = await runCli("01-plain-without-marker", [
   "--full",
 ]);
 
-const markerPath = join(xdgCacheHome, "quota-axi", "claude-keychain-access-granted");
+const markerPath = join(
+  xdgCacheHome,
+  "quota-axi",
+  "claude-keychain-access-granted",
+);
 const markerBeforeBootstrap = existsSync(markerPath);
 
 const bootstrap = await runCli("02-bootstrap-with-allow-keychain-prompt", [
@@ -157,18 +178,21 @@ const summary = {
       status: bootstrap.parsed.providers[0]?.state?.status,
       reason: bootstrap.parsed.providers[0]?.state?.reason ?? "none",
       markerMode,
-      cachePercentUsed:
-        JSON.parse(readFileSync(join(evidenceDir, "cache-after-bootstrap.json"), "utf-8"))
-          .providers[0]?.windows[0]?.percentUsed,
+      cachePercentUsed: JSON.parse(
+        readFileSync(join(evidenceDir, "cache-after-bootstrap.json"), "utf-8"),
+      ).providers[0]?.windows[0]?.percentUsed,
     },
     {
       command: "quota-axi --provider claude --json --full",
       exitCode: plainAfterMarker.exitCode,
       status: plainAfterMarker.parsed.providers[0]?.state?.status,
       reason: plainAfterMarker.parsed.providers[0]?.state?.reason ?? "none",
-      cachePercentUsed:
-        JSON.parse(readFileSync(join(evidenceDir, "cache-after-plain-marker.json"), "utf-8"))
-          .providers[0]?.windows[0]?.percentUsed,
+      cachePercentUsed: JSON.parse(
+        readFileSync(
+          join(evidenceDir, "cache-after-plain-marker.json"),
+          "utf-8",
+        ),
+      ).providers[0]?.windows[0]?.percentUsed,
     },
   ],
   securityCalls,
@@ -179,7 +203,10 @@ const summary = {
   cachePath: cacheAfterPlainPath.replace(root, "."),
 };
 
-writeFileSync(join(evidenceDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+writeFileSync(
+  join(evidenceDir, "summary.json"),
+  `${JSON.stringify(summary, null, 2)}\n`,
+);
 
 const markdown = `# quota-axi Claude Keychain Default Read Evidence
 
@@ -218,7 +245,8 @@ if (
   securityCalls[2] !== "find-generic-password -s Claude Code-credentials -w" ||
   markerBeforeBootstrap ||
   markerMode !== "0600" ||
-  withoutMarker.parsed.providers[0]?.state?.reason !== "keychain_access_required" ||
+  withoutMarker.parsed.providers[0]?.state?.reason !==
+    "keychain_access_required" ||
   bootstrap.parsed.providers[0]?.state?.status !== "fresh" ||
   plainAfterMarker.parsed.providers[0]?.state?.status !== "fresh" ||
   summary.cliFlow[2].cachePercentUsed !== 7 ||

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/keychain-default-read-e2e.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/keychain-default-read-e2e.mjs
@@ -1,0 +1,235 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const root = process.cwd();
+const evidenceDir = join(root, ".no-mistakes", "evidence", "fm", "quota-axi-keychain-default-read-k7");
+const runtimeDir = join(evidenceDir, "runtime");
+const fakeBin = join(runtimeDir, "bin");
+const fakeHome = join(runtimeDir, "home");
+const xdgCacheHome = join(runtimeDir, "cache");
+const callLog = join(evidenceDir, "security-calls.log");
+const fakeToken = `TEST_TOKEN_${randomUUID()}`;
+
+rmSync(runtimeDir, { recursive: true, force: true });
+rmSync(callLog, { force: true });
+mkdirSync(fakeBin, { recursive: true });
+mkdirSync(fakeHome, { recursive: true });
+mkdirSync(xdgCacheHome, { recursive: true });
+
+const securityScript = `#!/bin/sh
+printf '%s\\n' "$*" >> "$SECURITY_CALL_LOG"
+if [ "$1" = "find-generic-password" ] && [ "$2" = "-s" ] && [ "$3" = "Claude Code-credentials" ] && [ "$4" = "-w" ]; then
+  printf '%s\\n' '{"claudeAiOauth":{"accessToken":"${fakeToken}","expiresAt":"2035-01-01T00:00:00.000Z","plan":"pro"}}'
+  exit 0
+fi
+if [ "$1" = "find-generic-password" ] && [ "$2" = "-s" ] && [ "$3" = "Claude Code-credentials" ]; then
+  printf '%s\\n' 'keychain item present'
+  exit 0
+fi
+exit 2
+`;
+
+const securityPath = join(fakeBin, "security");
+writeFileSync(securityPath, securityScript);
+chmodSync(securityPath, 0o700);
+writeFileSync(callLog, "");
+
+process.env.HOME = fakeHome;
+process.env.USERPROFILE = fakeHome;
+process.env.XDG_CACHE_HOME = xdgCacheHome;
+process.env.PATH = `${fakeBin}:${process.env.PATH ?? ""}`;
+process.env.SECURITY_CALL_LOG = callLog;
+Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+
+const observedAuthorization = [];
+let fetchCount = 0;
+globalThis.fetch = async (_url, init = {}) => {
+  fetchCount += 1;
+  const headers = init.headers ?? {};
+  const authorization =
+    headers instanceof Headers
+      ? headers.get("authorization")
+      : headers.authorization ?? headers.Authorization;
+  observedAuthorization.push(authorization === `Bearer ${fakeToken}`);
+  const utilization = fetchCount === 1 ? 12 : 7;
+  return new Response(
+    JSON.stringify({
+      five_hour: {
+        utilization,
+        resets_at: "2035-01-01T05:00:00.000Z",
+      },
+    }),
+    { status: 200 },
+  );
+};
+
+const { main } = await import(pathToFileURL(join(root, "src", "cli.ts")).href);
+
+async function runCli(label, argv) {
+  const chunks = [];
+  process.exitCode = undefined;
+  await main({
+    argv,
+    binPath: "quota-axi",
+    stdout: {
+      write(chunk) {
+        chunks.push(String(chunk));
+        return true;
+      },
+    },
+  });
+  const text = chunks.join("");
+  writeFileSync(join(evidenceDir, `${label}.json`), text);
+  const parsed = JSON.parse(text);
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = undefined;
+  return { exitCode, parsed, text };
+}
+
+const withoutMarker = await runCli("01-plain-without-marker", [
+  "--provider",
+  "claude",
+  "--json",
+  "--full",
+]);
+
+const markerPath = join(xdgCacheHome, "quota-axi", "claude-keychain-access-granted");
+const markerBeforeBootstrap = existsSync(markerPath);
+
+const bootstrap = await runCli("02-bootstrap-with-allow-keychain-prompt", [
+  "--provider",
+  "claude",
+  "--json",
+  "--full",
+  "--allow-keychain-prompt",
+]);
+const cacheAfterBootstrapPath = join(xdgCacheHome, "quota-axi", "quotas.json");
+writeFileSync(
+  join(evidenceDir, "cache-after-bootstrap.json"),
+  readFileSync(cacheAfterBootstrapPath, "utf-8"),
+);
+
+const plainAfterMarker = await runCli("03-plain-after-marker", [
+  "--provider",
+  "claude",
+  "--json",
+  "--full",
+]);
+const cacheAfterPlainPath = join(xdgCacheHome, "quota-axi", "quotas.json");
+writeFileSync(
+  join(evidenceDir, "cache-after-plain-marker.json"),
+  readFileSync(cacheAfterPlainPath, "utf-8"),
+);
+
+const securityCalls = readFileSync(callLog, "utf-8")
+  .trim()
+  .split("\n")
+  .filter(Boolean);
+const markerMode = existsSync(markerPath)
+  ? (statSync(markerPath).mode & 0o777).toString(8).padStart(4, "0")
+  : "missing";
+
+const tokenRendered =
+  withoutMarker.text.includes(fakeToken) ||
+  bootstrap.text.includes(fakeToken) ||
+  plainAfterMarker.text.includes(fakeToken) ||
+  readFileSync(cacheAfterPlainPath, "utf-8").includes(fakeToken);
+
+const summary = {
+  cliFlow: [
+    {
+      command: "quota-axi --provider claude --json --full",
+      exitCode: withoutMarker.exitCode,
+      status: withoutMarker.parsed.providers[0]?.state?.status,
+      reason: withoutMarker.parsed.providers[0]?.state?.reason,
+      remedyCommand: withoutMarker.parsed.providers[0]?.state?.remedyCommand,
+      keychainAttempt: withoutMarker.parsed.providers[0]?.attempts?.find(
+        (attempt) => attempt.source === "keychain",
+      ),
+      markerExistsBeforeBootstrap: markerBeforeBootstrap,
+    },
+    {
+      command:
+        "quota-axi --provider claude --json --full --allow-keychain-prompt",
+      exitCode: bootstrap.exitCode,
+      status: bootstrap.parsed.providers[0]?.state?.status,
+      reason: bootstrap.parsed.providers[0]?.state?.reason ?? "none",
+      markerMode,
+      cachePercentUsed:
+        JSON.parse(readFileSync(join(evidenceDir, "cache-after-bootstrap.json"), "utf-8"))
+          .providers[0]?.windows[0]?.percentUsed,
+    },
+    {
+      command: "quota-axi --provider claude --json --full",
+      exitCode: plainAfterMarker.exitCode,
+      status: plainAfterMarker.parsed.providers[0]?.state?.status,
+      reason: plainAfterMarker.parsed.providers[0]?.state?.reason ?? "none",
+      cachePercentUsed:
+        JSON.parse(readFileSync(join(evidenceDir, "cache-after-plain-marker.json"), "utf-8"))
+          .providers[0]?.windows[0]?.percentUsed,
+    },
+  ],
+  securityCalls,
+  oauthFetches: fetchCount,
+  authorizationHeaderObservedAndRedacted: observedAuthorization,
+  tokenRenderedInCliOrCacheOutput: tokenRendered,
+  markerPath: markerPath.replace(root, "."),
+  cachePath: cacheAfterPlainPath.replace(root, "."),
+};
+
+writeFileSync(join(evidenceDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+
+const markdown = `# quota-axi Claude Keychain Default Read Evidence
+
+This evidence runs the actual CLI entrypoint with a fake macOS \`security\` command and a fake Claude OAuth usage API.
+The fake Keychain value contains a sentinel token, and the harness checks that the token is not rendered in CLI output or cache files.
+
+## CLI flow
+
+| Step | Command | Exit | Provider status | Advice | Cache percent |
+| --- | --- | ---: | --- | --- | ---: |
+| 1 | \`quota-axi --provider claude --json --full\` | ${withoutMarker.exitCode} | ${withoutMarker.parsed.providers[0]?.state?.status} | ${withoutMarker.parsed.providers[0]?.state?.reason} | n/a |
+| 2 | \`quota-axi --provider claude --json --full --allow-keychain-prompt\` | ${bootstrap.exitCode} | ${bootstrap.parsed.providers[0]?.state?.status} | ${bootstrap.parsed.providers[0]?.state?.reason ?? "none"} | ${summary.cliFlow[1].cachePercentUsed} |
+| 3 | \`quota-axi --provider claude --json --full\` | ${plainAfterMarker.exitCode} | ${plainAfterMarker.parsed.providers[0]?.state?.status} | ${plainAfterMarker.parsed.providers[0]?.state?.reason ?? "none"} | ${summary.cliFlow[2].cachePercentUsed} |
+
+## Security command calls
+
+\`\`\`text
+${securityCalls.join("\n")}
+\`\`\`
+
+## Checks
+
+- The first plain call had no marker and only ran the non-secret presence check.
+- The first plain call emitted \`keychain_access_required\` advice with the \`quota-axi --allow-keychain-prompt\` remedy.
+- The bootstrap call used \`security find-generic-password -w\`, returned fresh quota, and created the marker with mode \`${markerMode}\`.
+- The later plain call reused the marker, used \`security find-generic-password -w\`, returned fresh quota, and refreshed the cache to \`${summary.cliFlow[2].cachePercentUsed}\` percent used.
+- The sentinel token was observed in OAuth authorization headers but was not rendered in CLI output or cache files: \`${!tokenRendered}\`.
+`;
+
+writeFileSync(join(evidenceDir, "summary.md"), markdown);
+
+if (
+  !securityCalls[0] ||
+  securityCalls[0].endsWith(" -w") ||
+  securityCalls[1] !== "find-generic-password -s Claude Code-credentials -w" ||
+  securityCalls[2] !== "find-generic-password -s Claude Code-credentials -w" ||
+  markerBeforeBootstrap ||
+  markerMode !== "0600" ||
+  withoutMarker.parsed.providers[0]?.state?.reason !== "keychain_access_required" ||
+  bootstrap.parsed.providers[0]?.state?.status !== "fresh" ||
+  plainAfterMarker.parsed.providers[0]?.state?.status !== "fresh" ||
+  summary.cliFlow[2].cachePercentUsed !== 7 ||
+  tokenRendered ||
+  observedAuthorization.some((observed) => !observed)
+) {
+  console.error(JSON.stringify(summary, null, 2));
+  process.exit(1);
+}
+
+rmSync(fakeBin, { recursive: true, force: true });
+rmSync(fakeHome, { recursive: true, force: true });
+
+console.log(JSON.stringify(summary, null, 2));

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/claude-keychain-access-granted
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/claude-keychain-access-granted
@@ -1,0 +1,1 @@
+granted

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json
@@ -1,0 +1,30 @@
+{
+  "generatedAt": "2026-07-08T01:25:14.480Z",
+  "schemaVersion": 1,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 7,
+          "percentRemaining": 93,
+          "resetsAt": "2035-01-01T05:00:00.000Z"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "sourcesTried": [
+          "oauth-file",
+          "oauth"
+        ],
+        "refreshedAt": "2026-07-08T01:25:14.480Z"
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json
@@ -19,10 +19,7 @@
       "state": {
         "status": "fresh",
         "stale": false,
-        "sourcesTried": [
-          "oauth-file",
-          "oauth"
-        ],
+        "sourcesTried": ["oauth-file", "oauth"],
         "refreshedAt": "2026-07-08T01:25:14.480Z"
       }
     }

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/security-calls.log
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/security-calls.log
@@ -1,0 +1,3 @@
+find-generic-password -s Claude Code-credentials
+find-generic-password -s Claude Code-credentials -w
+find-generic-password -s Claude Code-credentials -w

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.json
@@ -36,10 +36,7 @@
     "find-generic-password -s Claude Code-credentials -w"
   ],
   "oauthFetches": 2,
-  "authorizationHeaderObservedAndRedacted": [
-    true,
-    true
-  ],
+  "authorizationHeaderObservedAndRedacted": [true, true],
   "tokenRenderedInCliOrCacheOutput": false,
   "markerPath": "./.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/claude-keychain-access-granted",
   "cachePath": "./.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json"

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.json
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.json
@@ -1,0 +1,46 @@
+{
+  "cliFlow": [
+    {
+      "command": "quota-axi --provider claude --json --full",
+      "exitCode": 1,
+      "status": "auth_required",
+      "reason": "keychain_access_required",
+      "remedyCommand": "quota-axi --allow-keychain-prompt",
+      "keychainAttempt": {
+        "source": "keychain",
+        "status": "skipped",
+        "error": "keychain_prompt_required",
+        "credentialPresent": true
+      },
+      "markerExistsBeforeBootstrap": false
+    },
+    {
+      "command": "quota-axi --provider claude --json --full --allow-keychain-prompt",
+      "exitCode": 0,
+      "status": "fresh",
+      "reason": "none",
+      "markerMode": "0600",
+      "cachePercentUsed": 12
+    },
+    {
+      "command": "quota-axi --provider claude --json --full",
+      "exitCode": 0,
+      "status": "fresh",
+      "reason": "none",
+      "cachePercentUsed": 7
+    }
+  ],
+  "securityCalls": [
+    "find-generic-password -s Claude Code-credentials",
+    "find-generic-password -s Claude Code-credentials -w",
+    "find-generic-password -s Claude Code-credentials -w"
+  ],
+  "oauthFetches": 2,
+  "authorizationHeaderObservedAndRedacted": [
+    true,
+    true
+  ],
+  "tokenRenderedInCliOrCacheOutput": false,
+  "markerPath": "./.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/claude-keychain-access-granted",
+  "cachePath": "./.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/runtime/cache/quota-axi/quotas.json"
+}

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md
@@ -5,11 +5,11 @@ The fake Keychain value contains a sentinel token, and the harness checks that t
 
 ## CLI flow
 
-| Step | Command | Exit | Provider status | Advice | Cache percent |
-| --- | --- | ---: | --- | --- | ---: |
-| 1 | `quota-axi --provider claude --json --full` | 1 | auth_required | keychain_access_required | n/a |
-| 2 | `quota-axi --provider claude --json --full --allow-keychain-prompt` | 0 | fresh | none | 12 |
-| 3 | `quota-axi --provider claude --json --full` | 0 | fresh | none | 7 |
+| Step | Command                                                             | Exit | Provider status | Advice                   | Cache percent |
+| ---- | ------------------------------------------------------------------- | ---: | --------------- | ------------------------ | ------------: |
+| 1    | `quota-axi --provider claude --json --full`                         |    1 | auth_required   | keychain_access_required |           n/a |
+| 2    | `quota-axi --provider claude --json --full --allow-keychain-prompt` |    0 | fresh           | none                     |            12 |
+| 3    | `quota-axi --provider claude --json --full`                         |    0 | fresh           | none                     |             7 |
 
 ## Security command calls
 

--- a/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md
+++ b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md
@@ -1,0 +1,28 @@
+# quota-axi Claude Keychain Default Read Evidence
+
+This evidence runs the actual CLI entrypoint with a fake macOS `security` command and a fake Claude OAuth usage API.
+The fake Keychain value contains a sentinel token, and the harness checks that the token is not rendered in CLI output or cache files.
+
+## CLI flow
+
+| Step | Command | Exit | Provider status | Advice | Cache percent |
+| --- | --- | ---: | --- | --- | ---: |
+| 1 | `quota-axi --provider claude --json --full` | 1 | auth_required | keychain_access_required | n/a |
+| 2 | `quota-axi --provider claude --json --full --allow-keychain-prompt` | 0 | fresh | none | 12 |
+| 3 | `quota-axi --provider claude --json --full` | 0 | fresh | none | 7 |
+
+## Security command calls
+
+```text
+find-generic-password -s Claude Code-credentials
+find-generic-password -s Claude Code-credentials -w
+find-generic-password -s Claude Code-credentials -w
+```
+
+## Checks
+
+- The first plain call had no marker and only ran the non-secret presence check.
+- The first plain call emitted `keychain_access_required` advice with the `quota-axi --allow-keychain-prompt` remedy.
+- The bootstrap call used `security find-generic-password -w`, returned fresh quota, and created the marker with mode `0600`.
+- The later plain call reused the marker, used `security find-generic-password -w`, returned fresh quota, and refreshed the cache to `7` percent used.
+- The sentinel token was observed in OAuth authorization headers but was not rendered in CLI output or cache files: `true`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,8 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Never launch the Claude CLI to probe quota, because that would spend the quota being measured.
 - The read-only Codex app-server JSON-RPC probe is the only CLI fallback.
 - The cache path is `~/.cache/quota-axi/quotas.json`, or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set.
-- The Claude Keychain access marker is stored alongside the cache and contains no credential material.
-- Cache files must be `0600` and contain only normalized non-secret snapshots.
+- The Claude Keychain access marker is stored alongside the cache, is `0600`, and contains no credential material.
+- Quota cache files must be `0600` and contain only normalized non-secret snapshots.
 - Only fresh provider snapshots with windows are cached.
 - Failed providers, stale providers, account identity, and source attempts are not cached.
 - Do not cache raw provider responses or credential headers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,13 +10,14 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
 - JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
-- macOS Claude Keychain value reads are skipped by default because they can prompt; quota-axi may still run a non-secret Keychain item presence check so it only suggests access when a credential item exists.
-- `--allow-keychain-prompt` is the only opt-in that permits reading the Claude Keychain value, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
+- macOS Claude Keychain value reads are skipped on plain calls until a successful value read records the non-secret access marker under the quota-axi cache directory; after that, plain calls may reuse the existing grant and read live Claude quota.
+- `--allow-keychain-prompt` is the first-time opt-in that permits the Claude Keychain value read which can prompt, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
 - Codex uses `$CODEX_HOME/auth.json` or `~/.codex/auth.json` OAuth before the CLI fallback.
 - Codex `auth.json` support is OAuth-token only; never treat `OPENAI_API_KEY` as valid quota auth or send API keys to ChatGPT quota endpoints.
 - Never launch the Claude CLI to probe quota, because that would spend the quota being measured.
 - The read-only Codex app-server JSON-RPC probe is the only CLI fallback.
 - The cache path is `~/.cache/quota-axi/quotas.json`, or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set.
+- The Claude Keychain access marker is stored alongside the cache and contains no credential material.
 - Cache files must be `0600` and contain only normalized non-secret snapshots.
 - Only fresh provider snapshots with windows are cached.
 - Failed providers, stale providers, account identity, and source attempts are not cached.

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ Auth source names are `oauth-file`, `keychain`, `auth-json`, and `cli-rpc`.
 ## Security Posture
 
 quota-axi reads `~/.claude/.credentials.json` for Claude.
-On macOS, it reads the `Claude Code-credentials` Keychain value with `--allow-keychain-prompt`, and records a non-secret access marker after a successful read.
+On macOS, it reads the `Claude Code-credentials` Keychain value with `--allow-keychain-prompt` or, after a non-secret access marker exists, on plain calls.
+quota-axi records that marker after any successful Keychain value read.
 When that marker exists, plain calls read the Keychain value again so an already-approved "Always Allow" grant keeps live Claude quota fresh.
 Without the flag or marker, quota-axi may perform a non-secret Keychain item presence check so it only suggests Keychain access when a Claude credential item exists.
 For Codex, it reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback.
@@ -235,7 +236,8 @@ It never launches the Claude CLI, so it cannot accidentally spend the quota it m
 Direct HTTP requests go only to Anthropic and OpenAI first-party usage endpoints with the user's local credentials.
 It sends credential values only to the first-party provider request they authenticate.
 It never prints, logs, or caches credential values.
-The cache lives at `~/.cache/quota-axi/quotas.json` (or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set), uses `0600` file permissions, and stores normalized non-secret snapshots only.
+The quota cache lives at `~/.cache/quota-axi/quotas.json` (or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set), uses `0600` file permissions, and stores normalized non-secret snapshots only.
+The Claude Keychain access marker lives alongside it as `claude-keychain-access-granted`, uses `0600` file permissions, and contains no credential material.
 Only fresh provider snapshots with windows are cached.
 Failed providers, stale providers, account identity, and source attempts are not cached.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ It is data only: it never routes, recommends, proxies, intercepts, logs in, impo
 
 **macOS + Claude note:** Claude Code keeps its live token in the macOS Keychain.
 quota-axi will not read that token unless the user grants permission, so Claude quota reads can stay stale until the user grants access after on-disk credentials expire.
-Run `quota-axi --allow-keychain-prompt` once and approve Keychain access with "Always Allow" so future non-interactive quota reads can refresh live Claude data.
+Run `quota-axi --allow-keychain-prompt` once and approve Keychain access with "Always Allow".
+After a successful Keychain read, future non-interactive quota reads use that existing grant and refresh live Claude data without requiring the flag.
 
 ```sh
 $ npx -y quota-axi
@@ -174,7 +175,7 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 ```
 
 - **Live first** - direct provider usage calls use 15 second request timeouts, Codex JSON-RPC reads use short per-call timeouts, and stale cache fallback is per provider.
-- **No default Keychain prompt** - macOS Claude Keychain value reads are skipped unless `--allow-keychain-prompt` is passed.
+- **No first-run Keychain prompt** - macOS Claude Keychain value reads are skipped on plain calls until `--allow-keychain-prompt` succeeds once, then future plain calls reuse that existing grant.
 - **Partial success is success** - one provider can fail while another returns fresh or stale data, and the process still exits 0. Exit code 1 means every provider failed, and 2 means a usage error.
 - **No token equivalence** - quota-axi does not claim that one provider percentage equals another provider percentage.
 
@@ -223,8 +224,9 @@ Auth source names are `oauth-file`, `keychain`, `auth-json`, and `cli-rpc`.
 ## Security Posture
 
 quota-axi reads `~/.claude/.credentials.json` for Claude.
-On macOS, it reads the `Claude Code-credentials` Keychain value only with `--allow-keychain-prompt`; when enabled, the Keychain credential is tried before file credentials.
-Without that flag, quota-axi may perform a non-secret Keychain item presence check so it only suggests Keychain access when a Claude credential item exists.
+On macOS, it reads the `Claude Code-credentials` Keychain value with `--allow-keychain-prompt`, and records a non-secret access marker after a successful read.
+When that marker exists, plain calls read the Keychain value again so an already-approved "Always Allow" grant keeps live Claude quota fresh.
+Without the flag or marker, quota-axi may perform a non-secret Keychain item presence check so it only suggests Keychain access when a Claude credential item exists.
 For Codex, it reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback.
 Codex `auth.json` support is OAuth-token only; API key values such as `OPENAI_API_KEY` are treated as invalid for quota usage calls and are not sent to ChatGPT usage endpoints.
 It may run `codex -s read-only -a untrusted app-server` for Codex JSON-RPC fallback.

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -34,9 +34,11 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
    secret values.
-6. On macOS, Claude Keychain value reads are skipped by default.
+6. On macOS, Claude Keychain value reads are skipped by default until the user grants access once.
    If quota output reports `reason: keychain_access_required`, tell your user to run
    `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow").
+   After that successful grant, plain `quota-axi` calls reuse the existing Keychain access
+   marker to refresh live Claude quota without requiring the flag.
 
 ## Usage
 

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -64,5 +64,6 @@ examples:
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
-- The cache at `~/.cache/quota-axi/quotas.json` only ever holds normalized non-secret
-  snapshots; nothing quota-axi prints or caches reveals credential values.
+- The quota cache at `~/.cache/quota-axi/quotas.json` only ever holds normalized
+  non-secret snapshots.
+  The Claude Keychain access marker lives alongside it and contains no credential values.

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -44,8 +44,16 @@ function samePath(left: string, right: string): boolean {
 }
 
 export function cacheFilePath(): string {
+  return join(cacheDirPath(), "quotas.json");
+}
+
+export function claudeKeychainAccessMarkerPath(): string {
+  return join(cacheDirPath(), "claude-keychain-access-granted");
+}
+
+function cacheDirPath(): string {
   const base = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
-  return join(base, "quota-axi", "quotas.json");
+  return join(base, "quota-axi");
 }
 
 export function ensurePrivateParent(file: string): void {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,7 +1,13 @@
+import { chmodSync, existsSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readCachedProvider } from "../cache.js";
-import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import {
+  claudeKeychainAccessMarkerPath,
+  ensurePrivateParent,
+  readJsonFileResult,
+  type JsonFileReadResult,
+} from "../lib/fs.js";
 import { execFileText } from "../lib/process.js";
 import { clampPercent, nowIso, retryAfterToIso } from "../lib/time.js";
 import type {
@@ -314,10 +320,10 @@ async function readCredentialStates(
   states.push(fileState);
 
   if (process.platform === "darwin") {
-    if (!options.allowKeychainPrompt) {
-      states.push(await readSkippedKeychainCredentialState());
-    } else {
+    if (options.allowKeychainPrompt || hasKeychainAccessMarker()) {
       states.push(await readKeychainCredentialState());
+    } else {
+      states.push(await readSkippedKeychainCredentialState());
     }
   }
 
@@ -377,6 +383,7 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
   } catch (error) {
     return keychainFailureState(error);
   }
+  writeKeychainAccessMarkerBestEffort();
   try {
     return extractCredentialState(
       { status: "success", value: JSON.parse(blob) },
@@ -391,6 +398,24 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
         error: "json_parse_error",
       },
     };
+  }
+}
+
+function hasKeychainAccessMarker(): boolean {
+  return existsSync(claudeKeychainAccessMarkerPath());
+}
+
+function writeKeychainAccessMarkerBestEffort(): void {
+  try {
+    const file = claudeKeychainAccessMarkerPath();
+    ensurePrivateParent(file);
+    const temp = `${file}.${process.pid}.tmp`;
+    writeFileSync(temp, "granted\n", { mode: 0o600 });
+    chmodSync(temp, 0o600);
+    renameSync(temp, file);
+    chmodSync(file, 0o600);
+  } catch {
+    return;
   }
 }
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -86,7 +86,8 @@ ${TOP_HELP.trimEnd()}
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
-- The cache at \`~/.cache/quota-axi/quotas.json\` only ever holds normalized non-secret
-  snapshots; nothing quota-axi prints or caches reveals credential values.
+- The quota cache at \`~/.cache/quota-axi/quotas.json\` only ever holds normalized
+  non-secret snapshots.
+  The Claude Keychain access marker lives alongside it and contains no credential values.
 `;
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -66,9 +66,11 @@ or when comparing Claude and Codex headroom side by side.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing
    secret values.
-6. On macOS, Claude Keychain value reads are skipped by default.
+6. On macOS, Claude Keychain value reads are skipped by default until the user grants access once.
    If quota output reports \`reason: keychain_access_required\`, tell your user to run
    \`quota-axi --allow-keychain-prompt\` once and approve Keychain access ("Always Allow").
+   After that successful grant, plain \`quota-axi\` calls reuse the existing Keychain access
+   marker to refresh live Claude quota without requiring the flag.
 
 ## Usage
 

--- a/test/lib/fs.test.ts
+++ b/test/lib/fs.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+
 afterEach(() => {
   vi.doUnmock("node:os");
   vi.resetModules();
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
 });
 
 async function importFsWithHome(home: string) {
@@ -42,5 +46,18 @@ describe("collapseHome", () => {
     const { collapseHome } = await importFsWithHome("/Users/kun");
 
     expect(collapseHome("quota-axi")).toBe("quota-axi");
+  });
+});
+
+describe("cache paths", () => {
+  it("places the Claude keychain marker alongside the quota cache", async () => {
+    const { cacheFilePath, claudeKeychainAccessMarkerPath } =
+      await importFsWithHome("/Users/kun");
+    process.env.XDG_CACHE_HOME = "/tmp/quota-cache";
+
+    expect(cacheFilePath()).toBe("/tmp/quota-cache/quota-axi/quotas.json");
+    expect(claudeKeychainAccessMarkerPath()).toBe(
+      "/tmp/quota-cache/quota-axi/claude-keychain-access-granted",
+    );
   });
 });

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -1,6 +1,12 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalHome = process.env.HOME;
@@ -154,7 +160,7 @@ describe("Claude credential-state reporting", () => {
     });
   });
 
-  it("marks a skipped keychain prompt only after confirming the keychain item exists", async () => {
+  it("does not attempt a default keychain value read without the access marker", async () => {
     usePlatform("darwin");
     useTempHome();
     const execFileText = vi.fn(async () => "");
@@ -187,6 +193,141 @@ describe("Claude credential-state reporting", () => {
       error: "keychain_prompt_required",
       credentialPresent: true,
     });
+  });
+
+  it("uses the keychain value on a default call when the access marker exists", async () => {
+    usePlatform("darwin");
+    useTempHome();
+    const marker = await writeKeychainAccessMarker();
+    const execFileText = vi.fn(async () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-keychain-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+          status: 200,
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchQuota, inspectAuth } =
+      await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(marker).toContain("claude-keychain-access-granted");
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+      expect.any(Number),
+    );
+    expect(execFileText).not.toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", "Claude Code-credentials"],
+      expect.any(Number),
+    );
+    expect(auth.sources).toContainEqual({
+      source: "keychain",
+      status: "available",
+    });
+    expect(result.state.status).toBe("fresh");
+    expect(result.source).toBe("oauth");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer fresh-keychain-token",
+        }),
+      }),
+    );
+  });
+
+  it("writes the keychain access marker after an explicit allowed value read", async () => {
+    usePlatform("darwin");
+    useTempHome();
+    const { claudeKeychainAccessMarkerPath } =
+      await import("../../src/lib/fs.js");
+    const execFileText = vi.fn(async () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-keychain-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+            status: 200,
+          }),
+      ),
+    );
+
+    const { fetchQuota } = await import("../../src/providers/claude.js");
+    const result = await fetchQuota({ allowKeychainPrompt: true });
+
+    expect(result.state.status).toBe("fresh");
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
+      expect.any(Number),
+    );
+    expect(existsSync(claudeKeychainAccessMarkerPath())).toBe(true);
+  });
+
+  it("refreshes the cache after a successful default keychain read", async () => {
+    usePlatform("darwin");
+    useTempHome();
+    await writeKeychainAccessMarker();
+    const execFileText = vi.fn(async () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-keychain-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+            status: 200,
+          }),
+      ),
+    );
+    const { readCachedProvider, writeCachedProviders } =
+      await import("../../src/cache.js");
+    writeCachedProviders([cachedClaudeQuota(80)]);
+    const chunks: string[] = [];
+
+    const { main } = await import("../../src/cli.js");
+    await main({
+      argv: ["--provider", "claude", "--json"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+      },
+    });
+
+    const output = JSON.parse(chunks.join("")) as {
+      providers: Array<{ state: { status: string } }>;
+    };
+    expect(output.providers[0]?.state.status).toBe("fresh");
+    expect(readCachedProvider("claude")?.windows[0]?.percentUsed).toBe(12);
   });
 
   it("does not mark keychain prompt required when the keychain item is missing", async () => {
@@ -236,3 +377,35 @@ describe("Claude credential-state reporting", () => {
     });
   });
 });
+
+async function writeKeychainAccessMarker(): Promise<string> {
+  const { claudeKeychainAccessMarkerPath } =
+    await import("../../src/lib/fs.js");
+  const marker = claudeKeychainAccessMarkerPath();
+  mkdirSync(dirname(marker), { recursive: true, mode: 0o700 });
+  writeFileSync(marker, "granted\n", { mode: 0o600 });
+  return marker;
+}
+
+function cachedClaudeQuota(percentUsed: number) {
+  return {
+    provider: "claude" as const,
+    label: "Claude",
+    source: "oauth" as const,
+    windows: [
+      {
+        id: "five_hour",
+        label: "session",
+        kind: "session" as const,
+        percentUsed,
+        percentRemaining: 100 - percentUsed,
+      },
+    ],
+    state: {
+      status: "fresh" as const,
+      stale: false,
+      refreshedAt: "2026-07-06T18:10:00Z",
+      sourcesTried: ["oauth"],
+    },
+  };
+}


### PR DESCRIPTION
## Intent

Fix quota-axi so a plain no-flag invocation on macOS reuses a previously granted Claude Keychain access approval. The default path must remain non-surprising for never-granted users: without a durable marker, plain calls should only do the existing non-secret presence check and emit keychain_access_required advice. After any successful Keychain value read, including the explicit --allow-keychain-prompt bootstrap path, quota-axi should write a non-secret marker alongside the cache; when that marker exists, plain calls may run security find-generic-password -w with the existing timeout, use the token only for live Claude quota, never print or log secrets, and refresh the normalized cache on successful live reads. Keep --allow-keychain-prompt as the first-time interactive bootstrap, keep advice only for the genuinely never-granted prompt-blocked case, update generated skill/docs/project memory, and preserve release-please generated files.

## What Changed

- Reuse Claude Keychain access on macOS plain quota calls after a successful value read records the non-secret `claude-keychain-access-granted` marker alongside the quota cache.
- Keep first-run plain calls non-interactive by using the existing non-secret Keychain presence check and `keychain_access_required` advice until `--allow-keychain-prompt` succeeds.
- Update README, generated skill guidance, project memory, unit coverage, and no-mistakes E2E evidence for marker creation, cache refresh, and secret redaction.

## Risk Assessment

⚠️ Medium: The quota path itself is narrowly implemented, but the shared credential reader changes default behavior for auth inspection and may cause unexpected Keychain prompts after a marker exists.

## Testing

Inspected the target diff/status, ran focused Claude auth and filesystem tests, ran the full Vitest suite, and generated reviewer-visible CLI evidence showing the no-marker advice path, the `--allow-keychain-prompt` bootstrap marker write, and a later plain invocation reusing the marker to read live quota and refresh cache; all checks passed and transient dependency output was removed.

- Evidence: [End-to-end evidence summary](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md)
- Evidence: [Machine-readable evidence summary](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.json)
- Evidence: [Plain invocation before marker JSON](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/01-plain-without-marker.json)
- Evidence: [Bootstrap invocation JSON](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/02-bootstrap-with-allow-keychain-prompt.json)
- Evidence: [Plain invocation after marker JSON](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/03-plain-after-marker.json)
<details>
<summary>Evidence: Fake security command calls</summary>

Source: [Fake security command calls](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/security-calls.log)

```text
find-generic-password -s Claude Code-credentials
find-generic-password -s Claude Code-credentials -w
find-generic-password -s Claude Code-credentials -w
```
</details>
- Evidence: [Cache after marker-backed plain invocation](https://github.com/kunchenguid/quota-axi/blob/7e6fd7a6095a0e74f32f47e415a357644586722b/.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/cache-after-plain-marker.json)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `src/providers/claude.ts:323` - `readCredentialStates` is shared by quota refreshes and `quota-axi auth`, so once the marker exists a plain `auth` command will also run `security find-generic-password -w`. That broadens the default Keychain value read beyond live quota refresh and can still prompt or hang for up to 60s if the stored grant was revoked or was only a one-time Allow; consider keeping marker-based value reads on the quota path and leaving auth on the non-secret presence check unless `--allow-keychain-prompt` is passed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run test/providers/claude-auth.test.ts test/lib/fs.test.ts`
- `pnpm exec tsx .no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/keychain-default-read-e2e.mjs`
- `pnpm test`
- <code>Manual evidence review: inspected `.no-mistakes/evidence/fm/quota-axi-keychain-default-read-k7/summary.md`, `security-calls.log`, and marker/cache file modes after the harness run.</code>
- <code>Cleanup check: removed transient `node_modules` and verified no `node_modules`, `dist`, `coverage`, or `.tmp-cache` directories remained.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
