### PR TITLE
feat(providers): add cursor copilot and grok quota reports

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/auth-cursor-copilot-grok.json
+++ b/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/auth-cursor-copilot-grok.json
@@ -1,0 +1,36 @@
+{
+  "generatedAt": "2026-07-08T17:01:28.128Z",
+  "schemaVersion": 1,
+  "auth": [
+    {
+      "provider": "cursor",
+      "sources": [
+        {
+          "source": "state-vscdb",
+          "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//quota-axi-e2e.SZuuP5/cursor-state.vscdb",
+          "status": "available"
+        }
+      ]
+    },
+    {
+      "provider": "copilot",
+      "sources": [
+        {
+          "source": "apps-json",
+          "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//quota-axi-e2e.SZuuP5/copilot-apps.json",
+          "status": "available"
+        }
+      ]
+    },
+    {
+      "provider": "grok",
+      "sources": [
+        {
+          "source": "auth-json",
+          "path": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T//quota-axi-e2e.SZuuP5/grok-auth.json",
+          "status": "available"
+        }
+      ]
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/cli-cursor-copilot-grok.json
+++ b/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/cli-cursor-copilot-grok.json
@@ -1,0 +1,176 @@
+{
+  "generatedAt": "2026-07-08T17:01:28.027Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "cursor",
+      "label": "Cursor",
+      "source": "api",
+      "plan": "Cursor Pro",
+      "account": {
+        "email": "cursor-evidence@example.invalid"
+      },
+      "windows": [
+        {
+          "id": "included_usage",
+          "label": "included usage",
+          "kind": "monthly",
+          "percentUsed": 42,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 58
+        },
+        {
+          "id": "auto_usage",
+          "label": "auto usage",
+          "kind": "monthly",
+          "percentUsed": 15,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 85
+        },
+        {
+          "id": "api_usage",
+          "label": "API usage",
+          "kind": "monthly",
+          "percentUsed": 8,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 92
+        },
+        {
+          "id": "spend_limit",
+          "label": "spend limit",
+          "kind": "credits",
+          "percentUsed": 25,
+          "spentUsd": 12.5,
+          "limitUsd": 50,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 75
+        }
+      ],
+      "attempts": [
+        {
+          "source": "api",
+          "status": "success"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-08T17:01:28.027Z",
+        "sourcesTried": [
+          "api"
+        ]
+      }
+    },
+    {
+      "provider": "copilot",
+      "label": "GitHub Copilot",
+      "source": "api",
+      "plan": "business",
+      "account": {
+        "accountId": "octo-evidence"
+      },
+      "windows": [
+        {
+          "id": "chat",
+          "label": "chat",
+          "kind": "monthly",
+          "percentUsed": 39,
+          "percentRemaining": 61,
+          "resetsAt": "2026-07-31T00:00:00.000Z"
+        },
+        {
+          "id": "completions",
+          "label": "completions",
+          "kind": "monthly",
+          "percentUsed": 16,
+          "percentRemaining": 84,
+          "resetsAt": "2026-07-31T00:00:00.000Z"
+        },
+        {
+          "id": "premium_interactions",
+          "label": "premium interactions",
+          "kind": "monthly",
+          "percentUsed": 75,
+          "percentRemaining": 25,
+          "resetsAt": "2026-07-31T00:00:00.000Z"
+        }
+      ],
+      "attempts": [
+        {
+          "source": "api",
+          "status": "success"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-08T17:01:28.013Z",
+        "sourcesTried": [
+          "api"
+        ]
+      }
+    },
+    {
+      "provider": "grok",
+      "label": "Grok",
+      "source": "api",
+      "plan": "SuperGrok",
+      "account": {
+        "email": "grok-evidence@example.invalid",
+        "organization": "team-evidence"
+      },
+      "windows": [
+        {
+          "id": "credits",
+          "label": "credits",
+          "kind": "credits",
+          "percentUsed": 33,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 67
+        },
+        {
+          "id": "on_demand",
+          "label": "on-demand credits",
+          "kind": "credits",
+          "percentUsed": 13,
+          "percentRemaining": 87,
+          "resetsAt": "2026-07-31T00:00:00.000Z"
+        },
+        {
+          "id": "product:grok_4_heavy",
+          "label": "Grok 4 Heavy",
+          "kind": "credits",
+          "percentUsed": 50,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 50
+        },
+        {
+          "id": "product:voice_mode",
+          "label": "Voice Mode",
+          "kind": "credits",
+          "percentUsed": 10,
+          "resetsAt": "2026-07-31T00:00:00.000Z",
+          "percentRemaining": 90
+        }
+      ],
+      "credits": {
+        "remaining": 48,
+        "unit": "credits"
+      },
+      "attempts": [
+        {
+          "source": "api",
+          "status": "success"
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "refreshedAt": "2026-07-08T17:01:28.014Z",
+        "sourcesTried": [
+          "api"
+        ]
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/cli-cursor-copilot-grok.json
+++ b/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/cli-cursor-copilot-grok.json
@@ -56,9 +56,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-08T17:01:28.027Z",
-        "sourcesTried": [
-          "api"
-        ]
+        "sourcesTried": ["api"]
       }
     },
     {
@@ -105,9 +103,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-08T17:01:28.013Z",
-        "sourcesTried": [
-          "api"
-        ]
+        "sourcesTried": ["api"]
       }
     },
     {
@@ -167,9 +163,7 @@
         "status": "fresh",
         "stale": false,
         "refreshedAt": "2026-07-08T17:01:28.014Z",
-        "sourcesTried": [
-          "api"
-        ]
+        "sourcesTried": ["api"]
       }
     }
   ]

--- a/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs
@@ -82,9 +82,7 @@ function jsonResponse(body) {
 function headerValue(headers, name) {
   if (!headers) return undefined;
   if (headers instanceof Headers) return headers.get(name) ?? undefined;
-  const entries = Array.isArray(headers)
-    ? headers
-    : Object.entries(headers);
+  const entries = Array.isArray(headers) ? headers : Object.entries(headers);
   const match = entries.find(
     ([key]) => String(key).toLowerCase() === name.toLowerCase(),
   );

--- a/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs
@@ -1,0 +1,92 @@
+const RESET_AT = "2026-07-31T00:00:00.000Z";
+
+globalThis.fetch = async function quotaAxiEvidenceFetch(input, init = {}) {
+  const url = String(input);
+  const authorization = headerValue(init.headers, "authorization");
+  if (!authorization?.startsWith("Bearer fake-")) {
+    throw new Error(`evidence fetch missing fake bearer token for ${url}`);
+  }
+
+  if (
+    url ===
+    "https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage"
+  ) {
+    return jsonResponse({
+      billingCycleEnd: RESET_AT,
+      planUsage: {
+        totalPercentUsed: 42,
+        autoPercentUsed: 15,
+        apiPercentUsed: 8,
+      },
+      spendLimitUsage: {
+        individualLimit: 5000,
+        individualRemaining: 3750,
+      },
+    });
+  }
+
+  if (
+    url === "https://api2.cursor.sh/aiserver.v1.DashboardService/GetPlanInfo"
+  ) {
+    return jsonResponse({
+      planInfo: {
+        planName: "Cursor Pro",
+        billingCycleEnd: RESET_AT,
+      },
+    });
+  }
+
+  if (url === "https://api.github.com/copilot_internal/user") {
+    return jsonResponse({
+      login: "octo-evidence",
+      copilot_plan: "business",
+      quota_reset_date_utc: RESET_AT,
+      quota_snapshots: {
+        chat: { percent_remaining: 61, quota_reset_at: RESET_AT },
+        completions: { percent_remaining: 84, quota_reset_at: RESET_AT },
+        premium_interactions: {
+          percent_remaining: 25,
+          quota_reset_at: RESET_AT,
+        },
+      },
+    });
+  }
+
+  if (url === "https://cli-chat-proxy.grok.com/v1/billing?format=credits") {
+    return jsonResponse({
+      config: {
+        subscription_tier: "SuperGrok",
+        billingPeriodEnd: RESET_AT,
+        creditUsagePercent: 33,
+        onDemandCap: { val: 1000 },
+        onDemandUsed: { val: 125 },
+        prepaidBalance: { val: 48 },
+        productUsage: [
+          { product: "Grok 4 Heavy", usagePercent: 50 },
+          { product: "Voice Mode", usagePercent: 10 },
+        ],
+      },
+    });
+  }
+
+  throw new Error(`unexpected evidence fetch: ${url}`);
+};
+
+function jsonResponse(body) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function headerValue(headers, name) {
+  if (!headers) return undefined;
+  if (headers instanceof Headers) return headers.get(name) ?? undefined;
+  const entries = Array.isArray(headers)
+    ? headers
+    : Object.entries(headers);
+  const match = entries.find(
+    ([key]) => String(key).toLowerCase() === name.toLowerCase(),
+  );
+  return match ? String(match[1]) : undefined;
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,12 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - It reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
 - Claude quota windows can include `five_hour`, `seven_day`, `seven_day_opus`, and `extra_usage`. When the OAuth usage response includes a `limits` array, that array is the authoritative, self-describing source and is preferred over the fixed top-level fields: it surfaces every active limit, including ones scoped to a specific model (e.g. Fable) via `scope.model.display_name`, with a `model:<slug>` window id.
 - Codex quota windows can include `five_hour` and `weekly`, plus optional credit balance data. Codex responses can also carry extra limits scoped to a specific model or feature (HTTP: `additional_rate_limits`; app-server RPC: `rateLimitsByLimitId`), surfaced as `model:<id>:5h` / `model:<id>:7d` windows.
-- Cursor reads the local Cursor state database for `cursorAuth` values and can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows from the first-party dashboard usage endpoint.
-- GitHub Copilot reads `~/.config/github-copilot/apps.json` and can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions` from GitHub's first-party Copilot user endpoint. If the endpoint only exposes entitlement and no numeric quota windows, return a fresh provider report with `windows: []` rather than inventing percentages.
-- Grok reads `~/.grok/auth.json` and can report `credits`, optional `on_demand`, and optional `product:<slug>` windows from the first-party billing endpoint.
+- Cursor reads `$CURSOR_STATE_DB` or the local Cursor state database via `sqlite3 -readonly` for `cursorAuth` values and can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows from the first-party dashboard usage endpoint.
+- If `sqlite3` is unavailable, Cursor auth is reported as skipped with `sqlite3_unavailable`; do not treat that as permission to install system packages.
+- GitHub Copilot reads `$GITHUB_COPILOT_APPS_JSON` or the local `github-copilot/apps.json` auth file and can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions` from GitHub's first-party Copilot user endpoint. If the endpoint only exposes entitlement and no numeric quota windows, return a fresh provider report with `windows: []` rather than inventing percentages.
+- Copilot only sends tokens associated with public GitHub hosts to the public endpoint; host-specific GitHub Enterprise tokens are treated as unavailable there.
+- Grok reads `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json`/`~/.grok/auth.json`, selects session-scoped auth instead of API-key entries, and can report `credits`, optional `on_demand`, and optional `product:<slug>` windows from the first-party billing endpoint.
+- Grok may read `$GROK_HOME/version.json` or package metadata near a local `grok` executable to send `x-grok-client-version`, but it must not launch the Grok CLI.
 - Provider adapter behavior (retry-after handling, snake/camel field tolerance, window parsing) is an original, clean-room implementation derived only from the vendors' own OAuth/HTTP behavior; quota-axi carries no vendored or attributed third-party adapter code.
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
@@ -22,7 +25,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - The cache path is `~/.cache/quota-axi/quotas.json`, or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set.
 - The Claude Keychain access marker is stored alongside the cache, is `0600`, and contains no credential material.
 - Quota cache files must be `0600` and contain only normalized non-secret snapshots.
-- Only fresh provider snapshots with windows are cached.
+- Only fresh provider snapshots with windows are cached; fresh provider reports with no windows clear any existing cached snapshot for that provider.
 - Failed providers, stale providers, account identity, and source attempts are not cached.
 - Do not cache raw provider responses or credential headers.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,12 @@
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
 - quota-axi is data only.
-- It reports local Claude and Codex quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
+- It reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
 - Claude quota windows can include `five_hour`, `seven_day`, `seven_day_opus`, and `extra_usage`. When the OAuth usage response includes a `limits` array, that array is the authoritative, self-describing source and is preferred over the fixed top-level fields: it surfaces every active limit, including ones scoped to a specific model (e.g. Fable) via `scope.model.display_name`, with a `model:<slug>` window id.
 - Codex quota windows can include `five_hour` and `weekly`, plus optional credit balance data. Codex responses can also carry extra limits scoped to a specific model or feature (HTTP: `additional_rate_limits`; app-server RPC: `rateLimitsByLimitId`), surfaced as `model:<id>:5h` / `model:<id>:7d` windows.
+- Cursor reads the local Cursor state database for `cursorAuth` values and can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows from the first-party dashboard usage endpoint.
+- GitHub Copilot reads `~/.config/github-copilot/apps.json` and can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions` from GitHub's first-party Copilot user endpoint. If the endpoint only exposes entitlement and no numeric quota windows, return a fresh provider report with `windows: []` rather than inventing percentages.
+- Grok reads `~/.grok/auth.json` and can report `credits`, optional `on_demand`, and optional `product:<slug>` windows from the first-party billing endpoint.
 - Provider adapter behavior (retry-after handling, snake/camel field tolerance, window parsing) is an original, clean-room implementation derived only from the vendors' own OAuth/HTTP behavior; quota-axi carries no vendored or attributed third-party adapter code.
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 Quota CLI for agents - designed with [AXI](https://axi.md) (Agent eXperience Interface).
 
 Agents need quota state before they choose where work can safely run.
-Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth files.
+Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth sources.
 
 quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows in one [AXI](https://axi.md)-shaped call.
 It is data only: it never routes, recommends, proxies, intercepts, logs in, imports browser cookies, or mutates provider state.
 
-- **Official sources** - quota-axi reads local provider auth files and calls the first-party quota, usage, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
+- **Official sources** - quota-axi reads local provider auth sources and calls the first-party quota, usage, billing, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
 - **Local first** - everything runs on the machine that holds the credentials; the only network calls are to first-party provider endpoints, never a third-party relay.
 - **Token efficient** - default stdout is compact TOON so agents spend fewer tokens parsing quota state, with `--json` available when a caller needs the normalized model.
 
@@ -174,7 +174,7 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
       ▼
 ┌───────────────┐       ┌──────────────┐
 │ local auth    │ ───▶  │ first-party  │
-│ sources       │       │ usage APIs   │
+│ sources       │       │ provider APIs│
 └─────┬─────────┘       └──────┬───────┘
       ▼                        ▼
 ┌───────────────┐       ┌──────────────┐
@@ -187,7 +187,7 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 └───────────────┘       └──────────────┘
 ```
 
-- **Live first** - direct provider usage calls use 15 second request timeouts, Codex JSON-RPC reads use short per-call timeouts, and stale cache fallback is per provider.
+- **Live first** - direct provider HTTP calls use 15 second request timeouts, Codex JSON-RPC reads use short per-call timeouts, and stale cache fallback is per provider.
 - **No first-run Keychain prompt** - macOS Claude Keychain value reads are skipped on plain calls until `--allow-keychain-prompt` succeeds once, then future plain calls reuse that existing grant.
 - **Partial success is success** - one provider can fail while another returns fresh or stale data, and the process still exits 0. Exit code 1 means every provider failed, and 2 means a usage error.
 - **No token equivalence** - quota-axi does not claim that one provider percentage equals another provider percentage.
@@ -235,7 +235,7 @@ Grok can report `credits`, optional `on_demand`, and optional product-scoped `pr
 Auth source entries include `source`, optional `path`, `status`, and optional `error`.
 Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 Auth source statuses are `available`, `missing`, `invalid`, `expired`, or `skipped`.
-Auth source names are `oauth-file`, `keychain`, `auth-json`, `apps-json`, `state-vscdb`, and `cli-rpc`.
+Auth source names are `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, and `cli-rpc`.
 
 ## Security Posture
 
@@ -247,9 +247,12 @@ Without the flag or marker, quota-axi may perform a non-secret Keychain item pre
 For Codex, it reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback.
 Codex `auth.json` support is OAuth-token only; API key values such as `OPENAI_API_KEY` are treated as invalid for quota usage calls and are not sent to ChatGPT usage endpoints.
 It may run `codex -s read-only -a untrusted app-server` for Codex JSON-RPC fallback.
-For Cursor, it reads the local Cursor state database for `cursorAuth` values and calls Cursor's first-party dashboard usage endpoint.
-For GitHub Copilot, it reads the local Copilot apps auth file and calls GitHub's first-party Copilot user endpoint.
-For Grok, it reads the local Grok auth JSON and calls Grok's first-party billing endpoint.
+For Cursor, it reads `$CURSOR_STATE_DB` when set or the platform Cursor state database path, uses `sqlite3 -readonly` to read `cursorAuth` values, and calls Cursor's first-party dashboard usage endpoint.
+If `sqlite3` is unavailable, Cursor auth is reported as skipped with `sqlite3_unavailable`.
+For GitHub Copilot, it reads `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file and calls GitHub's first-party Copilot user endpoint.
+It only sends tokens associated with public GitHub hosts to that public endpoint; host-specific GitHub Enterprise tokens are treated as unavailable there.
+For Grok, it reads `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`, selects session-scoped auth instead of API-key entries, and calls Grok's first-party billing endpoint.
+For Grok, it may read `$GROK_HOME/version.json` or package metadata near a local `grok` executable to send an `x-grok-client-version` header, but it does not launch the Grok CLI.
 It never launches the Claude CLI, so it cannot accidentally spend the quota it measures.
 
 Direct HTTP requests go only to first-party provider usage, quota, billing, or entitlement endpoints with the user's local credentials.
@@ -258,6 +261,7 @@ It never prints, logs, or caches credential values.
 The quota cache lives at `~/.cache/quota-axi/quotas.json` (or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set), uses `0600` file permissions, and stores normalized non-secret snapshots only.
 The Claude Keychain access marker lives alongside it as `claude-keychain-access-granted`, uses `0600` file permissions, and contains no credential material.
 Only fresh provider snapshots with windows are cached.
+Fresh provider reports with no windows clear any cached snapshot for that provider, so entitlement-only reports do not leave stale quota windows behind.
 Failed providers, stale providers, account identity, and source attempts are not cached.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Quota CLI for agents - designed with [AXI](https://axi.md) (Agent eXperience Int
 Agents need quota state before they choose where work can safely run.
 Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth files.
 
-quota-axi reports local Claude and Codex quota windows in one [AXI](https://axi.md)-shaped call.
+quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows in one [AXI](https://axi.md)-shaped call.
 It is data only: it never routes, recommends, proxies, intercepts, logs in, imports browser cookies, or mutates provider state.
 
-- **Official sources** - quota-axi reads local Claude and Codex auth files and calls the same first-party usage endpoints the vendor CLIs use, with a read-only Codex app-server probe as fallback.
-- **Local first** - everything runs on the machine that holds the credentials; the only network calls are to Anthropic's and OpenAI's own usage endpoints, never a third-party relay.
+- **Official sources** - quota-axi reads local provider auth files and calls the first-party quota, usage, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
+- **Local first** - everything runs on the machine that holds the credentials; the only network calls are to first-party provider endpoints, never a third-party relay.
 - **Token efficient** - default stdout is compact TOON so agents spend fewer tokens parsing quota state, with `--json` available when a caller needs the normalized model.
 
 ## Quick Start
@@ -34,10 +34,13 @@ $ npx -y quota-axi
 bin: ~/.npm/_npx/.../quota-axi
 description: Report local agent-provider quota windows for routing-aware agents
 generatedAt: "2026-03-15T16:42:00.000Z"
-providers[2]{provider,plan,source,status,refreshedAt}:
+providers[5]{provider,plan,source,status,refreshedAt}:
   claude,pro,oauth,fresh,"2026-03-15T16:41:55.000Z"
   codex,plus,cli-rpc,fresh,"2026-03-15T16:41:58.000Z"
-windows[7]{provider,id,label,percentRemaining,resetsAt,state}:
+  cursor,pro,api,fresh,"2026-03-15T16:41:59.000Z"
+  copilot,individual,api,fresh,"2026-03-15T16:42:00.000Z"
+  grok,supergrok,api,fresh,"2026-03-15T16:42:00.000Z"
+windows[13]{provider,id,label,percentRemaining,resetsAt,state}:
   claude,five_hour,session,82,"2026-03-15T21:15:00.000Z",fresh
   claude,seven_day,week,64,"2026-03-19T15:00:00.000Z",fresh
   claude,seven_day_opus,opus week,93,"2026-03-20T09:30:00.000Z",fresh
@@ -45,6 +48,12 @@ windows[7]{provider,id,label,percentRemaining,resetsAt,state}:
   codex,five_hour,session,58,"2026-03-15T20:45:00.000Z",fresh
   codex,weekly,week,47,"2026-03-19T09:00:00.000Z",fresh
   codex,"model:gpt-5.1-codex:5h",GPT-5.1-Codex session,100,"2026-03-16T01:41:58.000Z",fresh
+  cursor,included_usage,included usage,72,"2026-04-01T00:00:00.000Z",fresh
+  cursor,auto_usage,auto usage,91,"2026-04-01T00:00:00.000Z",fresh
+  cursor,api_usage,API usage,100,"2026-04-01T00:00:00.000Z",fresh
+  copilot,chat,chat,84,"2026-04-01T00:00:00.000Z",fresh
+  copilot,premium_interactions,premium interactions,53,"2026-04-01T00:00:00.000Z",fresh
+  grok,credits,credits,67,"2026-04-01T00:00:00.000Z",fresh
 help[3]:
   Run `quota-axi --provider claude --json` for JSON output
   Run `quota-axi --full` to include account and source-attempt details
@@ -97,11 +106,14 @@ $ quota-axi --provider claude --json
 $ quota-axi auth
 bin: ~/.npm/_npx/.../quota-axi
 description: Inspect local quota auth sources without printing secret values
-auth[4]{provider,source,path,status,error}:
+auth[7]{provider,source,path,status,error}:
   claude,oauth-file,~/.claude/.credentials.json,available,none
   claude,keychain,none,skipped,keychain_prompt_required
   codex,auth-json,~/.codex/auth.json,available,none
   codex,cli-rpc,none,available,none
+  cursor,state-vscdb,~/Library/Application Support/Cursor/User/globalStorage/state.vscdb,available,none
+  copilot,apps-json,~/.config/github-copilot/apps.json,available,none
+  grok,auth-json,~/.grok/auth.json,available,none
 help[1]:
   Run `quota-axi --allow-keychain-prompt auth` to permit macOS Keychain access
 ```
@@ -156,7 +168,8 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 └─────┬──────┘
       ▼
 ┌───────────────┐
-│ claude,codex  │
+│ provider      │
+│ adapters      │
 └─────┬─────────┘
       ▼
 ┌───────────────┐       ┌──────────────┐
@@ -183,19 +196,19 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 | Command     | Description                                      |
 | ----------- | ------------------------------------------------ |
-| `quota-axi` | Report Claude and Codex quota windows            |
+| `quota-axi` | Report supported local quota windows             |
 | `auth`      | Report local auth-source availability, no values |
 
 ### Flags
 
-| Flag                      | Description                                            |
-| ------------------------- | ------------------------------------------------------ |
-| `--provider claude,codex` | Scope providers                                        |
-| `--json`                  | Emit normalized JSON instead of TOON for quota or auth |
-| `--full`                  | Include quota account identity and source attempts     |
-| `--allow-keychain-prompt` | Permit macOS Claude Keychain access that could prompt  |
-| `-h`, `--help`            | Print terse [AXI](https://axi.md) help                 |
-| `-v`, `-V`, `--version`   | Print version                                          |
+| Flag                                          | Description                                            |
+| --------------------------------------------- | ------------------------------------------------------ |
+| `--provider claude,codex,cursor,copilot,grok` | Scope providers                                        |
+| `--json`                                      | Emit normalized JSON instead of TOON for quota or auth |
+| `--full`                                      | Include quota account identity and source attempts     |
+| `--allow-keychain-prompt`                     | Permit macOS Claude Keychain access that could prompt  |
+| `-h`, `--help`                                | Print terse [AXI](https://axi.md) help                 |
+| `-v`, `-V`, `--version`                       | Print version                                          |
 
 ## Output Model
 
@@ -208,18 +221,21 @@ Default TOON output includes the same condition in an `advice` block with `provi
 Quota windows include `id`, `label`, `kind`, optional percentages, optional reset fields, optional `windowSeconds`, and optional credit-spend fields.
 Account identity and per-source `attempts` are omitted unless `--full` is passed.
 Provider statuses are `fresh`, `stale`, `unavailable`, `auth_required`, `rate_limited`, or `error`.
-Provider sources are `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`; current provider adapters emit `oauth`, `cli-rpc`, `cache`, and `unavailable`.
+Provider sources are `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`; current provider adapters emit `oauth`, `cli-rpc`, `api`, `cache`, and `unavailable`.
 Window kinds are `session`, `weekly`, `monthly`, `model`, `credits`, or `unknown`.
 Source attempts use `success`, `failed`, or `skipped`.
 Source attempts can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 Claude can report `five_hour`, `seven_day`, optional `seven_day_opus`, and optional `extra_usage` windows.
 When the account's usage response includes a scoped `limits` list, quota-axi surfaces every active window it describes instead, including model-scoped ones (e.g. Fable) as a `model:<slug>` window.
 Codex can report `five_hour` and `weekly` windows plus optional credit balance data, plus any additional model- or feature-scoped rate limits the account has as `model:<id>:5h` / `model:<id>:7d` windows, and an optional code-review rate limit as `code_review_five_hour` / `code_review_weekly`.
+Cursor can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows.
+GitHub Copilot can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions`; when the first-party endpoint exposes entitlement but no numeric quota windows, quota-axi reports a fresh provider state with an empty `windows` list rather than inventing percentages.
+Grok can report `credits`, optional `on_demand`, and optional product-scoped `product:<slug>` windows.
 `auth --json` emits `generatedAt`, `schemaVersion: 1`, and `auth`, where each provider report has `provider` and `sources`.
 Auth source entries include `source`, optional `path`, `status`, and optional `error`.
 Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 Auth source statuses are `available`, `missing`, `invalid`, `expired`, or `skipped`.
-Auth source names are `oauth-file`, `keychain`, `auth-json`, and `cli-rpc`.
+Auth source names are `oauth-file`, `keychain`, `auth-json`, `apps-json`, `state-vscdb`, and `cli-rpc`.
 
 ## Security Posture
 
@@ -231,9 +247,12 @@ Without the flag or marker, quota-axi may perform a non-secret Keychain item pre
 For Codex, it reads `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback.
 Codex `auth.json` support is OAuth-token only; API key values such as `OPENAI_API_KEY` are treated as invalid for quota usage calls and are not sent to ChatGPT usage endpoints.
 It may run `codex -s read-only -a untrusted app-server` for Codex JSON-RPC fallback.
+For Cursor, it reads the local Cursor state database for `cursorAuth` values and calls Cursor's first-party dashboard usage endpoint.
+For GitHub Copilot, it reads the local Copilot apps auth file and calls GitHub's first-party Copilot user endpoint.
+For Grok, it reads the local Grok auth JSON and calls Grok's first-party billing endpoint.
 It never launches the Claude CLI, so it cannot accidentally spend the quota it measures.
 
-Direct HTTP requests go only to Anthropic and OpenAI first-party usage endpoints with the user's local credentials.
+Direct HTTP requests go only to first-party provider usage, quota, billing, or entitlement endpoints with the user's local credentials.
 It sends credential values only to the first-party provider request they authenticate.
 It never prints, logs, or caches credential values.
 The quota cache lives at `~/.cache/quota-axi/quotas.json` (or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set), uses `0600` file permissions, and stores normalized non-secret snapshots only.

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: quota-axi
-description: "Report local Claude and Codex quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth files, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing Claude and Codex headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth files, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
   hermes:
-    tags: [quota, rate-limits, claude, codex, cli]
+    tags: [quota, rate-limits, claude, codex, cursor, copilot, grok, cli]
     category: observability
 ---
 
@@ -16,20 +16,20 @@ Report local agent-provider quota windows for routing-aware agents.
 You do not need quota-axi installed globally - invoke it with `npx -y quota-axi`.
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local Claude and Codex auth files and
-calls first-party provider usage endpoints; it never launches the Claude CLI, so it cannot
-spend the quota it measures.
+browser cookies, or mutates provider state. It reads local provider auth files and calls
+first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
+Claude CLI, so it cannot spend the quota it measures.
 
 ## When to use
 
 Use quota-axi whenever you need local quota headroom before deciding whether it is safe to
 keep working on a provider, when the user asks about usage, rate limits, or remaining quota,
-or when comparing Claude and Codex headroom side by side.
+or when comparing supported local provider headroom side by side.
 
 ## Workflow
 
-1. Run `npx -y quota-axi` for compact TOON output covering both providers' quota windows.
-2. Scope to one provider with `--provider claude` or `--provider codex`.
+1. Run `npx -y quota-axi` for compact TOON output covering supported providers' quota windows.
+2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok`.
 3. Pass `--json` for the normalized machine-readable model instead of TOON.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
@@ -47,10 +47,11 @@ usage: quota-axi [auth] [flags]
 commands[2]:
   (none)=quota, auth
 flags[6]:
-  --provider <claude,codex>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
+  quota-axi --provider cursor,copilot,grok
   quota-axi --json
   quota-axi --full
   quota-axi auth

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth files, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -16,7 +16,7 @@ Report local agent-provider quota windows for routing-aware agents.
 You do not need quota-axi installed globally - invoke it with `npx -y quota-axi`.
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local provider auth files and calls
+browser cookies, or mutates provider state. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
 Claude CLI, so it cannot spend the quota it measures.
 
@@ -67,4 +67,6 @@ examples:
   percentage equals another's.
 - The quota cache at `~/.cache/quota-axi/quotas.json` only ever holds normalized
   non-secret snapshots.
+  Fresh provider reports with no windows clear stale provider snapshots instead of caching
+  empty quota.
   The Claude Keychain access marker lives alongside it and contains no credential values.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -41,15 +41,29 @@ export function readCachedProvider(
 }
 
 export function writeCachedProviders(providers: ProviderQuota[]): void {
+  const clearProviders = new Set(
+    providers
+      .filter(
+        (provider) =>
+          provider.state.status === "fresh" && provider.windows.length === 0,
+      )
+      .map((provider) => provider.provider),
+  );
   const cacheable = providers
     .map(toCacheProvider)
     .filter((provider): provider is ProviderQuota => Boolean(provider));
-  if (cacheable.length === 0) return;
 
   const file = cacheFilePath();
   const byProvider = new Map<ProviderId, ProviderQuota>();
-  for (const provider of readCacheProviders())
+  let clearedExisting = false;
+  for (const provider of readCacheProviders()) {
+    if (clearProviders.has(provider.provider)) {
+      clearedExisting = true;
+      continue;
+    }
     byProvider.set(provider.provider, provider);
+  }
+  if (cacheable.length === 0 && !clearedExisting) return;
   for (const provider of cacheable) byProvider.set(provider.provider, provider);
   const merged = PROVIDER_IDS.map((provider) =>
     byProvider.get(provider),

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,11 +7,8 @@ import type {
   ProviderStatus,
   QuotaWindow,
 } from "./types.js";
+import { PROVIDER_IDS } from "./types.js";
 
-const PROVIDER_IDS = [
-  "claude",
-  "codex",
-] as const satisfies readonly ProviderId[];
 const PROVIDER_SOURCES = [
   "oauth",
   "cli-rpc",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,10 +26,11 @@ export const TOP_HELP = `usage: quota-axi [auth] [flags]
 commands[2]:
   (none)=quota, auth
 flags[6]:
-  --provider <claude,codex>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
+  quota-axi --provider cursor,copilot,grok
   quota-axi --json
   quota-axi --full
   quota-axi auth
@@ -112,6 +113,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
     if (arg === "auth") {
       command = "auth";
       continue;

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -25,12 +25,18 @@ export function execFileText(
 }
 
 export async function commandExists(command: string): Promise<boolean> {
+  return (await findCommandPath(command)) !== undefined;
+}
+
+export async function findCommandPath(
+  command: string,
+): Promise<string | undefined> {
   const normalized = command.trim();
-  if (normalized.length === 0) return false;
+  if (normalized.length === 0) return undefined;
   for (const candidate of commandPathCandidates(normalized)) {
-    if (await isExecutableFile(candidate)) return true;
+    if (await isExecutableFile(candidate)) return candidate;
   }
-  return false;
+  return undefined;
 }
 
 function commandPathCandidates(command: string): string[] {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -243,9 +243,20 @@ function extractCredentialState(
 }
 
 function copilotAppsFile(): string {
-  return process.env.GITHUB_COPILOT_APPS_JSON
-    ? process.env.GITHUB_COPILOT_APPS_JSON
-    : join(homedir(), ".config", "github-copilot", "apps.json");
+  if (process.env.GITHUB_COPILOT_APPS_JSON)
+    return process.env.GITHUB_COPILOT_APPS_JSON;
+  if (process.platform === "win32") {
+    return join(
+      process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local"),
+      "github-copilot",
+      "apps.json",
+    );
+  }
+  return join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+    "github-copilot",
+    "apps.json",
+  );
 }
 
 function rejectUnusableUsageResponse(response: Response): void {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -26,6 +26,7 @@ import {
 } from "./common.js";
 
 const USER_URL = "https://api.github.com/copilot_internal/user";
+const USER_HOST = new URL(USER_URL).hostname;
 const API_TIMEOUT_MS = 15_000;
 
 type CopilotCredentials = {
@@ -40,6 +41,11 @@ type CredentialState =
       source: AuthSourceReport;
     }
   | { status: "missing" | "invalid"; source: AuthSourceReport };
+
+type CredentialCandidate = {
+  credentials: CopilotCredentials;
+  host?: string;
+};
 
 export const copilotAdapter: ProviderAdapter = {
   id: "copilot",
@@ -225,21 +231,66 @@ function extractCredentialState(
       status: "invalid",
       source: { source: "apps-json", path, status: "invalid" },
     };
-  for (const value of Object.values(data)) {
+  const candidates: CredentialCandidate[] = [];
+  for (const [key, value] of Object.entries(data)) {
     const item = objectValue(value);
     const oauthToken = stringValue(item?.oauth_token);
     if (oauthToken) {
-      return {
-        status: "available",
+      candidates.push({
         credentials: { oauthToken, login: stringValue(item?.user) },
-        source: { source: "apps-json", path, status: "available" },
-      };
+        host: credentialHost(key, item),
+      });
     }
+  }
+  const selected =
+    candidates.find(({ host }) => host && matchesUserEndpoint(host)) ??
+    (candidates.some(({ host }) => host) ? undefined : candidates[0]);
+  if (selected) {
+    return {
+      status: "available",
+      credentials: selected.credentials,
+      source: { source: "apps-json", path, status: "available" },
+    };
   }
   return {
     status: "invalid",
     source: { source: "apps-json", path, status: "invalid" },
   };
+}
+
+function credentialHost(
+  key: string,
+  item: Record<string, unknown> | undefined,
+): string | undefined {
+  return (
+    normalizeHost(stringValue(item?.host)) ??
+    normalizeHost(stringValue(item?.hostname)) ??
+    normalizeHost(stringValue(item?.github_host)) ??
+    normalizeHost(stringValue(item?.githubHost)) ??
+    normalizeHost(stringValue(item?.server_uri)) ??
+    normalizeHost(stringValue(item?.serverUri)) ??
+    normalizeHost(key)
+  );
+}
+
+function normalizeHost(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  try {
+    const host = new URL(
+      trimmed.includes("://") ? trimmed : `https://${trimmed}`,
+    ).hostname.toLowerCase();
+    return host.includes(".") ? host : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesUserEndpoint(host: string): boolean {
+  return (
+    host === USER_HOST ||
+    (USER_HOST === "api.github.com" && host === "github.com")
+  );
 }
 
 function copilotAppsFile(): string {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -183,17 +183,14 @@ function normalizeQuotaSnapshots(
     const item = objectValue(value);
     if (!item) continue;
     const remaining = numberValue(item.percent_remaining);
-    const percentUsed =
-      remaining === undefined ? undefined : clampPercent(100 - remaining);
+    if (remaining === undefined) continue;
+    const percentUsed = clampPercent(100 - remaining);
     windows.push({
       id,
       label: id.replace(/_/g, " "),
       kind: "monthly",
       percentUsed,
-      percentRemaining:
-        remaining === undefined
-          ? percentRemaining(percentUsed)
-          : clampPercent(remaining),
+      percentRemaining: percentRemaining(percentUsed),
       resetsAt:
         parseEpochSecondsOrMillis(item.quota_reset_at) ??
         parseEpochSecondsOrMillis(resetFallback),
@@ -282,7 +279,14 @@ function normalizeHost(value: string | undefined): string | undefined {
     ).hostname.toLowerCase();
     return host.includes(".") ? host : undefined;
   } catch {
-    return undefined;
+    const host = trimmed
+      .replace(/^[a-z][a-z\d+.-]*:\/\//i, "")
+      .split(/[/?#]/, 1)[0]
+      ?.split(":", 1)[0]
+      ?.toLowerCase();
+    return host && /^[a-z0-9.-]+$/.test(host) && host.includes(".")
+      ? host
+      : undefined;
   }
 }
 

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -249,16 +249,35 @@ function copilotAppsFile(): string {
 }
 
 function rejectUnusableUsageResponse(response: Response): void {
+  if (response.status === 429 || response.status === 403) {
+    const rateLimit = rateLimitSignal(response);
+    if (response.status === 429 || rateLimit.limited) {
+      throw new RateLimitError(rateLimit.retryAfter);
+    }
+  }
   if (response.status === 401 || response.status === 403) {
     throw new Error("GitHub Copilot sign-in required");
   }
-  if (response.status === 429) {
-    throw new RateLimitError(
-      retryAfterToIso(response.headers.get("retry-after")),
-    );
-  }
   if (!response.ok)
     throw new Error(`GitHub Copilot quota unavailable (${response.status})`);
+}
+
+function rateLimitSignal(response: Response): {
+  limited: boolean;
+  retryAfter?: string;
+} {
+  const retryAfter = retryAfterToIso(response.headers.get("retry-after"));
+  if (retryAfter) return { limited: true, retryAfter };
+  const remaining = response.headers.get("x-ratelimit-remaining")?.trim();
+  if (remaining === "0") {
+    return {
+      limited: true,
+      retryAfter: parseEpochSecondsOrMillis(
+        response.headers.get("x-ratelimit-reset"),
+      ),
+    };
+  }
+  return { limited: false };
 }
 
 function parseEpochSecondsOrMillis(value: unknown): string | undefined {

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -1,0 +1,306 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readCachedProvider } from "../cache.js";
+import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import {
+  clampPercent,
+  nowIso,
+  percentRemaining,
+  retryAfterToIso,
+} from "../lib/time.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  QuotaWindow,
+  SourceAttempt,
+} from "../types.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+} from "./common.js";
+
+const USER_URL = "https://api.github.com/copilot_internal/user";
+const API_TIMEOUT_MS = 15_000;
+
+type CopilotCredentials = {
+  oauthToken: string;
+  login?: string;
+};
+
+type CredentialState =
+  | {
+      status: "available";
+      credentials: CopilotCredentials;
+      source: AuthSourceReport;
+    }
+  | { status: "missing" | "invalid"; source: AuthSourceReport };
+
+export const copilotAdapter: ProviderAdapter = {
+  id: "copilot",
+  label: "GitHub Copilot",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  const attempts: SourceAttempt[] = [];
+  let finalError: string;
+  let retryAfter: string | undefined;
+
+  const credentialState = readCredentialState();
+  if (credentialState.status === "available") {
+    attempts.push({ source: "api", status: "failed" });
+    try {
+      const quota = await fetchCopilotUser(credentialState.credentials);
+      attempts[attempts.length - 1] = { source: "api", status: "success" };
+      return successProvider({
+        provider: "copilot",
+        label: "GitHub Copilot",
+        source: "api",
+        plan: quota.plan,
+        account: quota.account,
+        windows: quota.windows,
+        refreshedAt: quota.refreshedAt,
+        sourcesTried: sourceNames(attempts),
+        attempts,
+      });
+    } catch (error) {
+      finalError = errorMessage(error);
+      attempts[attempts.length - 1] = {
+        source: "api",
+        status: "failed",
+        error: finalError,
+      };
+      if (error instanceof RateLimitError) retryAfter = error.retryAfter;
+    }
+  } else {
+    attempts.push({
+      source: "apps-json",
+      status: "skipped",
+      error: `credentials_${credentialState.status}`,
+    });
+    finalError = "GitHub Copilot sign-in required";
+  }
+
+  const cached = readCachedProvider("copilot");
+  if (cached) {
+    return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+  }
+
+  return failedProvider({
+    provider: "copilot",
+    label: "GitHub Copilot",
+    status: retryAfter ? "rate_limited" : statusFromError(finalError),
+    error: finalError,
+    retryAfter,
+    sourcesTried: sourceNames(attempts),
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const credentialState = readCredentialState();
+  return { provider: "copilot", sources: [credentialState.source] };
+}
+
+export function normalizeCopilotUser(raw: unknown):
+  | {
+      plan?: string;
+      account?: ProviderQuota["account"];
+      windows: QuotaWindow[];
+      refreshedAt: string;
+    }
+  | undefined {
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  const windows = normalizeQuotaSnapshots(
+    objectValue(data.quota_snapshots),
+    data.quota_reset_date_utc,
+  );
+  return {
+    plan:
+      stringValue(data.copilot_plan) ??
+      stringValue(data.access_type_sku) ??
+      stringValue(data.sku),
+    account: { accountId: stringValue(data.login) },
+    windows,
+    refreshedAt: nowIso(),
+  };
+}
+
+async function fetchCopilotUser(credentials: CopilotCredentials): Promise<{
+  plan?: string;
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  refreshedAt: string;
+}> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const response = await fetch(USER_URL, {
+      headers: {
+        authorization: `Bearer ${credentials.oauthToken}`,
+        accept: "application/json",
+        "user-agent": "GitHubCopilotCLI/1.0",
+      },
+      signal: controller.signal,
+    });
+    rejectUnusableUsageResponse(response);
+    const quota = normalizeCopilotUser(await response.json());
+    if (!quota) throw new Error("GitHub Copilot quota unavailable");
+    return quota;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function normalizeQuotaSnapshots(
+  snapshots: Record<string, unknown> | undefined,
+  resetFallback: unknown,
+): QuotaWindow[] {
+  if (!snapshots) return [];
+  const windows: QuotaWindow[] = [];
+  for (const [id, value] of Object.entries(snapshots)) {
+    const item = objectValue(value);
+    if (!item) continue;
+    const remaining = numberValue(item.percent_remaining);
+    const percentUsed =
+      remaining === undefined ? undefined : clampPercent(100 - remaining);
+    windows.push({
+      id,
+      label: id.replace(/_/g, " "),
+      kind: "monthly",
+      percentUsed,
+      percentRemaining:
+        remaining === undefined
+          ? percentRemaining(percentUsed)
+          : clampPercent(remaining),
+      resetsAt:
+        parseEpochSecondsOrMillis(item.quota_reset_at) ??
+        parseEpochSecondsOrMillis(resetFallback),
+    });
+  }
+  return windows;
+}
+
+function readCredentialState(authFile = copilotAppsFile()): CredentialState {
+  return extractCredentialState(readJsonFileResult(authFile), authFile);
+}
+
+function extractCredentialState(
+  raw: JsonFileReadResult,
+  path: string,
+): CredentialState {
+  if (raw.status === "missing")
+    return {
+      status: "missing",
+      source: { source: "apps-json", path, status: "missing" },
+    };
+  if (raw.status === "invalid")
+    return {
+      status: "invalid",
+      source: {
+        source: "apps-json",
+        path,
+        status: "invalid",
+        error: raw.error,
+      },
+    };
+  const data = objectValue(raw.value);
+  if (!data)
+    return {
+      status: "invalid",
+      source: { source: "apps-json", path, status: "invalid" },
+    };
+  for (const value of Object.values(data)) {
+    const item = objectValue(value);
+    const oauthToken = stringValue(item?.oauth_token);
+    if (oauthToken) {
+      return {
+        status: "available",
+        credentials: { oauthToken, login: stringValue(item?.user) },
+        source: { source: "apps-json", path, status: "available" },
+      };
+    }
+  }
+  return {
+    status: "invalid",
+    source: { source: "apps-json", path, status: "invalid" },
+  };
+}
+
+function copilotAppsFile(): string {
+  return process.env.GITHUB_COPILOT_APPS_JSON
+    ? process.env.GITHUB_COPILOT_APPS_JSON
+    : join(homedir(), ".config", "github-copilot", "apps.json");
+}
+
+function rejectUnusableUsageResponse(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("GitHub Copilot sign-in required");
+  }
+  if (response.status === 429) {
+    throw new RateLimitError(
+      retryAfterToIso(response.headers.get("retry-after")),
+    );
+  }
+  if (!response.ok)
+    throw new Error(`GitHub Copilot quota unavailable (${response.status})`);
+}
+
+function parseEpochSecondsOrMillis(value: unknown): string | undefined {
+  const number = numberValue(value);
+  if (number !== undefined) {
+    return new Date(
+      number > 10_000_000_000 ? number : number * 1000,
+    ).toISOString();
+  }
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) return parseEpochSecondsOrMillis(parsed);
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError")
+    return "GitHub Copilot quota request timed out";
+  return error instanceof Error
+    ? error.message
+    : "GitHub Copilot quota unavailable";
+}
+
+class RateLimitError extends Error {
+  constructor(readonly retryAfter: string | undefined) {
+    super("GitHub Copilot quota endpoint rate limited");
+  }
+}

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -127,12 +127,15 @@ export function normalizeCopilotUser(raw: unknown):
     objectValue(data.quota_snapshots),
     data.quota_reset_date_utc,
   );
+  const plan =
+    stringValue(data.copilot_plan) ??
+    stringValue(data.access_type_sku) ??
+    stringValue(data.sku);
+  const accountId = stringValue(data.login);
+  if (windows.length === 0 && !plan && !accountId) return undefined;
   return {
-    plan:
-      stringValue(data.copilot_plan) ??
-      stringValue(data.access_type_sku) ??
-      stringValue(data.sku),
-    account: { accountId: stringValue(data.login) },
+    plan,
+    account: accountId ? { accountId } : undefined,
     windows,
     refreshedAt: nowIso(),
   };

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -358,8 +358,7 @@ function cursorStateDbPath(): string {
     );
   }
   return join(
-    homedir(),
-    ".config",
+    process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"),
     "Cursor",
     "User",
     "globalStorage",

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -51,7 +51,7 @@ export async function fetchQuota(
   _options: ProviderOptions,
 ): Promise<ProviderQuota> {
   const attempts: SourceAttempt[] = [];
-  let finalError = "Cursor quota unavailable";
+  let finalError: string;
   let retryAfter: string | undefined;
 
   const credentialState = await readCredentialState();
@@ -87,8 +87,7 @@ export async function fetchQuota(
       status: "skipped",
       error: `credentials_${credentialState.status}`,
     });
-    if (credentialState.status !== "missing")
-      finalError = "Cursor sign-in required";
+    finalError = "Cursor sign-in required";
   }
 
   const cached = readCachedProvider("cursor");

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -332,7 +332,13 @@ async function readCursorStateValue(key: string): Promise<string | undefined> {
     SQLITE_TIMEOUT_MS,
   );
   const value = output.trim();
-  return value.length > 0 ? value : undefined;
+  if (value.length === 0) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "string" && parsed.length > 0 ? parsed : undefined;
+  } catch {
+    return value;
+  }
 }
 
 function cursorStateDbPath(): string {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -82,12 +82,13 @@ export async function fetchQuota(
       if (error instanceof RateLimitError) retryAfter = error.retryAfter;
     }
   } else {
+    const error = cursorCredentialError(credentialState);
     attempts.push({
       source: credentialState.source.source,
       status: "skipped",
-      error: `credentials_${credentialState.status}`,
+      error,
     });
-    finalError = "Cursor sign-in required";
+    finalError = cursorFinalError(credentialState, error);
   }
 
   const cached = readCachedProvider("cursor");
@@ -397,6 +398,21 @@ function sqliteErrorMessage(error: unknown): string {
   return /no such file|unable to open database/i.test(message)
     ? "credentials_missing"
     : "sqlite_read_error";
+}
+
+function cursorCredentialError(
+  state: Exclude<CredentialState, { status: "available" }>,
+): string {
+  return state.source.error ?? `credentials_${state.status}`;
+}
+
+function cursorFinalError(
+  state: Exclude<CredentialState, { status: "available" }>,
+  error: string,
+): string {
+  return state.status === "missing" || error === "credentials_missing"
+    ? "Cursor sign-in required"
+    : error;
 }
 
 function errorMessage(error: unknown): string {

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -302,13 +302,20 @@ async function readCredentialState(): Promise<CredentialState> {
       source: { source: "state-vscdb", path: STATE_DB, status: "available" },
     };
   } catch (error) {
+    const sqliteError = sqliteErrorMessage(error);
+    if (sqliteError === "credentials_missing") {
+      return {
+        status: "missing",
+        source: { source: "state-vscdb", path: STATE_DB, status: "missing" },
+      };
+    }
     return {
       status: "invalid",
       source: {
         source: "state-vscdb",
         path: STATE_DB,
         status: "invalid",
-        error: sqliteErrorMessage(error),
+        error: sqliteError,
       },
     };
   }

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -1,0 +1,413 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readCachedProvider } from "../cache.js";
+import { execFileText, commandExists } from "../lib/process.js";
+import { clampPercent, nowIso, retryAfterToIso } from "../lib/time.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  QuotaWindow,
+  SourceAttempt,
+} from "../types.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+  withRemaining,
+} from "./common.js";
+
+const API_URL = "https://api2.cursor.sh";
+const API_TIMEOUT_MS = 15_000;
+const SQLITE_TIMEOUT_MS = 5_000;
+const STATE_DB = cursorStateDbPath();
+
+type CursorCredentials = {
+  accessToken: string;
+  email?: string;
+  membershipType?: string;
+};
+
+type CredentialState =
+  | {
+      status: "available";
+      credentials: CursorCredentials;
+      source: AuthSourceReport;
+    }
+  | { status: "missing" | "invalid" | "skipped"; source: AuthSourceReport };
+
+export const cursorAdapter: ProviderAdapter = {
+  id: "cursor",
+  label: "Cursor",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  const attempts: SourceAttempt[] = [];
+  let finalError = "Cursor quota unavailable";
+  let retryAfter: string | undefined;
+
+  const credentialState = await readCredentialState();
+  if (credentialState.status === "available") {
+    attempts.push({ source: "api", status: "failed" });
+    try {
+      const quota = await fetchCursorUsage(credentialState.credentials);
+      attempts[attempts.length - 1] = { source: "api", status: "success" };
+      return successProvider({
+        provider: "cursor",
+        label: "Cursor",
+        source: "api",
+        plan: quota.plan,
+        account: quota.account,
+        windows: quota.windows,
+        credits: quota.credits,
+        refreshedAt: quota.refreshedAt,
+        sourcesTried: sourceNames(attempts),
+        attempts,
+      });
+    } catch (error) {
+      finalError = errorMessage(error);
+      attempts[attempts.length - 1] = {
+        source: "api",
+        status: "failed",
+        error: finalError,
+      };
+      if (error instanceof RateLimitError) retryAfter = error.retryAfter;
+    }
+  } else {
+    attempts.push({
+      source: credentialState.source.source,
+      status: "skipped",
+      error: `credentials_${credentialState.status}`,
+    });
+    if (credentialState.status !== "missing")
+      finalError = "Cursor sign-in required";
+  }
+
+  const cached = readCachedProvider("cursor");
+  if (cached) {
+    return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+  }
+
+  return failedProvider({
+    provider: "cursor",
+    label: "Cursor",
+    status: retryAfter ? "rate_limited" : statusFromError(finalError),
+    error: finalError,
+    retryAfter,
+    sourcesTried: sourceNames(attempts),
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const credentialState = await readCredentialState();
+  return { provider: "cursor", sources: [credentialState.source] };
+}
+
+export function normalizeCursorUsage(
+  usage: unknown,
+  planInfo?: unknown,
+  credentials?: Pick<CursorCredentials, "email" | "membershipType">,
+):
+  | {
+      plan?: string;
+      account?: ProviderQuota["account"];
+      windows: QuotaWindow[];
+      credits?: ProviderQuota["credits"];
+      refreshedAt: string;
+    }
+  | undefined {
+  const data = objectValue(usage);
+  if (!data) return undefined;
+  const planData = objectValue(planInfo);
+  const plan = objectValue(planData?.planInfo);
+  const planName =
+    stringValue(plan?.planName) ??
+    stringValue(plan?.price) ??
+    credentials?.membershipType;
+  const reset =
+    parseEpochMillisOrIso(data.billingCycleEnd) ??
+    parseEpochMillisOrIso(plan?.billingCycleEnd);
+  const planUsage = objectValue(data.planUsage);
+  const windows: QuotaWindow[] = [];
+
+  const total = numberValue(planUsage?.totalPercentUsed);
+  if (total !== undefined) {
+    windows.push(
+      withRemaining({
+        id: "included_usage",
+        label: "included usage",
+        kind: "monthly",
+        percentUsed: clampPercent(total),
+        resetsAt: reset,
+      }),
+    );
+  }
+  const auto = numberValue(planUsage?.autoPercentUsed);
+  if (auto !== undefined) {
+    windows.push(
+      withRemaining({
+        id: "auto_usage",
+        label: "auto usage",
+        kind: "monthly",
+        percentUsed: clampPercent(auto),
+        resetsAt: reset,
+      }),
+    );
+  }
+  const api = numberValue(planUsage?.apiPercentUsed);
+  if (api !== undefined) {
+    windows.push(
+      withRemaining({
+        id: "api_usage",
+        label: "API usage",
+        kind: "monthly",
+        percentUsed: clampPercent(api),
+        resetsAt: reset,
+      }),
+    );
+  }
+
+  const spend = objectValue(data.spendLimitUsage);
+  const individualLimit = numberValue(spend?.individualLimit);
+  const individualRemaining = numberValue(spend?.individualRemaining);
+  const individualUsed =
+    numberValue(spend?.individualUsed) ??
+    (individualLimit !== undefined && individualRemaining !== undefined
+      ? individualLimit - individualRemaining
+      : undefined);
+  if (individualLimit !== undefined && individualLimit > 0) {
+    windows.push(
+      withRemaining({
+        id: "spend_limit",
+        label: "spend limit",
+        kind: "credits",
+        percentUsed:
+          individualUsed === undefined
+            ? undefined
+            : clampPercent((individualUsed / individualLimit) * 100),
+        spentUsd:
+          individualUsed === undefined ? undefined : individualUsed / 100,
+        limitUsd: individualLimit / 100,
+        resetsAt: reset,
+      }),
+    );
+  }
+
+  if (windows.length === 0) return undefined;
+  return {
+    plan: planName,
+    account: { email: credentials?.email },
+    windows,
+    refreshedAt: nowIso(),
+  };
+}
+
+async function fetchCursorUsage(credentials: CursorCredentials): Promise<{
+  plan?: string;
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  credits?: ProviderQuota["credits"];
+  refreshedAt: string;
+}> {
+  const [usage, planInfo] = await Promise.all([
+    postDashboardRpc(credentials.accessToken, "GetCurrentPeriodUsage"),
+    postDashboardRpc(credentials.accessToken, "GetPlanInfo").catch(
+      () => undefined,
+    ),
+  ]);
+  const quota = normalizeCursorUsage(usage, planInfo, credentials);
+  if (!quota) throw new Error("Cursor quota unavailable");
+  return quota;
+}
+
+async function postDashboardRpc(
+  accessToken: string,
+  method: string,
+): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `${API_URL}/aiserver.v1.DashboardService/${method}`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${accessToken}`,
+          accept: "application/json",
+          "content-type": "application/json",
+          "connect-protocol-version": "1",
+        },
+        body: "{}",
+        signal: controller.signal,
+      },
+    );
+    rejectUnusableUsageResponse(response);
+    return response.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function rejectUnusableUsageResponse(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("Cursor sign-in required");
+  }
+  if (response.status === 429) {
+    throw new RateLimitError(
+      retryAfterToIso(response.headers.get("retry-after")),
+    );
+  }
+  if (!response.ok)
+    throw new Error(`Cursor quota unavailable (${response.status})`);
+}
+
+async function readCredentialState(): Promise<CredentialState> {
+  if (!(await commandExists("sqlite3"))) {
+    return {
+      status: "skipped",
+      source: {
+        source: "state-vscdb",
+        path: STATE_DB,
+        status: "skipped",
+        error: "sqlite3_unavailable",
+      },
+    };
+  }
+  try {
+    const accessToken = await readCursorStateValue("cursorAuth/accessToken");
+    if (!accessToken) {
+      return {
+        status: "missing",
+        source: { source: "state-vscdb", path: STATE_DB, status: "missing" },
+      };
+    }
+    const email = await readCursorStateValue("cursorAuth/cachedEmail");
+    const membershipType = await readCursorStateValue(
+      "cursorAuth/stripeMembershipType",
+    );
+    return {
+      status: "available",
+      credentials: { accessToken, email, membershipType },
+      source: { source: "state-vscdb", path: STATE_DB, status: "available" },
+    };
+  } catch (error) {
+    return {
+      status: "invalid",
+      source: {
+        source: "state-vscdb",
+        path: STATE_DB,
+        status: "invalid",
+        error: sqliteErrorMessage(error),
+      },
+    };
+  }
+}
+
+async function readCursorStateValue(key: string): Promise<string | undefined> {
+  const output = await execFileText(
+    "sqlite3",
+    [
+      "-readonly",
+      STATE_DB,
+      `select value from ItemTable where key = '${key.replace(/'/g, "''")}' limit 1;`,
+    ],
+    SQLITE_TIMEOUT_MS,
+  );
+  const value = output.trim();
+  return value.length > 0 ? value : undefined;
+}
+
+function cursorStateDbPath(): string {
+  if (process.env.CURSOR_STATE_DB) return process.env.CURSOR_STATE_DB;
+  if (process.platform === "darwin") {
+    return join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "Cursor",
+      "User",
+      "globalStorage",
+      "state.vscdb",
+    );
+  }
+  if (process.platform === "win32") {
+    return join(
+      process.env.APPDATA ?? join(homedir(), "AppData", "Roaming"),
+      "Cursor",
+      "User",
+      "globalStorage",
+      "state.vscdb",
+    );
+  }
+  return join(
+    homedir(),
+    ".config",
+    "Cursor",
+    "User",
+    "globalStorage",
+    "state.vscdb",
+  );
+}
+
+function parseEpochMillisOrIso(value: unknown): string | undefined {
+  const number = numberValue(value);
+  if (number !== undefined) {
+    return new Date(
+      number > 10_000_000_000 ? number : number * 1000,
+    ).toISOString();
+  }
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) return parseEpochMillisOrIso(parsed);
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function sqliteErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : "";
+  return /no such file|unable to open database/i.test(message)
+    ? "credentials_missing"
+    : "sqlite_read_error";
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError")
+    return "Cursor quota request timed out";
+  return error instanceof Error ? error.message : "Cursor quota unavailable";
+}
+
+class RateLimitError extends Error {
+  constructor(readonly retryAfter: string | undefined) {
+    super("Cursor quota endpoint rate limited");
+  }
+}

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -46,6 +46,11 @@ type CredentialState =
     }
   | { status: "missing" | "invalid" | "expired"; source: AuthSourceReport };
 
+type CredentialCandidate = GrokCredentials & {
+  scope?: string;
+  raw: Record<string, unknown>;
+};
+
 export const grokAdapter: ProviderAdapter = {
   id: "grok",
   label: "Grok",
@@ -89,7 +94,7 @@ export async function fetchQuota(
     }
   } else {
     attempts.push({
-      source: "auth-json",
+      source: credentialState.source.source,
       status: "skipped",
       error: `credentials_${credentialState.status}`,
     });
@@ -317,42 +322,67 @@ function realpathBestEffort(file: string): string {
   }
 }
 
-function readCredentialState(authFile = grokAuthFile()): CredentialState {
+function readCredentialState(): CredentialState {
+  const explicitAuthFile = stringValue(process.env.GROK_AUTH_JSON);
+  if (explicitAuthFile) {
+    return extractCredentialState(
+      readJsonFileResult(explicitAuthFile),
+      explicitAuthFile,
+    );
+  }
+  const inlineAuth = stringValue(process.env.GROK_AUTH);
+  if (inlineAuth) {
+    return extractCredentialState(
+      readInlineAuth(inlineAuth),
+      undefined,
+      "auth-env",
+    );
+  }
+  const authFile = grokAuthFile();
   return extractCredentialState(readJsonFileResult(authFile), authFile);
+}
+
+function readInlineAuth(value: string): JsonFileReadResult {
+  const text = value.trim();
+  try {
+    return { status: "success", value: normalizeInlineAuth(JSON.parse(text)) };
+  } catch {
+    return { status: "success", value: inlineTokenAuth(text) };
+  }
+}
+
+function normalizeInlineAuth(value: unknown): unknown {
+  return typeof value === "string" ? inlineTokenAuth(value) : value;
+}
+
+function inlineTokenAuth(key: string): Record<string, unknown> {
+  return { "https://accounts.x.ai/sign-in": { key } };
 }
 
 function extractCredentialState(
   raw: JsonFileReadResult,
-  path: string,
+  path?: string,
+  source = "auth-json",
 ): CredentialState {
   if (raw.status === "missing")
     return {
       status: "missing",
-      source: { source: "auth-json", path, status: "missing" },
+      source: authSource(source, path, "missing"),
     };
   if (raw.status === "invalid")
     return {
       status: "invalid",
-      source: {
-        source: "auth-json",
-        path,
-        status: "invalid",
-        error: raw.error,
-      },
+      source: authSource(source, path, "invalid", raw.error),
     };
   const data = objectValue(raw.value);
   if (!data)
     return {
       status: "invalid",
-      source: { source: "auth-json", path, status: "invalid" },
+      source: authSource(source, path, "invalid"),
     };
   let expired = false;
-  for (const value of Object.values(data)) {
-    const item = objectValue(value);
-    const key = stringValue(item?.key);
-    if (!key) continue;
-    const expiresAt =
-      stringValue(item?.expires_at) ?? stringValue(item?.expiresAt);
+  for (const candidate of selectedCredentialCandidates(data)) {
+    const expiresAt = candidate.expiresAt;
     if (isExpired(expiresAt)) {
       expired = true;
       continue;
@@ -360,30 +390,32 @@ function extractCredentialState(
     return {
       status: "available",
       credentials: {
-        key,
-        email: stringValue(item?.email),
-        teamId: stringValue(item?.team_id) ?? stringValue(item?.teamId),
+        key: candidate.key,
+        email: candidate.email,
+        teamId: candidate.teamId,
         expiresAt,
       },
-      source: { source: "auth-json", path, status: "available" },
+      source: authSource(source, path, "available"),
     };
   }
   if (expired) {
     return {
       status: "expired",
-      source: { source: "auth-json", path, status: "expired" },
+      source: authSource(source, path, "expired"),
     };
   }
   return {
     status: "invalid",
-    source: { source: "auth-json", path, status: "invalid" },
+    source: authSource(source, path, "invalid"),
   };
 }
 
 function grokAuthFile(): string {
-  return process.env.GROK_AUTH_JSON
-    ? process.env.GROK_AUTH_JSON
-    : join(grokHomeDir(), "auth.json");
+  return (
+    stringValue(process.env.GROK_AUTH_JSON) ??
+    stringValue(process.env.GROK_AUTH_PATH) ??
+    join(grokHomeDir(), "auth.json")
+  );
 }
 
 function grokHomeDir(): string {
@@ -407,6 +439,106 @@ function isExpired(value: string | undefined): boolean {
   if (!value) return false;
   const parsed = Date.parse(value);
   return !Number.isNaN(parsed) && parsed <= Date.now();
+}
+
+function authSource(
+  source: string,
+  path: string | undefined,
+  status: AuthSourceReport["status"],
+  error?: string,
+): AuthSourceReport {
+  return {
+    source,
+    path,
+    status,
+    error,
+  };
+}
+
+function selectedCredentialCandidates(
+  data: Record<string, unknown>,
+): CredentialCandidate[] {
+  const candidates = credentialCandidates(data);
+  const sessionCandidates = candidates.filter(isGrokSessionCandidate);
+  if (sessionCandidates.length > 0) return sessionCandidates;
+  return candidates.filter((candidate) => !isGrokApiKeyCandidate(candidate));
+}
+
+function credentialCandidates(
+  data: Record<string, unknown>,
+): CredentialCandidate[] {
+  const direct = credentialCandidate(data, stringValue(data.scope));
+  if (direct) return [direct];
+  return Object.entries(data).flatMap(([scope, value]) => {
+    const item = objectValue(value);
+    const candidate = item ? credentialCandidate(item, scope) : undefined;
+    return candidate ? [candidate] : [];
+  });
+}
+
+function credentialCandidate(
+  item: Record<string, unknown>,
+  scope: string | undefined,
+): CredentialCandidate | undefined {
+  const key = stringValue(item.key);
+  if (!key) return undefined;
+  return {
+    key,
+    scope: credentialScope(scope, item),
+    raw: item,
+    email: stringValue(item.email),
+    teamId: stringValue(item.team_id) ?? stringValue(item.teamId),
+    expiresAt: stringValue(item.expires_at) ?? stringValue(item.expiresAt),
+  };
+}
+
+function credentialScope(
+  scope: string | undefined,
+  item: Record<string, unknown>,
+): string | undefined {
+  return (
+    stringValue(item.scope) ??
+    stringValue(item.url) ??
+    stringValue(item.audience) ??
+    scope
+  );
+}
+
+function isGrokSessionCandidate(candidate: CredentialCandidate): boolean {
+  if (isGrokApiKeyCandidate(candidate)) return false;
+  const scope = parseScope(candidate.scope);
+  if (!scope) return false;
+  if (scope.host === "accounts.x.ai" && scope.path.startsWith("/sign-in"))
+    return true;
+  return scope.host === "grok.com" || scope.host === "www.grok.com";
+}
+
+function isGrokApiKeyCandidate(candidate: CredentialCandidate): boolean {
+  const scope = parseScope(candidate.scope);
+  const loweredScope = candidate.scope?.toLowerCase() ?? "";
+  const type =
+    stringValue(candidate.raw.type)?.toLowerCase() ??
+    stringValue(candidate.raw.kind)?.toLowerCase();
+  return (
+    type === "api-key" ||
+    type === "api_key" ||
+    loweredScope.includes("api-key") ||
+    loweredScope.includes("api_key") ||
+    scope?.host === "api.x.ai" ||
+    scope?.host === "api.grok.com"
+  );
+}
+
+function parseScope(
+  value: string | undefined,
+): { host: string; path: string } | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value.includes("://") ? value : `https://${value}`);
+    return { host: url.hostname.toLowerCase(), path: url.pathname };
+  } catch {
+    return undefined;
+  }
 }
 
 function parseIso(value: unknown): string | undefined {

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -1,7 +1,9 @@
+import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { readCachedProvider } from "../cache.js";
 import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import { findCommandPath } from "../lib/process.js";
 import {
   clampPercent,
   nowIso,
@@ -27,7 +29,6 @@ import {
 } from "./common.js";
 
 const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
-const GROK_CLIENT_VERSION = "0.2.91";
 const API_TIMEOUT_MS = 15_000;
 
 type GrokCredentials = {
@@ -210,12 +211,14 @@ async function fetchGrokBilling(credentials: GrokCredentials): Promise<{
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
   try {
+    const headers: Record<string, string> = {
+      authorization: `Bearer ${credentials.key}`,
+      accept: "application/json",
+    };
+    const clientVersion = await readGrokClientVersion();
+    if (clientVersion) headers["x-grok-client-version"] = clientVersion;
     const response = await fetch(BILLING_URL, {
-      headers: {
-        authorization: `Bearer ${credentials.key}`,
-        accept: "application/json",
-        "x-grok-client-version": GROK_CLIENT_VERSION,
-      },
+      headers,
       signal: controller.signal,
     });
     rejectUnusableUsageResponse(response);
@@ -224,6 +227,44 @@ async function fetchGrokBilling(credentials: GrokCredentials): Promise<{
     return quota;
   } finally {
     clearTimeout(timer);
+  }
+}
+
+async function readGrokClientVersion(): Promise<string | undefined> {
+  const executable = await findCommandPath("grok");
+  if (!executable) return undefined;
+  return readPackageVersionNear(realpathBestEffort(executable));
+}
+
+function readPackageVersionNear(file: string): string | undefined {
+  let directory = dirname(file);
+  while (true) {
+    const packageJson = readJsonFileResult(join(directory, "package.json"));
+    if (packageJson.status === "success") {
+      const pkg = objectValue(packageJson.value);
+      const version = stringValue(pkg?.version);
+      if (version && packageLooksLikeGrok(pkg)) return version;
+    }
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function packageLooksLikeGrok(
+  pkg: Record<string, unknown> | undefined,
+): boolean {
+  const name = stringValue(pkg?.name)?.toLowerCase();
+  if (name?.includes("grok")) return true;
+  const bin = objectValue(pkg?.bin);
+  return stringValue(bin?.grok) !== undefined;
+}
+
+function realpathBestEffort(file: string): string {
+  try {
+    return realpathSync(file);
+  } catch {
+    return file;
   }
 }
 

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -231,9 +231,58 @@ async function fetchGrokBilling(credentials: GrokCredentials): Promise<{
 }
 
 async function readGrokClientVersion(): Promise<string | undefined> {
+  const homeVersion = readGrokHomeClientVersion();
+  if (homeVersion) return homeVersion;
   const executable = await findCommandPath("grok");
   if (!executable) return undefined;
-  return readPackageVersionNear(realpathBestEffort(executable));
+  const realpath = realpathBestEffort(executable);
+  return (
+    extractGrokVersionFromPath(realpath) ?? readPackageVersionNear(realpath)
+  );
+}
+
+function readGrokHomeClientVersion(): string | undefined {
+  const versionJson = readJsonFileResult(join(grokHomeDir(), "version.json"));
+  if (versionJson.status !== "success") return undefined;
+  return versionFromJson(versionJson.value);
+}
+
+function versionFromJson(value: unknown): string | undefined {
+  const direct = stringValue(value);
+  if (direct) return extractVersion(direct);
+  const data = objectValue(value);
+  if (!data) return undefined;
+  for (const key of [
+    "version",
+    "clientVersion",
+    "client_version",
+    "currentVersion",
+    "current_version",
+  ]) {
+    const version = extractVersion(stringValue(data[key]));
+    if (version) return version;
+  }
+  for (const item of Object.values(data)) {
+    const version = extractVersion(stringValue(item));
+    if (version) return version;
+  }
+  return undefined;
+}
+
+function extractVersion(value: string | undefined): string | undefined {
+  return value?.match(
+    /(?:^|[^0-9])v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)(?:$|[^0-9A-Za-z])/,
+  )?.[1];
+}
+
+function extractGrokVersionFromPath(file: string): string | undefined {
+  for (const part of file.split(/[\\/]+/)) {
+    if (/grok/i.test(part)) {
+      const version = extractVersion(part);
+      if (version) return version;
+    }
+  }
+  return undefined;
 }
 
 function readPackageVersionNear(file: string): string | undefined {
@@ -334,7 +383,11 @@ function extractCredentialState(
 function grokAuthFile(): string {
   return process.env.GROK_AUTH_JSON
     ? process.env.GROK_AUTH_JSON
-    : join(homedir(), ".grok", "auth.json");
+    : join(grokHomeDir(), "auth.json");
+}
+
+function grokHomeDir(): string {
+  return process.env.GROK_HOME || join(homedir(), ".grok");
 }
 
 function rejectUnusableUsageResponse(response: Response): void {

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -256,6 +256,7 @@ function extractCredentialState(
       status: "invalid",
       source: { source: "auth-json", path, status: "invalid" },
     };
+  let expired = false;
   for (const value of Object.values(data)) {
     const item = objectValue(value);
     const key = stringValue(item?.key);
@@ -263,10 +264,8 @@ function extractCredentialState(
     const expiresAt =
       stringValue(item?.expires_at) ?? stringValue(item?.expiresAt);
     if (isExpired(expiresAt)) {
-      return {
-        status: "expired",
-        source: { source: "auth-json", path, status: "expired" },
-      };
+      expired = true;
+      continue;
     }
     return {
       status: "available",
@@ -277,6 +276,12 @@ function extractCredentialState(
         expiresAt,
       },
       source: { source: "auth-json", path, status: "available" },
+    };
+  }
+  if (expired) {
+    return {
+      status: "expired",
+      source: { source: "auth-json", path, status: "expired" },
     };
   }
   return {

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -1,0 +1,360 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readCachedProvider } from "../cache.js";
+import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import {
+  clampPercent,
+  nowIso,
+  percentRemaining,
+  retryAfterToIso,
+} from "../lib/time.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  QuotaWindow,
+  SourceAttempt,
+} from "../types.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+  withRemaining,
+} from "./common.js";
+
+const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const GROK_CLIENT_VERSION = "0.2.91";
+const API_TIMEOUT_MS = 15_000;
+
+type GrokCredentials = {
+  key: string;
+  email?: string;
+  teamId?: string;
+  expiresAt?: string;
+};
+
+type CredentialState =
+  | {
+      status: "available";
+      credentials: GrokCredentials;
+      source: AuthSourceReport;
+    }
+  | { status: "missing" | "invalid" | "expired"; source: AuthSourceReport };
+
+export const grokAdapter: ProviderAdapter = {
+  id: "grok",
+  label: "Grok",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  const attempts: SourceAttempt[] = [];
+  let finalError: string;
+  let retryAfter: string | undefined;
+
+  const credentialState = readCredentialState();
+  if (credentialState.status === "available") {
+    attempts.push({ source: "api", status: "failed" });
+    try {
+      const quota = await fetchGrokBilling(credentialState.credentials);
+      attempts[attempts.length - 1] = { source: "api", status: "success" };
+      return successProvider({
+        provider: "grok",
+        label: "Grok",
+        source: "api",
+        plan: quota.plan,
+        account: quota.account,
+        windows: quota.windows,
+        credits: quota.credits,
+        refreshedAt: quota.refreshedAt,
+        sourcesTried: sourceNames(attempts),
+        attempts,
+      });
+    } catch (error) {
+      finalError = errorMessage(error);
+      attempts[attempts.length - 1] = {
+        source: "api",
+        status: "failed",
+        error: finalError,
+      };
+      if (error instanceof RateLimitError) retryAfter = error.retryAfter;
+    }
+  } else {
+    attempts.push({
+      source: "auth-json",
+      status: "skipped",
+      error: `credentials_${credentialState.status}`,
+    });
+    finalError = "Grok sign-in required";
+  }
+
+  const cached = readCachedProvider("grok");
+  if (cached) {
+    return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+  }
+
+  return failedProvider({
+    provider: "grok",
+    label: "Grok",
+    status: retryAfter ? "rate_limited" : statusFromError(finalError),
+    error: finalError,
+    retryAfter,
+    sourcesTried: sourceNames(attempts),
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const credentialState = readCredentialState();
+  return { provider: "grok", sources: [credentialState.source] };
+}
+
+export function normalizeGrokBilling(
+  raw: unknown,
+  credentials?: Pick<GrokCredentials, "email" | "teamId">,
+):
+  | {
+      plan?: string;
+      account?: ProviderQuota["account"];
+      windows: QuotaWindow[];
+      credits?: ProviderQuota["credits"];
+      refreshedAt: string;
+    }
+  | undefined {
+  const config = objectValue(objectValue(raw)?.config);
+  if (!config) return undefined;
+  const currentPeriod = objectValue(config.currentPeriod);
+  const resetsAt =
+    parseIso(config.billingPeriodEnd) ?? parseIso(currentPeriod?.end);
+  const windows: QuotaWindow[] = [];
+  const creditUsagePercent = numberValue(config.creditUsagePercent);
+  if (creditUsagePercent !== undefined) {
+    windows.push(
+      withRemaining({
+        id: "credits",
+        label: "credits",
+        kind: "credits",
+        percentUsed: clampPercent(creditUsagePercent),
+        resetsAt,
+      }),
+    );
+  }
+  const onDemandCap = numberValue(objectValue(config.onDemandCap)?.val);
+  const onDemandUsed = numberValue(objectValue(config.onDemandUsed)?.val);
+  if (onDemandCap !== undefined && onDemandCap > 0) {
+    windows.push({
+      id: "on_demand",
+      label: "on-demand credits",
+      kind: "credits",
+      percentUsed:
+        onDemandUsed === undefined
+          ? undefined
+          : clampPercent((onDemandUsed / onDemandCap) * 100),
+      percentRemaining:
+        onDemandUsed === undefined
+          ? undefined
+          : percentRemaining(clampPercent((onDemandUsed / onDemandCap) * 100)),
+      resetsAt,
+    });
+  }
+  for (const entry of arrayValue(config.productUsage)) {
+    const product = objectValue(entry);
+    const productName = stringValue(product?.product);
+    const usagePercent = numberValue(product?.usagePercent);
+    if (!productName || usagePercent === undefined) continue;
+    windows.push(
+      withRemaining({
+        id: `product:${slugify(productName)}`,
+        label: productName,
+        kind: "credits",
+        percentUsed: clampPercent(usagePercent),
+        resetsAt,
+      }),
+    );
+  }
+  if (windows.length === 0) return undefined;
+  const prepaidBalance = numberValue(objectValue(config.prepaidBalance)?.val);
+  return {
+    plan:
+      stringValue(config.subscription_tier) ??
+      stringValue(config.subscriptionTier),
+    account: {
+      email: credentials?.email,
+      organization: credentials?.teamId,
+    },
+    windows,
+    credits:
+      prepaidBalance === undefined
+        ? undefined
+        : { remaining: prepaidBalance, unit: "credits" },
+    refreshedAt: nowIso(),
+  };
+}
+
+async function fetchGrokBilling(credentials: GrokCredentials): Promise<{
+  plan?: string;
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  credits?: ProviderQuota["credits"];
+  refreshedAt: string;
+}> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const response = await fetch(BILLING_URL, {
+      headers: {
+        authorization: `Bearer ${credentials.key}`,
+        accept: "application/json",
+        "x-grok-client-version": GROK_CLIENT_VERSION,
+      },
+      signal: controller.signal,
+    });
+    rejectUnusableUsageResponse(response);
+    const quota = normalizeGrokBilling(await response.json(), credentials);
+    if (!quota) throw new Error("Grok quota unavailable");
+    return quota;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function readCredentialState(authFile = grokAuthFile()): CredentialState {
+  return extractCredentialState(readJsonFileResult(authFile), authFile);
+}
+
+function extractCredentialState(
+  raw: JsonFileReadResult,
+  path: string,
+): CredentialState {
+  if (raw.status === "missing")
+    return {
+      status: "missing",
+      source: { source: "auth-json", path, status: "missing" },
+    };
+  if (raw.status === "invalid")
+    return {
+      status: "invalid",
+      source: {
+        source: "auth-json",
+        path,
+        status: "invalid",
+        error: raw.error,
+      },
+    };
+  const data = objectValue(raw.value);
+  if (!data)
+    return {
+      status: "invalid",
+      source: { source: "auth-json", path, status: "invalid" },
+    };
+  for (const value of Object.values(data)) {
+    const item = objectValue(value);
+    const key = stringValue(item?.key);
+    if (!key) continue;
+    const expiresAt =
+      stringValue(item?.expires_at) ?? stringValue(item?.expiresAt);
+    if (isExpired(expiresAt)) {
+      return {
+        status: "expired",
+        source: { source: "auth-json", path, status: "expired" },
+      };
+    }
+    return {
+      status: "available",
+      credentials: {
+        key,
+        email: stringValue(item?.email),
+        teamId: stringValue(item?.team_id) ?? stringValue(item?.teamId),
+        expiresAt,
+      },
+      source: { source: "auth-json", path, status: "available" },
+    };
+  }
+  return {
+    status: "invalid",
+    source: { source: "auth-json", path, status: "invalid" },
+  };
+}
+
+function grokAuthFile(): string {
+  return process.env.GROK_AUTH_JSON
+    ? process.env.GROK_AUTH_JSON
+    : join(homedir(), ".grok", "auth.json");
+}
+
+function rejectUnusableUsageResponse(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new Error("Grok sign-in required");
+  }
+  if (response.status === 429) {
+    throw new RateLimitError(
+      retryAfterToIso(response.headers.get("retry-after")),
+    );
+  }
+  if (!response.ok)
+    throw new Error(`Grok quota unavailable (${response.status})`);
+}
+
+function isExpired(value: string | undefined): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  return !Number.isNaN(parsed) && parsed <= Date.now();
+}
+
+function parseIso(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim() === "") return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError")
+    return "Grok quota request timed out";
+  return error instanceof Error ? error.message : "Grok quota unavailable";
+}
+
+class RateLimitError extends Error {
+  constructor(readonly retryAfter: string | undefined) {
+    super("Grok quota endpoint rate limited");
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,23 +1,35 @@
 import { claudeAdapter } from "./claude.js";
 import { codexAdapter } from "./codex.js";
-import type { ProviderAdapter, ProviderId } from "../types.js";
+import { copilotAdapter } from "./copilot.js";
+import { cursorAdapter } from "./cursor.js";
+import { grokAdapter } from "./grok.js";
+import {
+  PROVIDER_IDS,
+  type ProviderAdapter,
+  type ProviderId,
+} from "../types.js";
 
 export const PROVIDERS: Record<ProviderId, ProviderAdapter> = {
   claude: claudeAdapter,
   codex: codexAdapter,
+  cursor: cursorAdapter,
+  copilot: copilotAdapter,
+  grok: grokAdapter,
 };
 
 export function parseProviders(value: string | undefined): ProviderId[] {
-  if (!value) return ["claude", "codex"];
+  if (!value) return [...PROVIDER_IDS];
   const providers = value
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
-  const invalid = providers.find(
-    (provider) => provider !== "claude" && provider !== "codex",
-  );
+  const invalid = providers.find((provider) => !isProviderId(provider));
   if (invalid) {
     throw new Error(`unsupported provider: ${invalid}`);
   }
   return providers as ProviderId[];
+}
+
+function isProviderId(value: string): value is ProviderId {
+  return PROVIDER_IDS.includes(value as ProviderId);
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,18 +3,27 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
-  "Report local Claude and Codex quota windows via the quota-axi CLI - remaining " +
+  "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining " +
   "percentages, reset times, and provider status read from local auth files, with no " +
   "routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, or " +
-  "remaining quota, or when comparing Claude and Codex headroom.";
+  "remaining quota, or when comparing local provider headroom.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 
 // Extended frontmatter read by Nous Research's Hermes Agent harness
 // (https://hermes-agent.nousresearch.com/docs/user-guide/features/skills).
 // Harnesses that don't know these fields (e.g. Claude Code) ignore them.
-export const HERMES_TAGS = ["quota", "rate-limits", "claude", "codex", "cli"];
+export const HERMES_TAGS = [
+  "quota",
+  "rate-limits",
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "grok",
+  "cli",
+];
 export const HERMES_CATEGORY = "observability";
 
 function yamlDoubleQuote(value: string): string {
@@ -48,20 +57,20 @@ ${DESCRIPTION}
 You do not need quota-axi installed globally - invoke it with \`npx -y quota-axi\`.
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local Claude and Codex auth files and
-calls first-party provider usage endpoints; it never launches the Claude CLI, so it cannot
-spend the quota it measures.
+browser cookies, or mutates provider state. It reads local provider auth files and calls
+first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
+Claude CLI, so it cannot spend the quota it measures.
 
 ## When to use
 
 Use quota-axi whenever you need local quota headroom before deciding whether it is safe to
 keep working on a provider, when the user asks about usage, rate limits, or remaining quota,
-or when comparing Claude and Codex headroom side by side.
+or when comparing supported local provider headroom side by side.
 
 ## Workflow
 
-1. Run \`npx -y quota-axi\` for compact TOON output covering both providers' quota windows.
-2. Scope to one provider with \`--provider claude\` or \`--provider codex\`.
+1. Run \`npx -y quota-axi\` for compact TOON output covering supported providers' quota windows.
+2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok\`.
 3. Pass \`--json\` for the normalized machine-readable model instead of TOON.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,7 +4,7 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
   "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining " +
-  "percentages, reset times, and provider status read from local auth files, with no " +
+  "percentages, reset times, and provider status read from local auth sources, with no " +
   "routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, or " +
   "remaining quota, or when comparing local provider headroom.";
@@ -57,7 +57,7 @@ ${DESCRIPTION}
 You do not need quota-axi installed globally - invoke it with \`npx -y quota-axi\`.
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local provider auth files and calls
+browser cookies, or mutates provider state. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
 Claude CLI, so it cannot spend the quota it measures.
 
@@ -97,6 +97,8 @@ ${TOP_HELP.trimEnd()}
   percentage equals another's.
 - The quota cache at \`~/.cache/quota-axi/quotas.json\` only ever holds normalized
   non-secret snapshots.
+  Fresh provider reports with no windows clear stale provider snapshots instead of caching
+  empty quota.
   The Claude Keychain access marker lives alongside it and contains no credential values.
 `;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,12 @@
-export type ProviderId = "claude" | "codex";
+export type ProviderId = "claude" | "codex" | "cursor" | "copilot" | "grok";
+
+export const PROVIDER_IDS = [
+  "claude",
+  "codex",
+  "cursor",
+  "copilot",
+  "grok",
+] as const satisfies readonly ProviderId[];
 
 export type ProviderSource =
   | "oauth"

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -62,6 +62,21 @@ describe("quota cache", () => {
         ?.windows[0].percentUsed,
     ).toBe(20);
   });
+
+  it("clears a stale snapshot after a fresh no-window report", () => {
+    useTempCache();
+    writeCachedProviders([quota("claude", 10), quota("copilot", 20)]);
+    writeCachedProviders([quotaWithoutWindows("copilot")]);
+
+    const payload = JSON.parse(readFileSync(cacheFilePath(), "utf8")) as {
+      providers: ProviderQuota[];
+    };
+
+    expect(payload.providers.map((provider) => provider.provider)).toEqual([
+      "claude",
+    ]);
+    expect(readCachedProvider("copilot")).toBeUndefined();
+  });
 });
 
 function useTempCache(): void {
@@ -72,7 +87,7 @@ function useTempCache(): void {
 function quota(provider: ProviderId, percentUsed: number): ProviderQuota {
   return {
     provider,
-    label: provider === "claude" ? "Claude" : "Codex",
+    label: providerLabel(provider),
     source: "oauth",
     windows: [
       { id: "five_hour", label: "session", kind: "session", percentUsed },
@@ -86,4 +101,19 @@ function quota(provider: ProviderId, percentUsed: number): ProviderQuota {
     account: { email: "person@example.invalid" },
     attempts: [{ source: "oauth", status: "success" }],
   };
+}
+
+function quotaWithoutWindows(provider: ProviderId): ProviderQuota {
+  return {
+    ...quota(provider, 0),
+    windows: [],
+  };
+}
+
+function providerLabel(provider: ProviderId): string {
+  if (provider === "claude") return "Claude";
+  if (provider === "codex") return "Codex";
+  if (provider === "cursor") return "Cursor";
+  if (provider === "copilot") return "GitHub Copilot";
+  return "Grok";
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -271,7 +271,7 @@ describe("CLI quota rendering", () => {
     const chunks: string[] = [];
 
     await main({
-      argv: ["--json"],
+      argv: ["--provider", "claude,codex", "--json"],
       binPath: "quota-axi",
       stdout: {
         write(chunk) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -13,12 +13,18 @@ import type {
 
 const originalClaudeProvider = PROVIDERS.claude;
 const originalCodexProvider = PROVIDERS.codex;
+const originalCursorProvider = PROVIDERS.cursor;
+const originalCopilotProvider = PROVIDERS.copilot;
+const originalGrokProvider = PROVIDERS.grok;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
 afterEach(() => {
   PROVIDERS.claude = originalClaudeProvider;
   PROVIDERS.codex = originalCodexProvider;
+  PROVIDERS.cursor = originalCursorProvider;
+  PROVIDERS.copilot = originalCopilotProvider;
+  PROVIDERS.grok = originalGrokProvider;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -27,19 +33,33 @@ afterEach(() => {
 });
 
 describe("CLI argument parsing", () => {
-  it("defaults to both v1 providers", () => {
-    expect(parseArgs([]).providers).toEqual(["claude", "codex"]);
+  it("defaults to all supported providers", () => {
+    expect(parseArgs([]).providers).toEqual([
+      "claude",
+      "codex",
+      "cursor",
+      "copilot",
+      "grok",
+    ]);
   });
 
   it("scopes comma-separated providers", () => {
     expect(parseArgs(["--provider", "claude"]).providers).toEqual(["claude"]);
-    expect(parseArgs(["--provider=claude,codex"]).providers).toEqual([
-      "claude",
-      "codex",
+    expect(parseArgs(["--provider=cursor,copilot,grok"]).providers).toEqual([
+      "cursor",
+      "copilot",
+      "grok",
     ]);
   });
 
-  it("rejects providers outside v1 scope", () => {
+  it("ignores a standalone argument separator", () => {
+    expect(parseArgs(["--", "--provider", "grok", "--json"])).toMatchObject({
+      providers: ["grok"],
+      json: true,
+    });
+  });
+
+  it("rejects unsupported providers", () => {
     expect(() => parseArgs(["--provider", "gemini"])).toThrow(
       "unsupported provider",
     );
@@ -103,7 +123,7 @@ describe("CLI quota rendering", () => {
     const chunks: string[] = [];
 
     await main({
-      argv: [],
+      argv: ["--provider", "claude,codex"],
       binPath: "quota-axi",
       stdout: {
         write(chunk) {
@@ -131,7 +151,7 @@ describe("CLI quota rendering", () => {
     const chunks: string[] = [];
 
     await main({
-      argv: ["--json"],
+      argv: ["--provider", "claude,codex", "--json"],
       binPath: "quota-axi",
       stdout: {
         write(chunk) {
@@ -177,7 +197,7 @@ describe("CLI quota rendering", () => {
     const chunks: string[] = [];
 
     await main({
-      argv: ["--json"],
+      argv: ["--provider", "claude,codex", "--json"],
       binPath: "quota-axi",
       stdout: {
         write(chunk) {
@@ -212,7 +232,7 @@ describe("CLI quota rendering", () => {
     const chunks: string[] = [];
 
     await main({
-      argv: ["--json"],
+      argv: ["--provider", "claude,codex", "--json"],
       binPath: "quota-axi",
       stdout: {
         write(chunk) {

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -1,14 +1,18 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchQuota,
+  inspectAuth,
   normalizeCopilotUser,
 } from "../../src/providers/copilot.js";
 
 const originalAppsJson = process.env.GITHUB_COPILOT_APPS_JSON;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalHome = process.env.HOME;
+const originalLocalAppData = process.env.LOCALAPPDATA;
 let tempDir: string | undefined;
 
 beforeEach(() => {
@@ -24,12 +28,36 @@ afterEach(() => {
   else process.env.GITHUB_COPILOT_APPS_JSON = originalAppsJson;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
+  else process.env.LOCALAPPDATA = originalLocalAppData;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = undefined;
 });
 
 function writeAppsJson(value: unknown): void {
   writeFileSync(process.env.GITHUB_COPILOT_APPS_JSON!, JSON.stringify(value));
+}
+
+function writeJson(path: string, value: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(value));
+}
+
+async function withPlatform<T>(
+  platform: NodeJS.Platform,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return await callback();
+  } finally {
+    if (descriptor) Object.defineProperty(process, "platform", descriptor);
+  }
 }
 
 describe("GitHub Copilot quota parsing", () => {
@@ -115,5 +143,50 @@ describe("GitHub Copilot quota parsing", () => {
     expect(result.state.error).toBe(
       "GitHub Copilot quota endpoint rate limited",
     );
+  });
+
+  it("resolves Copilot auth under XDG config home", async () => {
+    const xdgConfigHome = join(tempDir!, "xdg-config");
+    const authFile = join(xdgConfigHome, "github-copilot", "apps.json");
+    delete process.env.GITHUB_COPILOT_APPS_JSON;
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.HOME = join(tempDir!, "home");
+    writeJson(authFile, {
+      fixture: {
+        oauth_token: "valid-token",
+      },
+    });
+
+    const result = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(result.sources).toContainEqual({
+      source: "apps-json",
+      path: authFile,
+      status: "available",
+    });
+  });
+
+  it("resolves Copilot auth under Windows local app data", async () => {
+    const localAppData = join(tempDir!, "local-app-data");
+    const authFile = join(localAppData, "github-copilot", "apps.json");
+    delete process.env.GITHUB_COPILOT_APPS_JSON;
+    delete process.env.XDG_CONFIG_HOME;
+    process.env.LOCALAPPDATA = localAppData;
+    process.env.HOME = join(tempDir!, "home");
+    writeJson(authFile, {
+      fixture: {
+        oauth_token: "valid-token",
+      },
+    });
+
+    await withPlatform("win32", async () => {
+      const result = await inspectAuth({ allowKeychainPrompt: false });
+
+      expect(result.sources).toContainEqual({
+        source: "apps-json",
+        path: authFile,
+        status: "available",
+      });
+    });
   });
 });

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCopilotUser } from "../../src/providers/copilot.js";
+
+describe("GitHub Copilot quota parsing", () => {
+  it("normalizes quota snapshots without inventing comparable percentages", () => {
+    const result = normalizeCopilotUser({
+      login: "fixture-user",
+      copilot_plan: "individual",
+      quota_reset_date_utc: "2026-08-01T00:00:00Z",
+      quota_snapshots: {
+        chat: {
+          percent_remaining: 80,
+          quota_reset_at: 1785542400,
+        },
+        premium_interactions: {
+          percent_remaining: "25",
+        },
+      },
+    });
+
+    expect(result?.plan).toBe("individual");
+    expect(result?.account?.accountId).toBe("fixture-user");
+    expect(result?.windows).toMatchObject([
+      {
+        id: "chat",
+        label: "chat",
+        kind: "monthly",
+        percentUsed: 20,
+        percentRemaining: 80,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+      },
+      {
+        id: "premium_interactions",
+        label: "premium interactions",
+        kind: "monthly",
+        percentUsed: 75,
+        percentRemaining: 25,
+        resetsAt: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("can return a fresh entitlement report with no numeric windows", () => {
+    const result = normalizeCopilotUser({
+      login: "fixture-user",
+      access_type_sku: "business",
+    });
+
+    expect(result).toMatchObject({
+      plan: "business",
+      account: { accountId: "fixture-user" },
+      windows: [],
+    });
+  });
+});

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, it } from "vitest";
-import { normalizeCopilotUser } from "../../src/providers/copilot.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchQuota,
+  normalizeCopilotUser,
+} from "../../src/providers/copilot.js";
+
+const originalAppsJson = process.env.GITHUB_COPILOT_APPS_JSON;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-copilot-"));
+  process.env.GITHUB_COPILOT_APPS_JSON = join(tempDir, "apps.json");
+  process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalAppsJson === undefined)
+    delete process.env.GITHUB_COPILOT_APPS_JSON;
+  else process.env.GITHUB_COPILOT_APPS_JSON = originalAppsJson;
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function writeAppsJson(value: unknown): void {
+  writeFileSync(process.env.GITHUB_COPILOT_APPS_JSON!, JSON.stringify(value));
+}
 
 describe("GitHub Copilot quota parsing", () => {
   it("normalizes quota snapshots without inventing comparable percentages", () => {
@@ -55,5 +86,34 @@ describe("GitHub Copilot quota parsing", () => {
 
   it("rejects empty Copilot payloads as unusable quota", () => {
     expect(normalizeCopilotUser({})).toBeUndefined();
+  });
+
+  it("classifies GitHub 403 rate-limit responses before auth failures", async () => {
+    writeAppsJson({
+      fixture: {
+        oauth_token: "valid-token",
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("{}", {
+            status: 403,
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": "1785542400",
+            },
+          }),
+      ),
+    );
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("rate_limited");
+    expect(result.state.retryAfter).toBe("2026-08-01T00:00:00.000Z");
+    expect(result.state.error).toBe(
+      "GitHub Copilot quota endpoint rate limited",
+    );
   });
 });

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -145,6 +145,50 @@ describe("GitHub Copilot quota parsing", () => {
     );
   });
 
+  it("selects the public GitHub token when apps.json has multiple hosts", async () => {
+    writeAppsJson({
+      "ghe.example.test": {
+        oauth_token: "enterprise-token",
+      },
+      "github.com": {
+        oauth_token: "public-token",
+      },
+    });
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer public-token",
+      );
+      return new Response(
+        JSON.stringify({
+          login: "fixture-user",
+          access_type_sku: "individual",
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("does not send host-specific enterprise tokens to the public endpoint", async () => {
+    writeAppsJson({
+      "ghe.example.test": {
+        oauth_token: "enterprise-token",
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("auth_required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("resolves Copilot auth under XDG config home", async () => {
     const xdgConfigHome = join(tempDir!, "xdg-config");
     const authFile = join(xdgConfigHome, "github-copilot", "apps.json");

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -112,6 +112,33 @@ describe("GitHub Copilot quota parsing", () => {
     });
   });
 
+  it("skips quota snapshots without numeric remaining percentages", () => {
+    const result = normalizeCopilotUser({
+      login: "fixture-user",
+      access_type_sku: "business",
+      quota_snapshots: {
+        chat: {
+          quota_reset_at: 1785542400,
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      plan: "business",
+      account: { accountId: "fixture-user" },
+      windows: [],
+    });
+    expect(
+      normalizeCopilotUser({
+        quota_snapshots: {
+          chat: {
+            quota_reset_at: 1785542400,
+          },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("rejects empty Copilot payloads as unusable quota", () => {
     expect(normalizeCopilotUser({})).toBeUndefined();
   });
@@ -187,6 +214,35 @@ describe("GitHub Copilot quota parsing", () => {
 
     expect(result.state.status).toBe("auth_required");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("selects public GitHub token from app-id keyed auth entries", async () => {
+    writeAppsJson({
+      "ghe.example.test:Iv1.enterprise": {
+        oauth_token: "enterprise-token",
+      },
+      "github.com:Iv1.public": {
+        oauth_token: "public-token",
+      },
+    });
+    const fetchMock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer public-token",
+      );
+      return new Response(
+        JSON.stringify({
+          login: "fixture-user",
+          access_type_sku: "individual",
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("resolves Copilot auth under XDG config home", async () => {

--- a/test/providers/copilot.test.ts
+++ b/test/providers/copilot.test.ts
@@ -52,4 +52,8 @@ describe("GitHub Copilot quota parsing", () => {
       windows: [],
     });
   });
+
+  it("rejects empty Copilot payloads as unusable quota", () => {
+    expect(normalizeCopilotUser({})).toBeUndefined();
+  });
 });

--- a/test/providers/cursor-auth.test.ts
+++ b/test/providers/cursor-auth.test.ts
@@ -44,4 +44,42 @@ describe("Cursor credential-state reporting", () => {
       error: "credentials_missing",
     });
   });
+
+  it("preserves skipped sqlite discovery failures", async () => {
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => false),
+      execFileText: vi.fn(),
+    }));
+
+    const { fetchQuota } = await import("../../src/providers/cursor.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("error");
+    expect(result.state.error).toBe("sqlite3_unavailable");
+    expect(result.attempts).toContainEqual({
+      source: "state-vscdb",
+      status: "skipped",
+      error: "sqlite3_unavailable",
+    });
+  });
+
+  it("preserves sqlite read errors", async () => {
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => true),
+      execFileText: vi.fn(async () => {
+        throw new Error("SQLITE_ERROR: database is locked");
+      }),
+    }));
+
+    const { fetchQuota } = await import("../../src/providers/cursor.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("error");
+    expect(result.state.error).toBe("sqlite_read_error");
+    expect(result.attempts).toContainEqual({
+      source: "state-vscdb",
+      status: "skipped",
+      error: "sqlite_read_error",
+    });
+  });
 });

--- a/test/providers/cursor-auth.test.ts
+++ b/test/providers/cursor-auth.test.ts
@@ -120,6 +120,48 @@ describe("Cursor credential-state reporting", () => {
     });
   });
 
+  it("parses JSON string values from Cursor state storage", async () => {
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => true),
+      execFileText: vi.fn(async (_command: string, args: string[]) => {
+        const query = args.at(-1) ?? "";
+        if (query.includes("cursorAuth/accessToken")) return '"valid-token"';
+        if (query.includes("cursorAuth/cachedEmail"))
+          return '"person@example.invalid"';
+        if (query.includes("cursorAuth/stripeMembershipType")) return '"pro"';
+        return "";
+      }),
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: unknown, init?: RequestInit) => {
+        expect(new Headers(init?.headers).get("authorization")).toBe(
+          "Bearer valid-token",
+        );
+        if (String(url).includes("GetPlanInfo")) {
+          return new Response(
+            JSON.stringify({ planInfo: { planName: "pro" } }),
+            { status: 200 },
+          );
+        }
+        return new Response(
+          JSON.stringify({
+            billingCycleEnd: "1783036800000",
+            planUsage: { totalPercentUsed: 10 },
+          }),
+          { status: 200 },
+        );
+      }),
+    );
+
+    const { fetchQuota } = await import("../../src/providers/cursor.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("person@example.invalid");
+    expect(result.plan).toBe("pro");
+  });
+
   it("resolves the Linux state database under XDG config home", async () => {
     delete process.env.CURSOR_STATE_DB;
     const xdgConfigHome = join(tempDir!, "xdg-config");

--- a/test/providers/cursor-auth.test.ts
+++ b/test/providers/cursor-auth.test.ts
@@ -82,4 +82,22 @@ describe("Cursor credential-state reporting", () => {
       error: "sqlite_read_error",
     });
   });
+
+  it("reports a missing state database as missing auth", async () => {
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => true),
+      execFileText: vi.fn(async () => {
+        throw new Error("unable to open database file");
+      }),
+    }));
+
+    const { inspectAuth } = await import("../../src/providers/cursor.js");
+    const result = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(result.sources).toContainEqual({
+      source: "state-vscdb",
+      path: process.env.CURSOR_STATE_DB,
+      status: "missing",
+    });
+  });
 });

--- a/test/providers/cursor-auth.test.ts
+++ b/test/providers/cursor-auth.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalCursorStateDb = process.env.CURSOR_STATE_DB;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const originalHome = process.env.HOME;
 let tempDir: string | undefined;
 
 beforeEach(() => {
@@ -22,9 +24,26 @@ afterEach(() => {
   else process.env.CURSOR_STATE_DB = originalCursorStateDb;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (originalXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = undefined;
 });
+
+async function withPlatform<T>(
+  platform: NodeJS.Platform,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return await callback();
+  } finally {
+    if (descriptor) Object.defineProperty(process, "platform", descriptor);
+  }
+}
 
 describe("Cursor credential-state reporting", () => {
   it("reports a missing access token as auth required", async () => {
@@ -98,6 +117,35 @@ describe("Cursor credential-state reporting", () => {
       source: "state-vscdb",
       path: process.env.CURSOR_STATE_DB,
       status: "missing",
+    });
+  });
+
+  it("resolves the Linux state database under XDG config home", async () => {
+    delete process.env.CURSOR_STATE_DB;
+    const xdgConfigHome = join(tempDir!, "xdg-config");
+    process.env.XDG_CONFIG_HOME = xdgConfigHome;
+    process.env.HOME = join(tempDir!, "home");
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => false),
+      execFileText: vi.fn(),
+    }));
+
+    await withPlatform("linux", async () => {
+      const { inspectAuth } = await import("../../src/providers/cursor.js");
+      const result = await inspectAuth({ allowKeychainPrompt: false });
+
+      expect(result.sources).toContainEqual({
+        source: "state-vscdb",
+        path: join(
+          xdgConfigHome,
+          "Cursor",
+          "User",
+          "globalStorage",
+          "state.vscdb",
+        ),
+        status: "skipped",
+        error: "sqlite3_unavailable",
+      });
     });
   });
 });

--- a/test/providers/cursor-auth.test.ts
+++ b/test/providers/cursor-auth.test.ts
@@ -1,0 +1,47 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalCursorStateDb = process.env.CURSOR_STATE_DB;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+beforeEach(() => {
+  vi.resetModules();
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-cursor-auth-"));
+  process.env.CURSOR_STATE_DB = join(tempDir, "state.vscdb");
+  process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.doUnmock("../../src/lib/process.js");
+  vi.resetModules();
+  if (originalCursorStateDb === undefined) delete process.env.CURSOR_STATE_DB;
+  else process.env.CURSOR_STATE_DB = originalCursorStateDb;
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("Cursor credential-state reporting", () => {
+  it("reports a missing access token as auth required", async () => {
+    vi.doMock("../../src/lib/process.js", () => ({
+      commandExists: vi.fn(async () => true),
+      execFileText: vi.fn(async () => ""),
+    }));
+
+    const { fetchQuota } = await import("../../src/providers/cursor.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Cursor sign-in required");
+    expect(result.attempts).toContainEqual({
+      source: "state-vscdb",
+      status: "skipped",
+      error: "credentials_missing",
+    });
+  });
+});

--- a/test/providers/cursor.test.ts
+++ b/test/providers/cursor.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCursorUsage } from "../../src/providers/cursor.js";
+
+describe("Cursor quota parsing", () => {
+  it("normalizes current-period plan usage windows", () => {
+    const result = normalizeCursorUsage(
+      {
+        billingCycleEnd: "1783036800000",
+        planUsage: {
+          totalPercentUsed: 42.5,
+          autoPercentUsed: 12,
+          apiPercentUsed: "7",
+        },
+        spendLimitUsage: {
+          individualLimit: 2500,
+          individualUsed: 625,
+        },
+      },
+      {
+        planInfo: {
+          planName: "pro",
+        },
+      },
+      {
+        email: "person@example.invalid",
+      },
+    );
+
+    expect(result?.plan).toBe("pro");
+    expect(result?.account?.email).toBe("person@example.invalid");
+    expect(result?.windows).toMatchObject([
+      {
+        id: "included_usage",
+        label: "included usage",
+        kind: "monthly",
+        percentUsed: 43,
+        percentRemaining: 57,
+        resetsAt: "2026-07-03T00:00:00.000Z",
+      },
+      {
+        id: "auto_usage",
+        label: "auto usage",
+        kind: "monthly",
+        percentUsed: 12,
+        percentRemaining: 88,
+      },
+      {
+        id: "api_usage",
+        label: "API usage",
+        kind: "monthly",
+        percentUsed: 7,
+        percentRemaining: 93,
+      },
+      {
+        id: "spend_limit",
+        label: "spend limit",
+        kind: "credits",
+        percentUsed: 25,
+        percentRemaining: 75,
+        spentUsd: 6.25,
+        limitUsd: 25,
+      },
+    ]);
+  });
+
+  it("returns undefined when Cursor exposes no numeric quota windows", () => {
+    expect(normalizeCursorUsage({ planUsage: {} })).toBeUndefined();
+  });
+});

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -6,11 +6,12 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchQuota, normalizeGrokBilling } from "../../src/providers/grok.js";
 
 const originalGrokAuthJson = process.env.GROK_AUTH_JSON;
+const originalGrokHome = process.env.GROK_HOME;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 const originalPath = process.env.PATH;
 const originalPathExt = process.env.PATHEXT;
@@ -19,6 +20,7 @@ let tempDir: string | undefined;
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "quota-axi-grok-auth-"));
   process.env.GROK_AUTH_JSON = join(tempDir, "auth.json");
+  process.env.GROK_HOME = join(tempDir, "grok-home");
   process.env.XDG_CACHE_HOME = join(tempDir, "cache");
   process.env.PATH = join(tempDir, "empty-bin");
   process.env.PATHEXT = ".CMD;.EXE";
@@ -28,6 +30,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
   if (originalGrokAuthJson === undefined) delete process.env.GROK_AUTH_JSON;
   else process.env.GROK_AUTH_JSON = originalGrokAuthJson;
+  if (originalGrokHome === undefined) delete process.env.GROK_HOME;
+  else process.env.GROK_HOME = originalGrokHome;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (originalPath === undefined) delete process.env.PATH;
@@ -38,8 +42,13 @@ afterEach(() => {
   tempDir = undefined;
 });
 
-function writeAuth(value: unknown): void {
-  writeFileSync(process.env.GROK_AUTH_JSON!, JSON.stringify(value));
+function writeJson(file: string, value: unknown): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(value));
+}
+
+function writeAuth(value: unknown, file = process.env.GROK_AUTH_JSON!): void {
+  writeJson(file, value);
 }
 
 function writeLocalGrokPackage(version: string): void {
@@ -50,6 +59,21 @@ function writeLocalGrokPackage(version: string): void {
     join(packageDir, "package.json"),
     JSON.stringify({ name: "grok", version, bin: { grok: "bin/grok" } }),
   );
+  const command =
+    process.platform === "win32"
+      ? join(binDir, "grok.CMD")
+      : join(binDir, "grok");
+  writeFileSync(
+    command,
+    process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\nexit 0\n",
+  );
+  chmodSync(command, 0o700);
+  process.env.PATH = binDir;
+}
+
+function writeVersionedGrokCommand(version: string): void {
+  const binDir = join(process.env.GROK_HOME!, "downloads", `grok-v${version}`);
+  mkdirSync(binDir, { recursive: true });
   const command =
     process.platform === "win32"
       ? join(binDir, "grok.CMD")
@@ -195,6 +219,113 @@ describe("Grok quota parsing", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           "x-grok-client-version": "9.9.9",
+        }),
+      }),
+    );
+  });
+
+  it("uses GROK_HOME version metadata in billing requests", async () => {
+    writeAuth({
+      current: {
+        key: "valid-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    writeJson(join(process.env.GROK_HOME!, "version.json"), {
+      version: "8.7.6",
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-grok-client-version": "8.7.6",
+        }),
+      }),
+    );
+  });
+
+  it("uses versioned standalone Grok command paths", async () => {
+    writeAuth({
+      current: {
+        key: "valid-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    writeVersionedGrokCommand("7.6.5");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-grok-client-version": "7.6.5",
+        }),
+      }),
+    );
+  });
+
+  it("reads auth.json under GROK_HOME when no explicit auth path is set", async () => {
+    delete process.env.GROK_AUTH_JSON;
+    writeAuth(
+      {
+        current: {
+          key: "home-key",
+          email: "person@example.invalid",
+          expires_at: "2035-01-01T00:00:00.000Z",
+        },
+      },
+      join(process.env.GROK_HOME!, "auth.json"),
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("person@example.invalid");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer home-key",
         }),
       }),
     );

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGrokBilling } from "../../src/providers/grok.js";
+
+describe("Grok quota parsing", () => {
+  it("normalizes credit, on-demand, and product windows", () => {
+    const result = normalizeGrokBilling(
+      {
+        config: {
+          billingPeriodEnd: "2026-08-02T00:00:00Z",
+          creditUsagePercent: 40,
+          onDemandCap: { val: "1000" },
+          onDemandUsed: { val: 250 },
+          prepaidBalance: { val: 12.5 },
+          subscriptionTier: "supergrok",
+          productUsage: [
+            { product: "Grok Build", usagePercent: "55" },
+            { product: "Voice", usagePercent: 105 },
+          ],
+        },
+      },
+      {
+        email: "person@example.invalid",
+        teamId: "team_fixture",
+      },
+    );
+
+    expect(result?.plan).toBe("supergrok");
+    expect(result?.account).toMatchObject({
+      email: "person@example.invalid",
+      organization: "team_fixture",
+    });
+    expect(result?.credits).toEqual({ remaining: 12.5, unit: "credits" });
+    expect(result?.windows).toMatchObject([
+      {
+        id: "credits",
+        label: "credits",
+        kind: "credits",
+        percentUsed: 40,
+        percentRemaining: 60,
+        resetsAt: "2026-08-02T00:00:00.000Z",
+      },
+      {
+        id: "on_demand",
+        label: "on-demand credits",
+        kind: "credits",
+        percentUsed: 25,
+        percentRemaining: 75,
+      },
+      {
+        id: "product:grok_build",
+        label: "Grok Build",
+        kind: "credits",
+        percentUsed: 55,
+        percentRemaining: 45,
+      },
+      {
+        id: "product:voice",
+        label: "Voice",
+        kind: "credits",
+        percentUsed: 100,
+        percentRemaining: 0,
+      },
+    ]);
+  });
+
+  it("returns undefined when Grok exposes no numeric quota windows", () => {
+    expect(normalizeGrokBilling({ config: {} })).toBeUndefined();
+  });
+});

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -6,12 +12,16 @@ import { fetchQuota, normalizeGrokBilling } from "../../src/providers/grok.js";
 
 const originalGrokAuthJson = process.env.GROK_AUTH_JSON;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalPath = process.env.PATH;
+const originalPathExt = process.env.PATHEXT;
 let tempDir: string | undefined;
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "quota-axi-grok-auth-"));
   process.env.GROK_AUTH_JSON = join(tempDir, "auth.json");
   process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+  process.env.PATH = join(tempDir, "empty-bin");
+  process.env.PATHEXT = ".CMD;.EXE";
 });
 
 afterEach(() => {
@@ -20,12 +30,36 @@ afterEach(() => {
   else process.env.GROK_AUTH_JSON = originalGrokAuthJson;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (originalPath === undefined) delete process.env.PATH;
+  else process.env.PATH = originalPath;
+  if (originalPathExt === undefined) delete process.env.PATHEXT;
+  else process.env.PATHEXT = originalPathExt;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = undefined;
 });
 
 function writeAuth(value: unknown): void {
   writeFileSync(process.env.GROK_AUTH_JSON!, JSON.stringify(value));
+}
+
+function writeLocalGrokPackage(version: string): void {
+  const packageDir = join(tempDir!, "lib", "node_modules", "grok");
+  const binDir = join(packageDir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name: "grok", version, bin: { grok: "bin/grok" } }),
+  );
+  const command =
+    process.platform === "win32"
+      ? join(binDir, "grok.CMD")
+      : join(binDir, "grok");
+  writeFileSync(
+    command,
+    process.platform === "win32" ? "@echo off\r\n" : "#!/bin/sh\nexit 0\n",
+  );
+  chmodSync(command, 0o700);
+  process.env.PATH = binDir;
 }
 
 describe("Grok quota parsing", () => {
@@ -128,6 +162,71 @@ describe("Grok quota parsing", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           authorization: "Bearer valid-key",
+        }),
+      }),
+    );
+  });
+
+  it("uses the installed local Grok package version in billing requests", async () => {
+    writeAuth({
+      current: {
+        key: "valid-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    writeLocalGrokPackage("9.9.9");
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-grok-client-version": "9.9.9",
+        }),
+      }),
+    );
+  });
+
+  it("omits the Grok client version header without a local Grok package", async () => {
+    writeAuth({
+      current: {
+        key: "valid-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          "x-grok-client-version": expect.any(String),
         }),
       }),
     );

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -1,5 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { normalizeGrokBilling } from "../../src/providers/grok.js";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchQuota, normalizeGrokBilling } from "../../src/providers/grok.js";
+
+const originalGrokAuthJson = process.env.GROK_AUTH_JSON;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-grok-auth-"));
+  process.env.GROK_AUTH_JSON = join(tempDir, "auth.json");
+  process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalGrokAuthJson === undefined) delete process.env.GROK_AUTH_JSON;
+  else process.env.GROK_AUTH_JSON = originalGrokAuthJson;
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function writeAuth(value: unknown): void {
+  writeFileSync(process.env.GROK_AUTH_JSON!, JSON.stringify(value));
+}
 
 describe("Grok quota parsing", () => {
   it("normalizes credit, on-demand, and product windows", () => {
@@ -65,5 +92,44 @@ describe("Grok quota parsing", () => {
 
   it("returns undefined when Grok exposes no numeric quota windows", () => {
     expect(normalizeGrokBilling({ config: {} })).toBeUndefined();
+  });
+
+  it("continues past expired entries to use later valid credentials", async () => {
+    writeAuth({
+      expired: {
+        key: "expired-key",
+        expires_at: "2020-01-01T00:00:00.000Z",
+      },
+      valid: {
+        key: "valid-key",
+        email: "person@example.invalid",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("person@example.invalid");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer valid-key",
+        }),
+      }),
+    );
   });
 });

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchQuota, normalizeGrokBilling } from "../../src/providers/grok.js";
 
 const originalGrokAuthJson = process.env.GROK_AUTH_JSON;
+const originalGrokAuthPath = process.env.GROK_AUTH_PATH;
+const originalGrokAuth = process.env.GROK_AUTH;
 const originalGrokHome = process.env.GROK_HOME;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 const originalPath = process.env.PATH;
@@ -20,6 +22,8 @@ let tempDir: string | undefined;
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), "quota-axi-grok-auth-"));
   process.env.GROK_AUTH_JSON = join(tempDir, "auth.json");
+  delete process.env.GROK_AUTH_PATH;
+  delete process.env.GROK_AUTH;
   process.env.GROK_HOME = join(tempDir, "grok-home");
   process.env.XDG_CACHE_HOME = join(tempDir, "cache");
   process.env.PATH = join(tempDir, "empty-bin");
@@ -30,6 +34,10 @@ afterEach(() => {
   vi.unstubAllGlobals();
   if (originalGrokAuthJson === undefined) delete process.env.GROK_AUTH_JSON;
   else process.env.GROK_AUTH_JSON = originalGrokAuthJson;
+  if (originalGrokAuthPath === undefined) delete process.env.GROK_AUTH_PATH;
+  else process.env.GROK_AUTH_PATH = originalGrokAuthPath;
+  if (originalGrokAuth === undefined) delete process.env.GROK_AUTH;
+  else process.env.GROK_AUTH = originalGrokAuth;
   if (originalGrokHome === undefined) delete process.env.GROK_HOME;
   else process.env.GROK_HOME = originalGrokHome;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
@@ -191,6 +199,61 @@ describe("Grok quota parsing", () => {
     );
   });
 
+  it("prefers session-scoped auth over API-key entries", async () => {
+    writeAuth({
+      "https://api.x.ai/v1": {
+        key: "api-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+      "https://accounts.x.ai/sign-in": {
+        key: "session-key",
+        email: "person@example.invalid",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("person@example.invalid");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer session-key",
+        }),
+      }),
+    );
+  });
+
+  it("does not use API-key auth entries for billing", async () => {
+    writeAuth({
+      "https://api.x.ai/v1": {
+        key: "api-key",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("auth_required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("uses the installed local Grok package version in billing requests", async () => {
     writeAuth({
       current: {
@@ -326,6 +389,100 @@ describe("Grok quota parsing", () => {
       expect.objectContaining({
         headers: expect.objectContaining({
           authorization: "Bearer home-key",
+        }),
+      }),
+    );
+  });
+
+  it("reads official GROK_AUTH_PATH before GROK_HOME", async () => {
+    delete process.env.GROK_AUTH_JSON;
+    process.env.GROK_AUTH_PATH = join(tempDir!, "official-auth.json");
+    writeAuth(
+      {
+        "https://accounts.x.ai/sign-in": {
+          key: "path-key",
+          email: "path@example.invalid",
+          expires_at: "2035-01-01T00:00:00.000Z",
+        },
+      },
+      process.env.GROK_AUTH_PATH,
+    );
+    writeAuth(
+      {
+        "https://accounts.x.ai/sign-in": {
+          key: "home-key",
+          expires_at: "2035-01-01T00:00:00.000Z",
+        },
+      },
+      join(process.env.GROK_HOME!, "auth.json"),
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("path@example.invalid");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer path-key",
+        }),
+      }),
+    );
+  });
+
+  it("reads inline GROK_AUTH before file fallbacks", async () => {
+    delete process.env.GROK_AUTH_JSON;
+    process.env.GROK_AUTH = JSON.stringify({
+      "https://accounts.x.ai/sign-in": {
+        key: "inline-key",
+        email: "inline@example.invalid",
+        expires_at: "2035-01-01T00:00:00.000Z",
+      },
+    });
+    writeAuth(
+      {
+        "https://accounts.x.ai/sign-in": {
+          key: "home-key",
+          expires_at: "2035-01-01T00:00:00.000Z",
+        },
+      },
+      join(process.env.GROK_HOME!, "auth.json"),
+    );
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            config: {
+              creditUsagePercent: 25,
+            },
+          }),
+          { status: 200 },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account?.email).toBe("inline@example.invalid");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer inline-key",
         }),
       }),
     );


### PR DESCRIPTION
## Intent

Add quota-axi support for Cursor, GitHub Copilot CLI, and Grok local quota providers, preserving data-only behavior, provider selection, normalized output, docs, tests, live read-only validation, and clean-room boundaries.

## What Changed
- Add Cursor, GitHub Copilot, and Grok quota providers to the default provider set with local auth discovery, read-only first-party quota fetches, normalized windows, and auth reporting.
- Harden provider parsing, credential source selection, retry/rate-limit handling, cache behavior, and edge cases for no-window or missing-auth responses.
- Update README and generated skill docs, plus provider, CLI, cache, and evidence coverage for the new provider behavior.

## Risk Assessment

⚠️ Medium: The remaining change is a large new-provider integration surface with external auth and quota API dependencies, but I did not find a substantiated code issue in the current diff.

## Testing

Ran the relevant provider/cache/CLI Vitest command, which executed the full 12-file test suite successfully, then exercised the actual CLI end-to-end for Cursor, GitHub Copilot, and Grok with isolated fake local auth/state files and deterministic first-party-shaped responses; the captured JSON evidence shows all three providers selected, available auth sources, fresh API-backed quota reports, and normalized Cursor, Copilot, and Grok quota windows.

- Evidence: [E2E quota JSON for Cursor, Copilot, and Grok](https://github.com/kunchenguid/quota-axi/blob/a85bd6aef9c1c11645a73d46a77fc40f6c732481/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/cli-cursor-copilot-grok.json)
- Evidence: [E2E auth JSON for Cursor, Copilot, and Grok](https://github.com/kunchenguid/quota-axi/blob/a85bd6aef9c1c11645a73d46a77fc40f6c732481/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/auth-cursor-copilot-grok.json)
- Evidence: [Deterministic first-party fetch preload used for E2E evidence](https://github.com/kunchenguid/quota-axi/blob/a85bd6aef9c1c11645a73d46a77fc40f6c732481/.no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (8) ✅</summary>

- ⚠️ `src/providers/cursor.ts:90` - When the Cursor DB exists but `cursorAuth/accessToken` is absent, this branch leaves `finalError` as the generic unavailable message, so the provider reports `state.status: error` instead of an auth-required sign-in state. Set the missing-credential path to `Cursor sign-in required` or otherwise map it deliberately.
- ⚠️ `src/providers/copilot.ts:130` - `normalizeCopilotUser({})` returns a fresh provider with no plan, account, or windows, which can mask a malformed or changed API payload and bypass stale-cache fallback. Require at least entitlement identity or quota windows before returning a fresh result.
- ⚠️ `src/providers/grok.ts:265` - If the Grok auth JSON contains multiple entries and the first keyed entry is expired, the loop returns `expired` immediately and never checks later valid credentials. Continue scanning and only return expired if no usable key is found.

🔧 Fix: Harden provider credential edge cases
3 warnings still open:
- ⚠️ `test/cli.test.ts:274` - This test still relies on the default provider set after the default was expanded to Cursor, Copilot, and Grok. Because only Claude and Codex are mocked here, the test can read real local provider auth and make real network calls when those credentials exist; scope this invocation to `claude,codex` like the surrounding tests.
- ⚠️ `src/providers/cursor.ts:90` - When Cursor credential discovery is skipped because `sqlite3` is unavailable, or fails with a SQLite read error, this path still reports `Cursor sign-in required` and maps the provider to `auth_required`. Preserve the concrete source error for skipped/read-error states so users do not get an auth remediation for a local reader failure.
- ⚠️ `src/providers/copilot.ts:135` - Copilot can now return a fresh entitlement-only report with `windows: []`, but cache writes ignore fresh providers with no windows and keep any older Copilot cache entry. After a later live failure, that older window snapshot can be returned as stale even though the latest successful response established that no numeric quota windows were available; clear the provider&#39;s existing cache entry when a fresh no-window Copilot report is observed.

🔧 Fix: Harden provider cache and credential edge cases
1 warning still open:
- ⚠️ `src/providers/grok.ts:30` - The Grok request always sends `x-grok-client-version: 0.2.91`. If the proxy rejects older CLI versions, users with an updated Grok install will still fail until quota-axi ships again; read the installed local Grok version or omit this header with a fallback instead of pinning it in source.

🔧 Fix: Use local Grok client version
3 warnings still open:
- ⚠️ `src/providers/copilot.ts:252` - GitHub REST rate limits can be returned as 403 with rate-limit headers, but this branch maps every Copilot 403 to sign-in required, so a rate-limited user would get the wrong auth-required state and no retry time. Check `retry-after` / `x-ratelimit-remaining` before treating 403 as auth. Reference: https://docs.github.com/rest/using-the-rest-api/rate-limits-for-the-rest-api
- ⚠️ `src/providers/grok.ts:233` - `readGrokClientVersion` only walks parent `package.json` files, which misses the official standalone Grok install layout where the executable is a versioned binary under `~/.grok/downloads` and the version is cached in `version.json`; the billing request then omits `x-grok-client-version` for that common install. Read `GROK_HOME`/`~/.grok/version.json` or parse the versioned binary name before falling back to npm package metadata.
- ⚠️ `src/providers/grok.ts:334` - Grok documents `GROK_HOME` as the override for its config directory, but `grokAuthFile` only checks `GROK_AUTH_JSON` and otherwise hardcodes `~/.grok/auth.json`, so users running Grok with a custom home are reported signed out. Resolve `auth.json` under `process.env.GROK_HOME` before the homedir default.

🔧 Fix: Harden Copilot and Grok provider edge cases
2 warnings still open:
- ⚠️ `src/providers/cursor.ts:306` - Missing Cursor DBs are normalized to `credentials_missing`, but the auth source still reports `status: invalid`; `quota-axi auth` will tell users the state DB is invalid instead of missing or not signed in. Return a missing credential/source state when `sqliteErrorMessage(error) === &#34;credentials_missing&#34;`.
- ⚠️ `src/providers/copilot.ts:245` - The default Copilot auth path is hardcoded to `~/.config/github-copilot/apps.json`, so Linux users with `XDG_CONFIG_HOME` or Windows users whose Copilot auth lives under `%USERPROFILE%\AppData\Local\github-copilot\apps.json` are reported signed out unless they set an override. Resolve the platform/XDG default before falling back. Reference: https://github.com/microsoft/copilot-intellij-feedback/issues/1633

🔧 Fix: Harden provider auth discovery
2 warnings still open:
- ⚠️ `src/providers/copilot.ts:228` - This scans every apps.json entry and uses the first oauth_token even though USER_URL is hardcoded to api.github.com. If the file contains multiple hosts, this can send a GitHub Enterprise or otherwise non-public token to the public GitHub API and miss a later github.com token; select the entry matching the endpoint host or derive the endpoint from the selected host.
- ⚠️ `src/providers/cursor.ts:360` - The Linux Cursor state DB path always falls back to ~/.config/Cursor, but Cursor&#39;s Electron user-data path can live under XDG_CONFIG_HOME. Users with custom XDG config homes will be reported signed out unless they set CURSOR_STATE_DB; resolve process.env.XDG_CONFIG_HOME before the homedir fallback.

🔧 Fix: Harden provider auth discovery
3 issues (1 error, 2 warnings) still open:
- 🚨 `src/providers/cursor.ts:335` - Cursor state values are JSON-encoded strings, so returning the raw sqlite cell passes a quoted token as `Bearer &#34;token&#34;` and makes live Cursor auth fail. Parse JSON string cells before returning, with a plain-string fallback. Source examples: https://github.com/Dwtexe/cursor-stats/issues/36 and https://github.com/eisbaw/cursor_api_demo/blob/main/cursor_auth_reader.py
- ⚠️ `src/providers/copilot.ts:280` - Common Copilot `apps.json` keys use `github.com:Iv1...`; `new URL()` treats that suffix as an invalid port, so mixed public and enterprise auth files can miss the public token and report signed out. Parse the host prefix before URL normalization. Example format: https://github.com/zed-industries/zed/issues/30784
- ⚠️ `src/providers/copilot.ts:188` - This pushes a Copilot window even when a snapshot has no numeric quota fields, making placeholder or changed payloads look fresh and cacheable with `unknown` quota. Skip snapshot entries without `percent_remaining` so entitlement-only responses stay as `windows: []`.

🔧 Fix: Harden Cursor and Copilot provider parsing
2 warnings still open:
- ⚠️ `src/providers/grok.ts:350` - This accepts the first unexpired auth entry with a `key`, but Grok can store non-session entries such as API-key auth alongside the `https://accounts.x.ai/sign-in` session token. Prefer the grok.com session-scope entry for the billing request and ignore API-key scopes so quota reads do not send the wrong credential or skip a later valid session token.
- ⚠️ `src/providers/grok.ts:383` - Grok supports auth overrides such as `GROK_AUTH_PATH` and inline `GROK_AUTH`, but this only checks the quota-axi-specific `GROK_AUTH_JSON` before falling back to `GROK_HOME/auth.json`. Users running Grok with the official overrides will be reported signed out or under the wrong account; read those overrides before the home-directory fallback.

🔧 Fix: Harden Grok auth source selection
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm test -- test/providers/copilot.test.ts test/providers/cursor-auth.test.ts test/providers/cursor.test.ts test/providers/grok.test.ts test/cli.test.ts test/cache.test.ts`
- <code>`node --import tsx --import .no-mistakes/evidence/fm/quota-axi-more-providers-p8/mock-first-party-fetch.mjs bin/quota-axi.ts --provider cursor,copilot,grok --json --full` with isolated temporary `CURSOR_STATE_DB`, `GITHUB_COPILOT_APPS_JSON`, `GROK_AUTH_JSON`, `GROK_HOME`, and `XDG_CACHE_HOME`, captured to the quota evidence JSON</code>
- <code>`node --import tsx bin/quota-axi.ts auth --provider cursor,copilot,grok --json` with the same isolated temporary provider auth/state files, captured to the auth evidence JSON</code>
- <code>`node --input-type=module` evidence parser asserting all three providers were selected, auth sources were available, quota states were fresh, API source was used, and expected normalized windows were present</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
