### PR TITLE
feat: add quota watch TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Failed providers, stale providers, account identity, and source attempts are not cached.
 - Do not cache raw provider responses or credential headers.
 - Watch snapshots live in `src/snapshot.ts`: `getWatchSnapshot` / `buildWatchSnapshot` produce a render-ready `WatchSnapshot` (remaining %, reset countdown, derived burn rate or honest unavailable, trust/staleness). Default `refresh: false` is cache/last-known only so the agent read path stays untaxed; `refresh: true` is the only path that fetches providers. Snapshots never include account identity or USD fields.
+- Watch TUI lives in `src/watch-render.ts` (`renderWatchPane`) and `src/watch.ts` (`runWatchLoop`); CLI `quota-axi watch` defaults to cache-only snapshots (`refresh: false`), paints remaining % / reset countdown / burn rate / trust, red-line markers from `SnapshotWindow.level`, and never shows USD outside `--full`.
 
 ## Development
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
 - quota-axi is data only.
-- It reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
+- It reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Antigravity (`agy`) quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
 - Claude quota windows can include `five_hour`, `seven_day`, `seven_day_opus`, and `extra_usage`. When the OAuth usage response includes a `limits` array, that array is the authoritative, self-describing source and is preferred over the fixed top-level fields: it surfaces every active limit, including ones scoped to a specific model (e.g. Fable) via `scope.model.display_name`, with a `model:<slug>` window id.
 - Codex quota windows can include `five_hour` and `weekly`, plus optional credit balance data. Codex responses can also carry extra limits scoped to a specific model or feature (HTTP: `additional_rate_limits`; app-server RPC: `rateLimitsByLimitId`), surfaced as `model:<id>:5h` / `model:<id>:7d` windows.
 - Cursor reads `$CURSOR_STATE_DB` or the local Cursor state database via `sqlite3 -readonly` for `cursorAuth` values and can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows from the first-party dashboard usage endpoint.
@@ -13,6 +13,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Grok reads `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json`/`~/.grok/auth.json`, selects session-scoped auth instead of API-key entries, recognizes OIDC records scoped to `auth.x.ai` with `auth_mode` or `authMode` set to `oidc`, and can report `credits`, optional `on_demand`, and optional `product:<slug>` windows from the first-party billing endpoint.
   When billing exposes only a current period and prepaid balance, Grok reports a reset-only `credits` window without inventing usage percentages.
 - Grok may read `$GROK_HOME/version.json` or package metadata near a local `grok` executable to send `x-grok-client-version`, but it must not launch the Grok CLI.
+- Antigravity (`agy`) discovers already-running Antigravity/`agy` processes via `ps` plus listening ports via `lsof`, then reads only 127.0.0.1 loopback quota endpoints. It prefers `RetrieveUserQuotaSummary`, may use `GetUserStatus` / `GetCommandModelConfigs` as read-only fallbacks, reports `gemini_5h`, `gemini_weekly`, `claude_gpt_5h`, and `claude_gpt_weekly` when grouped summary exists, and must never launch or restart Antigravity/`agy`.
 - Provider adapter behavior (retry-after handling, snake/camel field tolerance, window parsing) is an original, clean-room implementation derived only from the vendors' own OAuth/HTTP behavior; quota-axi carries no vendored or attributed third-party adapter code.
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Only fresh provider snapshots with windows are cached; fresh provider reports with no windows clear any existing cached snapshot for that provider.
 - Failed providers, stale providers, account identity, and source attempts are not cached.
 - Do not cache raw provider responses or credential headers.
+- Watch snapshots live in `src/snapshot.ts`: `getWatchSnapshot` / `buildWatchSnapshot` produce a render-ready `WatchSnapshot` (remaining %, reset countdown, derived burn rate or honest unavailable, trust/staleness). Default `refresh: false` is cache/last-known only so the agent read path stays untaxed; `refresh: true` is the only path that fetches providers. Snapshots never include account identity or USD fields.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Quota CLI for agents - designed with [AXI](https://axi.md) (Agent eXperience Int
 Agents need quota state before they choose where work can safely run.
 Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth sources.
 
-quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows in one [AXI](https://axi.md)-shaped call.
+quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Antigravity (`agy`) quota windows in one [AXI](https://axi.md)-shaped call.
 It is data only: it never routes, recommends, proxies, intercepts, logs in, imports browser cookies, or mutates provider state.
 
-- **Official sources** - quota-axi reads local provider auth sources and calls the first-party quota, usage, billing, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
+- **Official sources** - quota-axi reads local provider auth sources and calls the first-party quota, usage, billing, entitlement, or local loopback endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
 - **Local first** - everything runs on the machine that holds the credentials; the only network calls are to first-party provider endpoints, never a third-party relay.
 - **Token efficient** - default stdout is compact TOON so agents spend fewer tokens parsing quota state, with `--json` available when a caller needs the normalized model.
 
@@ -34,13 +34,14 @@ $ npx -y quota-axi
 bin: ~/.npm/_npx/.../quota-axi
 description: Report local agent-provider quota windows for routing-aware agents
 generatedAt: "2026-03-15T16:42:00.000Z"
-providers[5]{provider,plan,source,status,refreshedAt}:
+providers[6]{provider,plan,source,status,refreshedAt}:
   claude,pro,oauth,fresh,"2026-03-15T16:41:55.000Z"
   codex,plus,cli-rpc,fresh,"2026-03-15T16:41:58.000Z"
   cursor,pro,api,fresh,"2026-03-15T16:41:59.000Z"
   copilot,individual,api,fresh,"2026-03-15T16:42:00.000Z"
   grok,supergrok,api,fresh,"2026-03-15T16:42:00.000Z"
-windows[13]{provider,id,label,percentRemaining,resetsAt,state}:
+  agy,Pro,cli-rpc,fresh,"2026-03-15T16:42:00.000Z"
+windows[17]{provider,id,label,percentRemaining,resetsAt,state}:
   claude,five_hour,session,82,"2026-03-15T21:15:00.000Z",fresh
   claude,seven_day,week,64,"2026-03-19T15:00:00.000Z",fresh
   claude,seven_day_opus,opus week,93,"2026-03-20T09:30:00.000Z",fresh
@@ -54,6 +55,10 @@ windows[13]{provider,id,label,percentRemaining,resetsAt,state}:
   copilot,chat,chat,84,"2026-04-01T00:00:00.000Z",fresh
   copilot,premium_interactions,premium interactions,53,"2026-04-01T00:00:00.000Z",fresh
   grok,credits,credits,67,"2026-04-01T00:00:00.000Z",fresh
+  agy,gemini_5h,Gemini 5-hour,100,"2026-03-15T21:42:00.000Z",fresh
+  agy,gemini_weekly,Gemini weekly,98,"2026-03-18T21:30:30.000Z",fresh
+  agy,claude_gpt_5h,Claude/GPT 5-hour,100,"2026-03-15T21:42:00.000Z",fresh
+  agy,claude_gpt_weekly,Claude/GPT weekly,99,"2026-03-19T00:39:50.000Z",fresh
 help[3]:
   Run `quota-axi --provider claude --json` for JSON output
   Run `quota-axi --full` to include account and source-attempt details
@@ -106,7 +111,7 @@ $ quota-axi --provider claude --json
 $ quota-axi auth
 bin: ~/.npm/_npx/.../quota-axi
 description: Inspect local quota auth sources without printing secret values
-auth[7]{provider,source,path,status,error}:
+auth[8]{provider,source,path,status,error}:
   claude,oauth-file,~/.claude/.credentials.json,available,none
   claude,keychain,none,skipped,keychain_prompt_required
   codex,auth-json,~/.codex/auth.json,available,none
@@ -114,6 +119,7 @@ auth[7]{provider,source,path,status,error}:
   cursor,state-vscdb,~/Library/Application Support/Cursor/User/globalStorage/state.vscdb,available,none
   copilot,apps-json,~/.config/github-copilot/apps.json,available,none
   grok,auth-json,~/.grok/auth.json,available,none
+  agy,loopback,none,available,none
 help[1]:
   Run `quota-axi --allow-keychain-prompt auth` to permit macOS Keychain access
 ```
@@ -201,14 +207,14 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ### Flags
 
-| Flag                                          | Description                                            |
-| --------------------------------------------- | ------------------------------------------------------ |
-| `--provider claude,codex,cursor,copilot,grok` | Scope providers                                        |
-| `--json`                                      | Emit normalized JSON instead of TOON for quota or auth |
-| `--full`                                      | Include quota account identity and source attempts     |
-| `--allow-keychain-prompt`                     | Permit macOS Claude Keychain access that could prompt  |
-| `-h`, `--help`                                | Print terse [AXI](https://axi.md) help                 |
-| `-v`, `-V`, `--version`                       | Print version                                          |
+| Flag                                              | Description                                            |
+| ------------------------------------------------- | ------------------------------------------------------ |
+| `--provider claude,codex,cursor,copilot,grok,agy` | Scope providers                                        |
+| `--json`                                          | Emit normalized JSON instead of TOON for quota or auth |
+| `--full`                                          | Include quota account identity and source attempts     |
+| `--allow-keychain-prompt`                         | Permit macOS Claude Keychain access that could prompt  |
+| `-h`, `--help`                                    | Print terse [AXI](https://axi.md) help                 |
+| `-v`, `-V`, `--version`                           | Print version                                          |
 
 ## Output Model
 
@@ -270,6 +276,7 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 | GitHub Copilot           | Can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions`; when the first-party endpoint exposes entitlement but no numeric quota windows, quota-axi reports a fresh provider state with an empty `windows` list rather than inventing percentages.           |
 | Grok                     | Can report `credits`, optional `on_demand`, and optional product-scoped `product:<slug>` windows.                                                                                                                                                                                               |
 | Grok current period only | If Grok's billing response only exposes the current billing period and prepaid balance, quota-axi reports a fresh `credits` window with `resetsAt` and `credits.remaining` but no usage percentage.                                                                                             |
+| Antigravity (`agy`)      | Can report `gemini_5h`, `gemini_weekly`, `claude_gpt_5h`, and `claude_gpt_weekly` from an already-running Antigravity app or `agy` loopback quota summary. If only model config quota is exposed, quota-axi reports model-scoped `model:<slug>` windows instead of inventing grouped windows.   |
 
 ### `auth --json` shape
 
@@ -281,10 +288,10 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 
 Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 
-| Name                 | Values                                                                                       |
-| -------------------- | -------------------------------------------------------------------------------------------- |
-| Auth source statuses | `available`, `missing`, `invalid`, `expired`, or `skipped`                                   |
-| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, and `cli-rpc` |
+| Name                 | Values                                                                                                   |
+| -------------------- | -------------------------------------------------------------------------------------------------------- |
+| Auth source statuses | `available`, `missing`, `invalid`, `expired`, or `skipped`                                               |
+| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, `cli-rpc`, and `loopback` |
 
 ## Security Posture
 
@@ -297,6 +304,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 | Cursor         | `$CURSOR_STATE_DB` when set or the platform Cursor state database path                                                                                                           |
 | GitHub Copilot | `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file                                                                                                         |
 | Grok           | `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`                                                                       |
+| Antigravity    | No credential files; discovers already-running Antigravity or `agy` processes and reads only their 127.0.0.1 loopback quota endpoints                                            |
 
 ### Provider notes
 
@@ -327,12 +335,19 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 - Session-scoped Grok auth includes web/session scopes and OIDC records scoped to `auth.x.ai` with `auth_mode` or `authMode` set to `oidc`, including scope keys with `::<client id>` suffixes.
 - It may read `$GROK_HOME/version.json` or package metadata near a local `grok` executable to send an `x-grok-client-version` header, but it does not launch the Grok CLI.
 
+**Antigravity**
+
+- It never launches, restarts, signs in to, or mutates Antigravity or `agy`.
+- It runs process and listening-port discovery, then POSTs `{}` to documented local read endpoints on `127.0.0.1`.
+- It prefers `RetrieveUserQuotaSummary`, uses `GetUserStatus` for account plan identity behind `--full`, and can fall back to model quota data from `GetUserStatus` / `GetCommandModelConfigs` when grouped quota summary is unavailable.
+- Burn rate is not reported for Antigravity v1 because the local payload exposes point-in-time quota snapshots, not enough history to compute a rate honestly.
+
 ### Safety guarantees
 
 - Direct HTTP requests go only to first-party provider usage, quota, billing, or entitlement endpoints with the user's local credentials.
 - It sends credential values only to the first-party provider request they authenticate.
 - It never prints, logs, or caches credential values.
-- It never launches the Claude CLI, so it cannot accidentally spend the quota it measures.
+- It never launches the Claude CLI or Antigravity/`agy`, so it cannot accidentally spend the quota it measures.
 
 ### Cache
 

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -53,11 +53,11 @@ or when comparing supported local provider headroom side by side.
 ## Usage
 
 ```
-usage: quota-axi [auth] [flags]
-commands[2]:
-  (none)=quota, auth
-flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+usage: quota-axi [auth|watch] [flags]
+commands[3]:
+  (none)=quota, auth, watch
+flags[9]:
+  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --interval <seconds>, --refresh, --once, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
@@ -66,6 +66,9 @@ examples:
   quota-axi --json
   quota-axi --full
   quota-axi auth
+  quota-axi watch
+  quota-axi watch --interval 15 --provider codex,grok
+  quota-axi watch --refresh --once
 ```
 
 ## Tips

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Antigravity quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
   hermes:
-    tags: [quota, rate-limits, claude, codex, cursor, copilot, grok, cli]
+    tags:
+      - quota
+      - rate-limits
+      - claude
+      - codex
+      - cursor
+      - copilot
+      - grok
+      - agy
+      - antigravity
+      - cli
     category: observability
 ---
 
@@ -17,8 +27,8 @@ You do not need quota-axi installed globally - invoke it with `npx -y quota-axi`
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
 browser cookies, or mutates provider state. It reads local provider auth sources and calls
-first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
-Claude CLI, so it cannot spend the quota it measures.
+first-party provider quota, usage, billing, entitlement, or local loopback endpoints; it never
+launches the Claude CLI or Antigravity/agy, so it cannot spend the quota it measures.
 
 ## When to use
 
@@ -29,7 +39,7 @@ or when comparing supported local provider headroom side by side.
 ## Workflow
 
 1. Run `npx -y quota-axi` for compact TOON output covering supported providers' quota windows.
-2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok`.
+2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok,agy`.
 3. Pass `--json` for the normalized machine-readable model instead of TOON.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
@@ -47,11 +57,12 @@ usage: quota-axi [auth] [flags]
 commands[2]:
   (none)=quota, auth
 flags[6]:
-  --provider <claude,codex,cursor,copilot,grok>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
-  quota-axi --provider cursor,copilot,grok
+  quota-axi --provider agy
+  quota-axi --provider cursor,copilot,grok,agy
   quota-axi --json
   quota-axi --full
   quota-axi auth

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   renderError,
   renderQuotaToon,
 } from "./render.js";
+import { getWatchSnapshot } from "./snapshot.js";
 import type {
   AuthProviderReport,
   ProviderId,
@@ -18,15 +19,20 @@ import type {
   ProviderQuota,
   QuotaAxiResponse,
 } from "./types.js";
+import {
+  defaultWatchIntervalSeconds,
+  runWatchLoop,
+  type WatchLoopDeps,
+} from "./watch.js";
 
 export const DESCRIPTION =
   "Report local agent-provider quota windows for routing-aware agents.";
 
-export const TOP_HELP = `usage: quota-axi [auth] [flags]
-commands[2]:
-  (none)=quota, auth
-flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+export const TOP_HELP = `usage: quota-axi [auth|watch] [flags]
+commands[3]:
+  (none)=quota, auth, watch
+flags[9]:
+  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --interval <seconds>, --refresh, --once, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
@@ -35,20 +41,27 @@ examples:
   quota-axi --json
   quota-axi --full
   quota-axi auth
+  quota-axi watch
+  quota-axi watch --interval 15 --provider codex,grok
+  quota-axi watch --refresh --once
 `;
 
 type MainOptions = {
   argv?: string[];
-  stdout?: Pick<NodeJS.WriteStream, "write">;
+  stdout?: Pick<NodeJS.WriteStream, "write" | "isTTY">;
   binPath?: string;
+  watchDeps?: Partial<WatchLoopDeps>;
 };
 
 type ParsedArgs = {
-  command: "quota" | "auth" | "help" | "version";
+  command: "quota" | "auth" | "watch" | "help" | "version";
   providers: ProviderId[];
   json: boolean;
   full: boolean;
   allowKeychainPrompt: boolean;
+  intervalSeconds: number;
+  refresh: boolean;
+  once: boolean;
 };
 
 export async function main(options: MainOptions = {}): Promise<void> {
@@ -76,6 +89,10 @@ export async function main(options: MainOptions = {}): Promise<void> {
       } else {
         stdout.write(`${renderAuthToon(reports, binPath)}\n`);
       }
+      return;
+    }
+    if (parsed.command === "watch") {
+      await runWatchCommand(parsed, stdout, options.watchDeps);
       return;
     }
 
@@ -111,6 +128,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let json = false;
   let full = false;
   let allowKeychainPrompt = false;
+  let intervalSeconds = defaultWatchIntervalSeconds();
+  let refresh = false;
+  let once = false;
 
   for (let index = 0; index < argv.length; index++) {
     const arg = argv[index];
@@ -119,6 +139,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === "auth") {
       command = "auth";
+      continue;
+    }
+    if (arg === "watch") {
+      command = "watch";
       continue;
     }
     if (arg === "--help" || arg === "-h") {
@@ -139,6 +163,25 @@ export function parseArgs(argv: string[]): ParsedArgs {
     }
     if (arg === "--allow-keychain-prompt") {
       allowKeychainPrompt = true;
+      continue;
+    }
+    if (arg === "--refresh") {
+      refresh = true;
+      continue;
+    }
+    if (arg === "--once") {
+      once = true;
+      continue;
+    }
+    if (arg === "--interval" || arg === "-i") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--interval requires seconds");
+      intervalSeconds = parseIntervalSeconds(value);
+      index++;
+      continue;
+    }
+    if (arg.startsWith("--interval=")) {
+      intervalSeconds = parseIntervalSeconds(arg.slice("--interval=".length));
       continue;
     }
     if (arg === "--provider") {
@@ -162,7 +205,89 @@ export function parseArgs(argv: string[]): ParsedArgs {
     json,
     full,
     allowKeychainPrompt,
+    intervalSeconds,
+    refresh,
+    once,
   };
+}
+
+async function runWatchCommand(
+  parsed: ParsedArgs,
+  stdout: Pick<NodeJS.WriteStream, "write" | "isTTY">,
+  watchDeps?: Partial<WatchLoopDeps>,
+): Promise<void> {
+  const isTty = Boolean(
+    watchDeps?.isTty ??
+    ("isTTY" in stdout ? stdout.isTTY : process.stdout.isTTY),
+  );
+  const getSnapshot =
+    watchDeps?.getSnapshot ??
+    ((options) =>
+      getWatchSnapshot({
+        ...options,
+        providers: parsed.providers,
+        refresh: parsed.refresh,
+        allowKeychainPrompt: parsed.allowKeychainPrompt,
+      }));
+
+  if (parsed.json) {
+    const snapshot = await getSnapshot({
+      providers: parsed.providers,
+      refresh: parsed.refresh,
+      allowKeychainPrompt: parsed.allowKeychainPrompt,
+    });
+    stdout.write(`${JSON.stringify(snapshot, null, 2)}\n`);
+    return;
+  }
+
+  await runWatchLoop(
+    {
+      intervalMs: parsed.intervalSeconds * 1000,
+      snapshot: {
+        providers: parsed.providers,
+        refresh: parsed.refresh,
+        allowKeychainPrompt: parsed.allowKeychainPrompt,
+      },
+      render: {
+        full: parsed.full,
+        color: isTty,
+      },
+      once: parsed.once || !isTty,
+    },
+    {
+      getSnapshot,
+      write: (chunk) => {
+        stdout.write(chunk);
+      },
+      clear:
+        watchDeps?.clear ??
+        (() => {
+          if (isTty) stdout.write("\u001b[H\u001b[2J");
+        }),
+      sleep: watchDeps?.sleep,
+      isTty,
+      shouldContinue: watchDeps?.shouldContinue,
+      onSignal:
+        watchDeps?.onSignal ??
+        ((handler) => {
+          const onSig = () => handler();
+          process.once("SIGINT", onSig);
+          process.once("SIGTERM", onSig);
+          return () => {
+            process.off("SIGINT", onSig);
+            process.off("SIGTERM", onSig);
+          };
+        }),
+    },
+  );
+}
+
+function parseIntervalSeconds(value: string): number {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error("--interval must be a positive number of seconds");
+  }
+  return seconds;
 }
 
 async function fetchQuota(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,11 +26,12 @@ export const TOP_HELP = `usage: quota-axi [auth] [flags]
 commands[2]:
   (none)=quota, auth
 flags[6]:
-  --provider <claude,codex,cursor,copilot,grok>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,agy>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
-  quota-axi --provider cursor,copilot,grok
+  quota-axi --provider agy
+  quota-axi --provider cursor,copilot,grok,agy
   quota-axi --json
   quota-axi --full
   quota-axi auth

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -1,0 +1,842 @@
+import * as http from "node:http";
+import * as https from "node:https";
+import { readCachedProvider } from "../cache.js";
+import { execFileText } from "../lib/process.js";
+import {
+  clampPercent,
+  nowIso,
+  parseEpochOrIso,
+  percentRemaining,
+} from "../lib/time.js";
+import type {
+  AuthProviderReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  ProviderStatus,
+  QuotaWindow,
+  SourceAttempt,
+} from "../types.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+} from "./common.js";
+
+const QUOTA_SUMMARY_PATH =
+  "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary";
+const USER_STATUS_PATH =
+  "/exa.language_server_pb.LanguageServerService/GetUserStatus";
+const COMMAND_MODEL_CONFIGS_PATH =
+  "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs";
+const UNLEASH_PATH =
+  "/exa.language_server_pb.LanguageServerService/GetUnleashData";
+const PROCESS_TIMEOUT_MS = 5_000;
+const PORT_TIMEOUT_MS = 2_000;
+const REQUEST_TIMEOUT_MS = 3_000;
+
+type AgyProcessSource = "agy" | "app";
+
+export type AgyProcessInfo = {
+  pid: number;
+  command: string;
+  source: AgyProcessSource;
+  csrfToken?: string;
+  extensionPort?: number;
+  extensionServerCsrfToken?: string;
+};
+
+export type AgyConnectionEndpoint = {
+  scheme: "https" | "http";
+  port: number;
+  source: AgyProcessSource;
+  pid: number;
+  csrfToken?: string;
+  requiresCsrfToken: boolean;
+  requiresUnleashProbe: boolean;
+};
+
+export type AgyProbeRuntime = {
+  execFileText(
+    command: string,
+    args: string[],
+    timeoutMs: number,
+  ): Promise<string>;
+  requestJson(
+    endpoint: AgyConnectionEndpoint,
+    path: string,
+    timeoutMs: number,
+  ): Promise<unknown>;
+};
+
+export const agyAdapter: ProviderAdapter = {
+  id: "agy",
+  label: "Antigravity",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  return fetchQuotaWithRuntime(defaultRuntime);
+}
+
+export async function fetchQuotaWithRuntime(
+  runtime: AgyProbeRuntime,
+): Promise<ProviderQuota> {
+  const attempts: SourceAttempt[] = [{ source: "loopback", status: "failed" }];
+  let finalError: string;
+
+  try {
+    const quota = await fetchLoopbackQuota(runtime);
+    attempts[0] = { source: "loopback", status: "success" };
+    return successProvider({
+      provider: "agy",
+      label: "Antigravity",
+      source: "cli-rpc",
+      plan: quota.plan,
+      account: quota.account,
+      windows: quota.windows,
+      refreshedAt: quota.refreshedAt,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  } catch (error) {
+    finalError = errorMessage(error);
+    attempts[0] = {
+      source: "loopback",
+      status: error instanceof AgyUnavailableError ? "skipped" : "failed",
+      error: finalError,
+    };
+  }
+
+  const cached = readCachedProvider("agy");
+  if (cached) {
+    return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+  }
+
+  return failedProvider({
+    provider: "agy",
+    label: "Antigravity",
+    status: statusForError(finalError),
+    error: finalError,
+    sourcesTried: sourceNames(attempts),
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const endpoints = await discoverAgyEndpoints(defaultRuntime);
+  return {
+    provider: "agy",
+    sources: [
+      {
+        source: "loopback",
+        status: endpoints.length > 0 ? "available" : "missing",
+      },
+    ],
+  };
+}
+
+export function normalizeAgyQuotaSummary(raw: unknown):
+  | {
+      windows: QuotaWindow[];
+      refreshedAt: string;
+    }
+  | undefined {
+  const payload = quotaSummaryPayload(raw);
+  const groups = arrayValue(payload?.groups);
+  const windows = groups
+    .flatMap(normalizeQuotaSummaryGroup)
+    .sort(compareAgyWindows);
+  if (windows.length === 0) return undefined;
+  return { windows, refreshedAt: nowIso() };
+}
+
+export function normalizeAgyUserStatus(raw: unknown):
+  | {
+      plan?: string;
+      account?: ProviderQuota["account"];
+      windows: QuotaWindow[];
+      refreshedAt: string;
+    }
+  | undefined {
+  const data = objectValue(raw);
+  const status = objectValue(data?.userStatus) ?? data;
+  if (!status) return undefined;
+  const planStatus = objectValue(status.planStatus);
+  const planInfo = objectValue(planStatus?.planInfo);
+  const accountEmail = stringValue(status.email);
+  const userTier = objectValue(status.userTier);
+  const plan = stringValue(userTier?.name) ?? stringValue(planInfo?.planName);
+  const configData =
+    objectValue(status.cascadeModelConfigData) ??
+    objectValue(data?.cascadeModelConfigData) ??
+    data;
+  const windows = normalizeModelConfigWindows(configData);
+  if (windows.length === 0 && !plan && !accountEmail) return undefined;
+  return {
+    plan,
+    account: accountEmail ? { email: accountEmail } : undefined,
+    windows,
+    refreshedAt: nowIso(),
+  };
+}
+
+export function processInfosFromPs(output: string): AgyProcessInfo[] {
+  const processes: AgyProcessInfo[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/^\s*(\d+)\s+(.+)$/);
+    if (!match) continue;
+    const pid = Number(match[1]);
+    const command = match[2].trim();
+    if (!Number.isInteger(pid) || command.length === 0) continue;
+    const source = agyProcessSource(command);
+    if (!source) continue;
+    processes.push({
+      pid,
+      command,
+      source,
+      csrfToken: flagValue(command, "csrf_token"),
+      extensionPort: numberValue(flagValue(command, "extension_server_port")),
+      extensionServerCsrfToken: flagValue(
+        command,
+        "extension_server_csrf_token",
+      ),
+    });
+  }
+  return processes;
+}
+
+export function portsFromLsof(output: string): number[] {
+  const ports = new Set<number>();
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.match(/TCP\s+(?:\[[^\]]+\]|[^:]+):(\d+)\s+\(LISTEN\)/);
+    const port = match ? Number(match[1]) : undefined;
+    if (port && port > 0 && port <= 65535) ports.add(port);
+  }
+  return [...ports];
+}
+
+async function fetchLoopbackQuota(runtime: AgyProbeRuntime): Promise<{
+  plan?: string;
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  refreshedAt: string;
+}> {
+  const endpoints = await discoverAgyEndpoints(runtime);
+  if (endpoints.length === 0)
+    throw new AgyUnavailableError("Antigravity/agy is not running");
+
+  let lastError: unknown;
+  for (const endpoint of endpoints) {
+    try {
+      if (
+        endpoint.requiresUnleashProbe &&
+        !(await probeEndpoint(runtime, endpoint))
+      )
+        continue;
+      return await fetchEndpointQuota(runtime, endpoint);
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Antigravity quota unavailable");
+}
+
+async function discoverAgyEndpoints(
+  runtime: AgyProbeRuntime,
+): Promise<AgyConnectionEndpoint[]> {
+  const processes = processInfosFromPs(await readProcessList(runtime));
+  const endpoints: AgyConnectionEndpoint[] = [];
+  for (const processInfo of processes) {
+    const listeningPorts = await readListeningPorts(runtime, processInfo.pid);
+    if (processInfo.source === "agy") {
+      for (const port of listeningPorts) {
+        endpoints.push(
+          endpointFor(processInfo, "https", port, undefined, false, false),
+          endpointFor(processInfo, "http", port, undefined, false, false),
+        );
+      }
+      continue;
+    }
+
+    if (processInfo.csrfToken) {
+      for (const port of listeningPorts) {
+        endpoints.push(
+          endpointFor(
+            processInfo,
+            "https",
+            port,
+            processInfo.csrfToken,
+            true,
+            true,
+          ),
+          endpointFor(
+            processInfo,
+            "http",
+            port,
+            processInfo.csrfToken,
+            true,
+            true,
+          ),
+        );
+      }
+    }
+
+    if (processInfo.extensionPort) {
+      const token =
+        processInfo.extensionServerCsrfToken ?? processInfo.csrfToken;
+      if (token) {
+        endpoints.push(
+          endpointFor(
+            processInfo,
+            "http",
+            processInfo.extensionPort,
+            token,
+            true,
+            true,
+          ),
+        );
+      }
+    }
+  }
+  return endpoints.sort(compareEndpoints);
+}
+
+function endpointFor(
+  processInfo: AgyProcessInfo,
+  scheme: AgyConnectionEndpoint["scheme"],
+  port: number,
+  csrfToken: string | undefined,
+  requiresCsrfToken: boolean,
+  requiresUnleashProbe: boolean,
+): AgyConnectionEndpoint {
+  return {
+    scheme,
+    port,
+    source: processInfo.source,
+    pid: processInfo.pid,
+    csrfToken,
+    requiresCsrfToken,
+    requiresUnleashProbe,
+  };
+}
+
+async function fetchEndpointQuota(
+  runtime: AgyProbeRuntime,
+  endpoint: AgyConnectionEndpoint,
+): Promise<{
+  plan?: string;
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  refreshedAt: string;
+}> {
+  let summaryError: unknown;
+  try {
+    const summary = normalizeAgyQuotaSummary(
+      await runtime.requestJson(
+        endpoint,
+        QUOTA_SUMMARY_PATH,
+        REQUEST_TIMEOUT_MS,
+      ),
+    );
+    if (summary) {
+      const identity = await fetchEndpointIdentity(runtime, endpoint);
+      return {
+        ...summary,
+        plan: identity?.plan,
+        account: identity?.account,
+      };
+    }
+    summaryError = new AgyMalformedResponseError(
+      "Antigravity quota summary malformed",
+    );
+  } catch (error) {
+    summaryError = error;
+  }
+
+  for (const path of [USER_STATUS_PATH, COMMAND_MODEL_CONFIGS_PATH]) {
+    try {
+      const fallback = normalizeAgyUserStatus(
+        await runtime.requestJson(endpoint, path, REQUEST_TIMEOUT_MS),
+      );
+      if (fallback && fallback.windows.length > 0) return fallback;
+    } catch (error) {
+      summaryError = error;
+    }
+  }
+
+  throw summaryError instanceof Error
+    ? summaryError
+    : new Error("Antigravity quota unavailable");
+}
+
+async function probeEndpoint(
+  runtime: AgyProbeRuntime,
+  endpoint: AgyConnectionEndpoint,
+): Promise<boolean> {
+  try {
+    await runtime.requestJson(endpoint, UNLEASH_PATH, REQUEST_TIMEOUT_MS);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function fetchEndpointIdentity(
+  runtime: AgyProbeRuntime,
+  endpoint: AgyConnectionEndpoint,
+): Promise<
+  | {
+      plan?: string;
+      account?: ProviderQuota["account"];
+    }
+  | undefined
+> {
+  try {
+    return normalizeAgyUserStatus(
+      await runtime.requestJson(endpoint, USER_STATUS_PATH, REQUEST_TIMEOUT_MS),
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function readProcessList(runtime: AgyProbeRuntime): Promise<string> {
+  if (process.platform === "win32") return "";
+  try {
+    return await runtime.execFileText(
+      "ps",
+      ["-axo", "pid=,command="],
+      PROCESS_TIMEOUT_MS,
+    );
+  } catch {
+    return "";
+  }
+}
+
+async function readListeningPorts(
+  runtime: AgyProbeRuntime,
+  pid: number,
+): Promise<number[]> {
+  if (process.platform === "win32") return [];
+  try {
+    return portsFromLsof(
+      await runtime.execFileText(
+        "lsof",
+        ["-nP", "-a", "-p", String(pid), "-iTCP", "-sTCP:LISTEN"],
+        PORT_TIMEOUT_MS,
+      ),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function normalizeQuotaSummaryGroup(raw: unknown): QuotaWindow[] {
+  const group = objectValue(raw);
+  if (!group) return [];
+  const groupName = stringValue(group.displayName) ?? "Quota";
+  return arrayValue(group.buckets)
+    .map((bucket) => normalizeQuotaSummaryBucket(groupName, bucket))
+    .filter((window): window is QuotaWindow => Boolean(window));
+}
+
+function normalizeQuotaSummaryBucket(
+  groupName: string,
+  raw: unknown,
+): QuotaWindow | undefined {
+  const bucket = objectValue(raw);
+  if (!bucket) return undefined;
+  const disabled = booleanValue(bucket.disabled) ?? false;
+  if (disabled) return undefined;
+  const bucketId =
+    stringValue(bucket.bucketId) ?? stringValue(bucket.bucket_id);
+  if (!bucketId) return undefined;
+  const windowKind = agyWindowKind(bucket);
+  const group = agyWindowGroup(groupName, bucketId);
+  const label = `${group.label} ${windowKind.label}`;
+  const result: QuotaWindow = {
+    id: `${group.id}_${windowKind.id}`,
+    label,
+    kind: windowKind.kind,
+    resetsAt:
+      parseEpochOrIso(bucket.resetTime) ?? parseEpochOrIso(bucket.reset_time),
+    resetText: stringValue(bucket.description),
+    windowSeconds: windowKind.windowSeconds,
+  };
+  const remaining = remainingFraction(bucket);
+  if (remaining !== undefined) {
+    const percentUsed = clampPercent((1 - clampFraction(remaining)) * 100);
+    result.percentUsed = percentUsed;
+    result.percentRemaining = percentRemaining(percentUsed);
+  }
+  if (result.percentUsed === undefined && !result.resetsAt && !result.resetText)
+    return undefined;
+  return result;
+}
+
+function normalizeModelConfigWindows(raw: unknown): QuotaWindow[] {
+  const data = objectValue(raw);
+  const configs = arrayValue(data?.clientModelConfigs);
+  return configs
+    .map(normalizeModelConfigWindow)
+    .filter((window): window is QuotaWindow => Boolean(window));
+}
+
+function normalizeModelConfigWindow(raw: unknown): QuotaWindow | undefined {
+  const config = objectValue(raw);
+  if (!config) return undefined;
+  const label = stringValue(config.label);
+  const quotaInfo = objectValue(config.quotaInfo);
+  const modelOrAlias = objectValue(config.modelOrAlias);
+  const modelId =
+    stringValue(modelOrAlias?.model) ??
+    stringValue(modelOrAlias?.alias) ??
+    (label ? slugify(label) : undefined);
+  if (!label || !modelId || !quotaInfo) return undefined;
+  const remaining = remainingFraction(quotaInfo);
+  const result: QuotaWindow = {
+    id: `model:${slugify(modelId)}`,
+    label,
+    kind: "model",
+    resetsAt:
+      parseEpochOrIso(quotaInfo.resetTime) ??
+      parseEpochOrIso(quotaInfo.reset_time),
+  };
+  if (remaining !== undefined) {
+    const percentUsed = clampPercent((1 - clampFraction(remaining)) * 100);
+    result.percentUsed = percentUsed;
+    result.percentRemaining = percentRemaining(percentUsed);
+  }
+  return result.percentUsed === undefined && !result.resetsAt
+    ? undefined
+    : result;
+}
+
+function quotaSummaryPayload(
+  raw: unknown,
+): Record<string, unknown> | undefined {
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  return (
+    objectValue(data.response) ??
+    objectValue(data.summary) ??
+    (Array.isArray(data.groups) ? data : undefined)
+  );
+}
+
+function agyWindowGroup(
+  groupName: string,
+  bucketId: string,
+): { id: string; label: string; sortRank: number } {
+  const normalized = `${groupName} ${bucketId}`.toLowerCase();
+  if (normalized.includes("gemini")) {
+    return { id: "gemini", label: "Gemini", sortRank: 0 };
+  }
+  if (
+    normalized.includes("claude") ||
+    normalized.includes("gpt") ||
+    normalized.includes("3p")
+  ) {
+    return { id: "claude_gpt", label: "Claude/GPT", sortRank: 1 };
+  }
+  const id = slugify(groupName) || "quota";
+  return { id, label: groupName, sortRank: 2 };
+}
+
+function agyWindowKind(bucket: Record<string, unknown>): {
+  id: "5h" | "weekly" | "unknown";
+  label: "5-hour" | "weekly" | "quota";
+  kind: QuotaWindow["kind"];
+  windowSeconds?: number;
+  sortRank: number;
+} {
+  const raw = [
+    stringValue(bucket.window),
+    stringValue(bucket.bucketId),
+    stringValue(bucket.bucket_id),
+    stringValue(bucket.displayName),
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+  if (raw.includes("5h") || raw.includes("five")) {
+    return {
+      id: "5h",
+      label: "5-hour",
+      kind: "session",
+      windowSeconds: 5 * 60 * 60,
+      sortRank: 0,
+    };
+  }
+  if (raw.includes("week")) {
+    return {
+      id: "weekly",
+      label: "weekly",
+      kind: "weekly",
+      windowSeconds: 7 * 24 * 60 * 60,
+      sortRank: 1,
+    };
+  }
+  return { id: "unknown", label: "quota", kind: "unknown", sortRank: 2 };
+}
+
+function remainingFraction(data: Record<string, unknown>): number | undefined {
+  return (
+    numberValue(data.remainingFraction) ??
+    numberValue(data.remaining_fraction) ??
+    oneofRemainingFraction(data.remaining)
+  );
+}
+
+function oneofRemainingFraction(raw: unknown): number | undefined {
+  const direct = numberValue(raw);
+  if (direct !== undefined) return direct;
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  return (
+    numberValue(data.remainingFraction) ??
+    numberValue(data.remaining_fraction) ??
+    (stringValue(data.case) === "remainingFraction" ||
+    stringValue(data.case) === "remaining_fraction"
+      ? numberValue(data.value)
+      : undefined)
+  );
+}
+
+function compareAgyWindows(left: QuotaWindow, right: QuotaWindow): number {
+  const leftGroup = windowGroupRank(left.id);
+  const rightGroup = windowGroupRank(right.id);
+  if (leftGroup !== rightGroup) return leftGroup - rightGroup;
+  return windowKindRank(left) - windowKindRank(right);
+}
+
+function windowGroupRank(id: string): number {
+  if (id.startsWith("gemini_")) return 0;
+  if (id.startsWith("claude_gpt_")) return 1;
+  return 2;
+}
+
+function windowKindRank(window: QuotaWindow): number {
+  if (window.kind === "session") return 0;
+  if (window.kind === "weekly") return 1;
+  return 2;
+}
+
+function agyProcessSource(command: string): AgyProcessSource | undefined {
+  const executable = executableName(command);
+  if (executable === "agy") return "agy";
+  const lowered = command.toLowerCase();
+  if (lowered.includes("antigravity-cli") && lowered.includes("mcp-server.cjs"))
+    return "agy";
+  if (
+    /language[-_]server(?:_[a-z0-9_]+)?/i.test(command) &&
+    lowered.includes("antigravity")
+  )
+    return "app";
+  return undefined;
+}
+
+function executableName(command: string): string | undefined {
+  const token = command.trim().split(/\s+/, 1)[0];
+  if (!token) return undefined;
+  const name = token.replace(/\\/g, "/").split("/").pop()?.toLowerCase();
+  return name?.replace(/\.exe$/, "");
+}
+
+function flagValue(command: string, name: string): string | undefined {
+  const pattern = new RegExp(`(?:^|\\s)--${name}(?:=([^\\s]+)|\\s+([^\\s]+))`);
+  const match = command.match(pattern);
+  return match?.[1] ?? match?.[2];
+}
+
+function portsFromEndpoint(endpoint: AgyConnectionEndpoint): number {
+  return endpoint.port;
+}
+
+function compareEndpoints(
+  left: AgyConnectionEndpoint,
+  right: AgyConnectionEndpoint,
+): number {
+  const sourceRank = sourceSortRank(left.source) - sourceSortRank(right.source);
+  if (sourceRank !== 0) return sourceRank;
+  const portRank = portsFromEndpoint(left) - portsFromEndpoint(right);
+  if (portRank !== 0) return portRank;
+  return schemeSortRank(left.scheme) - schemeSortRank(right.scheme);
+}
+
+function sourceSortRank(source: AgyProcessSource): number {
+  return source === "agy" ? 0 : 1;
+}
+
+function schemeSortRank(scheme: AgyConnectionEndpoint["scheme"]): number {
+  return scheme === "https" ? 0 : 1;
+}
+
+function statusForError(error: string): ProviderStatus {
+  if (
+    /not running|no local|loopback timed out|ECONNREFUSED|ECONNRESET|ECONNABORTED|ENOTFOUND|EHOSTUNREACH|ETIMEDOUT|EPIPE|EPROTO|socket hang up/i.test(
+      error,
+    )
+  )
+    return "unavailable";
+  return statusFromError(error);
+}
+
+function requestLoopbackJson(
+  endpoint: AgyConnectionEndpoint,
+  path: string,
+  timeoutMs: number,
+): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify(requestBodyForPath(path));
+    const headers: Record<string, string | number> = {
+      accept: "application/json",
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(body),
+      "connect-protocol-version": "1",
+    };
+    if (endpoint.requiresCsrfToken && endpoint.csrfToken) {
+      headers["x-codeium-csrf-token"] = endpoint.csrfToken;
+    }
+    const options: http.RequestOptions & https.RequestOptions = {
+      hostname: "127.0.0.1",
+      port: endpoint.port,
+      path,
+      method: "POST",
+      headers,
+    };
+    if (endpoint.scheme === "https") options.rejectUnauthorized = false;
+    const client = endpoint.scheme === "https" ? https : http;
+    const request = client.request(options, (response) => {
+      const chunks: Uint8Array[] = [];
+      response.on("data", (chunk: Buffer | string) => {
+        const bytes = typeof chunk === "string" ? Buffer.from(chunk) : chunk;
+        chunks.push(new Uint8Array(bytes));
+      });
+      response.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        if (!response.statusCode || response.statusCode < 200) {
+          reject(new AgyHttpError(response.statusCode ?? 0, text));
+          return;
+        }
+        if (response.statusCode >= 300) {
+          reject(new AgyHttpError(response.statusCode, text));
+          return;
+        }
+        try {
+          resolve(JSON.parse(text) as unknown);
+        } catch {
+          reject(
+            new AgyMalformedResponseError(
+              "Antigravity loopback returned invalid JSON",
+            ),
+          );
+        }
+      });
+    });
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(
+        new AgyUnavailableError("Antigravity loopback timed out"),
+      );
+    });
+    request.on("error", (error) => reject(error));
+    request.end(body);
+  });
+}
+
+function requestBodyForPath(path: string): Record<string, unknown> {
+  if (path === QUOTA_SUMMARY_PATH) return { forceRefresh: true };
+  return {
+    metadata: {
+      ideName: "antigravity",
+      extensionName: "antigravity",
+      ideVersion: "unknown",
+      locale: "en",
+    },
+  };
+}
+
+function clampFraction(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "Antigravity quota unavailable";
+}
+
+class AgyUnavailableError extends Error {}
+
+class AgyMalformedResponseError extends Error {}
+
+class AgyHttpError extends Error {
+  constructor(
+    readonly status: number,
+    body: string,
+  ) {
+    super(`Antigravity quota unavailable (${status})${errorSuffix(body)}`);
+  }
+}
+
+function errorSuffix(body: string): string {
+  if (!body.trim()) return "";
+  try {
+    const data = JSON.parse(body) as Record<string, unknown>;
+    const message = stringValue(data.message) ?? stringValue(data.error);
+    return message ? `: ${message}` : "";
+  } catch {
+    return "";
+  }
+}
+
+const defaultRuntime: AgyProbeRuntime = {
+  execFileText,
+  requestJson: requestLoopbackJson,
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+import { agyAdapter } from "./agy.js";
 import { claudeAdapter } from "./claude.js";
 import { codexAdapter } from "./codex.js";
 import { copilotAdapter } from "./copilot.js";
@@ -15,6 +16,7 @@ export const PROVIDERS: Record<ProviderId, ProviderAdapter> = {
   cursor: cursorAdapter,
   copilot: copilotAdapter,
   grok: grokAdapter,
+  agy: agyAdapter,
 };
 
 export function parseProviders(value: string | undefined): ProviderId[] {

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,7 +3,7 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
-  "Report local Claude, Codex, Cursor, GitHub Copilot, and Grok quota windows via the quota-axi CLI - remaining " +
+  "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Antigravity quota windows via the quota-axi CLI - remaining " +
   "percentages, reset times, and provider status read from local auth sources, with no " +
   "routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, or " +
@@ -22,12 +22,18 @@ export const HERMES_TAGS = [
   "cursor",
   "copilot",
   "grok",
+  "agy",
+  "antigravity",
   "cli",
 ];
 export const HERMES_CATEGORY = "observability";
 
 function yamlDoubleQuote(value: string): string {
   return JSON.stringify(value);
+}
+
+function yamlStringList(values: string[], indent: string): string {
+  return values.map((value) => `${indent}- ${value}`).join("\n");
 }
 
 /**
@@ -46,7 +52,8 @@ user-invocable: false
 author: ${SKILL_AUTHOR}
 metadata:
   hermes:
-    tags: [${HERMES_TAGS.join(", ")}]
+    tags:
+${yamlStringList(HERMES_TAGS, "      ")}
     category: ${HERMES_CATEGORY}
 ---
 
@@ -58,8 +65,8 @@ You do not need quota-axi installed globally - invoke it with \`npx -y quota-axi
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
 browser cookies, or mutates provider state. It reads local provider auth sources and calls
-first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
-Claude CLI, so it cannot spend the quota it measures.
+first-party provider quota, usage, billing, entitlement, or local loopback endpoints; it never
+launches the Claude CLI or Antigravity/agy, so it cannot spend the quota it measures.
 
 ## When to use
 
@@ -70,7 +77,7 @@ or when comparing supported local provider headroom side by side.
 ## Workflow
 
 1. Run \`npx -y quota-axi\` for compact TOON output covering supported providers' quota windows.
-2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok\`.
+2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok,agy\`.
 3. Pass \`--json\` for the normalized machine-readable model instead of TOON.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,0 +1,336 @@
+import { readCachedProvider, writeCachedProviders } from "./cache.js";
+import { nowIso } from "./lib/time.js";
+import { PROVIDERS, parseProviders } from "./providers/index.js";
+import type {
+  ProviderId,
+  ProviderOptions,
+  ProviderQuota,
+  ProviderSource,
+  ProviderStateReason,
+  ProviderStatus,
+  QuotaWindow,
+} from "./types.js";
+import { PROVIDER_IDS } from "./types.js";
+
+export const WATCH_SNAPSHOT_SCHEMA_VERSION = 1 as const;
+
+export type SnapshotTrust = "fresh" | "cached" | "stale" | "unavailable";
+export type SnapshotLevel = "ok" | "warn" | "critical";
+
+export type BurnRate =
+  | { available: true; percentPerHour: number }
+  | {
+      available: false;
+      reason: "unavailable" | "insufficient_data";
+    };
+
+export type SnapshotWindow = {
+  id: string;
+  label: string;
+  kind: QuotaWindow["kind"];
+  percentRemaining?: number;
+  percentUsed?: number;
+  resetsAt?: string;
+  resetInSeconds: number | null;
+  resetText?: string;
+  burnRate: BurnRate;
+  level: SnapshotLevel;
+};
+
+export type ProviderSnapshot = {
+  provider: ProviderId;
+  label: string;
+  trust: SnapshotTrust;
+  status: ProviderStatus;
+  source: ProviderSource;
+  refreshedAt?: string;
+  plan?: string;
+  windows: SnapshotWindow[];
+  primary?: SnapshotWindow;
+  error?: string;
+  reason?: ProviderStateReason;
+  remedyCommand?: string;
+};
+
+export type WatchSnapshot = {
+  generatedAt: string;
+  schemaVersion: typeof WATCH_SNAPSHOT_SCHEMA_VERSION;
+  mode: "cache" | "refresh";
+  providers: ProviderSnapshot[];
+};
+
+export type WatchSnapshotOptions = {
+  providers?: ProviderId[] | string;
+  /** Default false: cache/last-known only (untaxed agent path). */
+  refresh?: boolean;
+  allowKeychainPrompt?: boolean;
+  now?: Date;
+};
+
+export type WatchSnapshotDeps = {
+  readCached?: (provider: ProviderId) => ProviderQuota | undefined;
+  fetchProvider?: (
+    provider: ProviderId,
+    options: ProviderOptions,
+  ) => Promise<ProviderQuota>;
+  writeCache?: (providers: ProviderQuota[]) => void;
+  nowIso?: () => string;
+};
+
+const WARN_REMAINING = 25;
+const CRITICAL_REMAINING = 10;
+
+/**
+ * Aggregate provider quota into a render-ready watch snapshot.
+ * Default path is cache-only so agent reads stay untaxed.
+ */
+export async function getWatchSnapshot(
+  options: WatchSnapshotOptions = {},
+  deps: WatchSnapshotDeps = {},
+): Promise<WatchSnapshot> {
+  const providers = resolveProviders(options.providers);
+  const refresh = options.refresh === true;
+  const now = options.now ?? new Date();
+  const generatedAt = deps.nowIso?.() ?? nowIso();
+  const readCached = deps.readCached ?? readCachedProvider;
+  const fetchProvider =
+    deps.fetchProvider ??
+    ((provider: ProviderId, providerOptions: ProviderOptions) =>
+      PROVIDERS[provider].fetchQuota(providerOptions));
+  const writeCache = deps.writeCache ?? writeCachedProvidersBestEffort;
+
+  if (!refresh) {
+    const cached = providers.map(
+      (provider) => readCached(provider) ?? missingCachedProvider(provider),
+    );
+    return buildWatchSnapshot(cached, {
+      mode: "cache",
+      now,
+      generatedAt,
+    });
+  }
+
+  const providerOptions: ProviderOptions = {
+    allowKeychainPrompt: options.allowKeychainPrompt === true,
+  };
+  const live = await Promise.all(
+    providers.map((provider) => fetchProvider(provider, providerOptions)),
+  );
+  writeCache(live);
+  return buildWatchSnapshot(live, {
+    mode: "refresh",
+    now,
+    generatedAt,
+  });
+}
+
+export type BuildWatchSnapshotOptions = {
+  mode?: "cache" | "refresh";
+  now?: Date;
+  generatedAt?: string;
+};
+
+/** Pure mapper from ProviderQuota[] to WatchSnapshot. */
+export function buildWatchSnapshot(
+  providers: ProviderQuota[],
+  options: BuildWatchSnapshotOptions = {},
+): WatchSnapshot {
+  const mode = options.mode ?? "cache";
+  const now = options.now ?? new Date();
+  const generatedAt = options.generatedAt ?? nowIso();
+  return {
+    generatedAt,
+    schemaVersion: WATCH_SNAPSHOT_SCHEMA_VERSION,
+    mode,
+    providers: providers.map((provider) =>
+      toProviderSnapshot(provider, mode, now),
+    ),
+  };
+}
+
+function toProviderSnapshot(
+  provider: ProviderQuota,
+  mode: "cache" | "refresh",
+  now: Date,
+): ProviderSnapshot {
+  const windows = provider.windows.map((window) =>
+    toSnapshotWindow(window, now),
+  );
+  const primary = selectPrimaryWindow(windows);
+  const snapshot: ProviderSnapshot = {
+    provider: provider.provider,
+    label: provider.label,
+    trust: trustFor(provider, mode),
+    status: provider.state.status,
+    source: provider.source,
+    windows,
+  };
+  if (provider.state.refreshedAt)
+    snapshot.refreshedAt = provider.state.refreshedAt;
+  if (provider.plan) snapshot.plan = provider.plan;
+  if (primary) snapshot.primary = primary;
+  if (provider.state.error) snapshot.error = provider.state.error;
+  if (provider.state.reason) snapshot.reason = provider.state.reason;
+  if (provider.state.remedyCommand)
+    snapshot.remedyCommand = provider.state.remedyCommand;
+  return snapshot;
+}
+
+export function toSnapshotWindow(
+  window: QuotaWindow,
+  now: Date = new Date(),
+): SnapshotWindow {
+  const resetInSeconds = computeResetInSeconds(window.resetsAt, now);
+  const burnRate = deriveBurnRate(window, now, resetInSeconds);
+  const snapshot: SnapshotWindow = {
+    id: window.id,
+    label: window.label,
+    kind: window.kind,
+    resetInSeconds,
+    burnRate,
+    level: levelForRemaining(window.percentRemaining),
+  };
+  if (window.percentRemaining !== undefined)
+    snapshot.percentRemaining = window.percentRemaining;
+  if (window.percentUsed !== undefined)
+    snapshot.percentUsed = window.percentUsed;
+  if (window.resetsAt) snapshot.resetsAt = window.resetsAt;
+  if (window.resetText) snapshot.resetText = window.resetText;
+  return snapshot;
+}
+
+export function deriveBurnRate(
+  window: QuotaWindow,
+  now: Date = new Date(),
+  resetInSeconds: number | null = computeResetInSeconds(window.resetsAt, now),
+): BurnRate {
+  if (
+    window.percentUsed === undefined ||
+    window.windowSeconds === undefined ||
+    window.windowSeconds <= 0 ||
+    resetInSeconds === null
+  ) {
+    return { available: false, reason: "insufficient_data" };
+  }
+  const elapsedSeconds = window.windowSeconds - resetInSeconds;
+  if (elapsedSeconds <= 0) {
+    return { available: false, reason: "insufficient_data" };
+  }
+  const percentPerHour = (window.percentUsed / elapsedSeconds) * 3600;
+  if (!Number.isFinite(percentPerHour) || percentPerHour < 0) {
+    return { available: false, reason: "unavailable" };
+  }
+  return {
+    available: true,
+    percentPerHour: roundBurn(percentPerHour),
+  };
+}
+
+export function levelForRemaining(
+  percentRemaining: number | undefined,
+): SnapshotLevel {
+  if (percentRemaining === undefined) return "ok";
+  if (percentRemaining <= CRITICAL_REMAINING) return "critical";
+  if (percentRemaining <= WARN_REMAINING) return "warn";
+  return "ok";
+}
+
+export function selectPrimaryWindow(
+  windows: SnapshotWindow[],
+): SnapshotWindow | undefined {
+  if (windows.length === 0) return undefined;
+  const session = windows.filter((window) => window.kind === "session");
+  const pool = session.length > 0 ? session : windows;
+  return [...pool].sort(compareUrgency)[0];
+}
+
+function compareUrgency(left: SnapshotWindow, right: SnapshotWindow): number {
+  const leftRemaining = left.percentRemaining ?? Number.POSITIVE_INFINITY;
+  const rightRemaining = right.percentRemaining ?? Number.POSITIVE_INFINITY;
+  if (leftRemaining !== rightRemaining) return leftRemaining - rightRemaining;
+  const leftReset = left.resetInSeconds ?? Number.POSITIVE_INFINITY;
+  const rightReset = right.resetInSeconds ?? Number.POSITIVE_INFINITY;
+  return leftReset - rightReset;
+}
+
+function trustFor(
+  provider: ProviderQuota,
+  mode: "cache" | "refresh",
+): SnapshotTrust {
+  const status = provider.state.status;
+  if (
+    status === "unavailable" ||
+    status === "auth_required" ||
+    status === "error" ||
+    status === "rate_limited"
+  ) {
+    return "unavailable";
+  }
+  if (status === "stale" || provider.state.stale) return "stale";
+  if (mode === "cache" || provider.source === "cache") return "cached";
+  if (status === "fresh") return "fresh";
+  return "unavailable";
+}
+
+function computeResetInSeconds(
+  resetsAt: string | undefined,
+  now: Date,
+): number | null {
+  if (!resetsAt) return null;
+  const resetMs = Date.parse(resetsAt);
+  if (Number.isNaN(resetMs)) return null;
+  const seconds = Math.floor((resetMs - now.getTime()) / 1000);
+  return seconds > 0 ? seconds : null;
+}
+
+function roundBurn(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function resolveProviders(
+  value: WatchSnapshotOptions["providers"],
+): ProviderId[] {
+  if (value === undefined) return [...PROVIDER_IDS];
+  if (typeof value === "string") return parseProviders(value);
+  return value;
+}
+
+function missingCachedProvider(provider: ProviderId): ProviderQuota {
+  return {
+    provider,
+    label: defaultLabel(provider),
+    source: "unavailable",
+    windows: [],
+    state: {
+      status: "unavailable",
+      stale: false,
+      error: "cache_miss",
+      sourcesTried: ["cache"],
+    },
+  };
+}
+
+function defaultLabel(provider: ProviderId): string {
+  switch (provider) {
+    case "claude":
+      return "Claude";
+    case "codex":
+      return "Codex";
+    case "cursor":
+      return "Cursor";
+    case "copilot":
+      return "GitHub Copilot";
+    case "grok":
+      return "Grok";
+    case "agy":
+      return "Antigravity";
+  }
+}
+
+function writeCachedProvidersBestEffort(providers: ProviderQuota[]): void {
+  try {
+    writeCachedProviders(providers);
+  } catch {
+    return;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,10 @@
-export type ProviderId = "claude" | "codex" | "cursor" | "copilot" | "grok";
+export type ProviderId =
+  | "claude"
+  | "codex"
+  | "cursor"
+  | "copilot"
+  | "grok"
+  | "agy";
 
 export const PROVIDER_IDS = [
   "claude",
@@ -6,6 +12,7 @@ export const PROVIDER_IDS = [
   "cursor",
   "copilot",
   "grok",
+  "agy",
 ] as const satisfies readonly ProviderId[];
 
 export type ProviderSource =

--- a/src/watch-render.ts
+++ b/src/watch-render.ts
@@ -1,0 +1,214 @@
+import type {
+  BurnRate,
+  ProviderSnapshot,
+  SnapshotLevel,
+  SnapshotWindow,
+  WatchSnapshot,
+} from "./snapshot.js";
+
+export type WatchRenderOptions = {
+  /** When true, allow USD/credit figures if present on the snapshot. */
+  full?: boolean;
+  /** Emit ANSI color for warn/critical when true. */
+  color?: boolean;
+  /** Fixed clock for countdown formatting in tests. */
+  now?: Date;
+};
+
+const ANSI = {
+  reset: "\u001b[0m",
+  dim: "\u001b[2m",
+  red: "\u001b[31m",
+  yellow: "\u001b[33m",
+  green: "\u001b[32m",
+  bold: "\u001b[1m",
+} as const;
+
+/**
+ * Pure presentation layer for `quota-axi watch`.
+ * Renders remaining %, reset countdown, burn rate, and trust/staleness.
+ * No USD figures unless options.full is set (captain Q5: level + burn + reset, no USD).
+ * Never performs I/O.
+ */
+export function renderWatchPane(
+  snapshot: WatchSnapshot,
+  options: WatchRenderOptions = {},
+): string {
+  const color = Boolean(options.color);
+  const full = Boolean(options.full);
+  const lines: string[] = [];
+
+  lines.push(
+    paint(
+      color,
+      "bold",
+      `quota-axi watch  ${snapshot.generatedAt}  mode=${snapshot.mode}`,
+    ),
+  );
+  lines.push(paint(color, "dim", "─".repeat(72)));
+
+  if (snapshot.providers.length === 0) {
+    lines.push("  (no providers)");
+    return lines.join("\n");
+  }
+
+  for (const provider of snapshot.providers) {
+    lines.push(...renderProvider(provider, { color }));
+  }
+
+  const hot = snapshot.providers.flatMap((provider) =>
+    provider.windows
+      .filter(
+        (window) => window.level === "warn" || window.level === "critical",
+      )
+      .map((window) => ({ provider: provider.provider, window })),
+  );
+  if (hot.length > 0) {
+    lines.push(paint(color, "dim", "─".repeat(72)));
+    lines.push(paint(color, "bold", "RED LINE"));
+    for (const item of hot) {
+      const tag = levelTag(item.window.level, color);
+      const remaining =
+        item.window.percentRemaining === undefined
+          ? "?"
+          : `${item.window.percentRemaining}%`;
+      lines.push(
+        `  ${tag} ${item.provider}/${item.window.id} remaining ${remaining}`,
+      );
+    }
+  }
+
+  const pane = lines.join("\n");
+  // Q5: no USD outside --full. Snapshot has no USD fields; still scrub $ markers.
+  return full ? pane : scrubUsd(pane);
+}
+
+function renderProvider(
+  provider: ProviderSnapshot,
+  options: { color: boolean },
+): string[] {
+  const { color } = options;
+  const lines: string[] = [];
+  const trust = paintTrust(provider.trust, color);
+  const plan = provider.plan ? `  plan=${provider.plan}` : "";
+  lines.push(
+    `${paint(color, "bold", provider.label)}  [${provider.provider}]  ${trust}  ${provider.status}${plan}`,
+  );
+
+  if (provider.error) {
+    lines.push(paint(color, "dim", `  error: ${provider.error}`));
+  }
+  if (provider.reason && provider.remedyCommand) {
+    lines.push(
+      paint(
+        color,
+        "dim",
+        `  remedy: ${provider.remedyCommand} (${provider.reason})`,
+      ),
+    );
+  }
+  if (provider.refreshedAt) {
+    lines.push(paint(color, "dim", `  refreshed: ${provider.refreshedAt}`));
+  }
+
+  if (provider.windows.length === 0) {
+    lines.push(paint(color, "dim", "  (no windows)"));
+    lines.push("");
+    return lines;
+  }
+
+  const primaryId = provider.primary?.id;
+  for (const window of provider.windows) {
+    const isPrimary = primaryId !== undefined && window.id === primaryId;
+    lines.push(renderWindowLine(window, { color, isPrimary }));
+  }
+  lines.push("");
+  return lines;
+}
+
+function renderWindowLine(
+  window: SnapshotWindow,
+  options: { color: boolean; isPrimary: boolean },
+): string {
+  const { color, isPrimary } = options;
+  const tag = levelTag(window.level, color);
+  const mark = isPrimary ? "*" : " ";
+  const remaining =
+    window.percentRemaining === undefined
+      ? "  ?%"
+      : `${String(window.percentRemaining).padStart(3)}%`;
+  const reset = formatReset(window);
+  const burn = formatBurn(window.burnRate);
+  const label = window.label.padEnd(18).slice(0, 18);
+  return `${mark}${tag} ${label}  rem ${remaining}  reset ${reset}  burn ${burn}`;
+}
+
+function scrubUsd(text: string): string {
+  return text.replace(/\$[\d,.]+/g, "[hidden]").replace(/\bUSD\b/gi, "");
+}
+
+function formatReset(window: SnapshotWindow): string {
+  if (window.resetInSeconds === null || window.resetInSeconds === undefined) {
+    return window.resetText?.trim() || "unknown";
+  }
+  if (window.resetInSeconds <= 0) return "now";
+  return formatDuration(window.resetInSeconds);
+}
+
+function formatBurn(burn: BurnRate): string {
+  if (!burn.available) {
+    return burn.reason === "insufficient_data" ? "n/a" : "—";
+  }
+  const value = burn.percentPerHour;
+  if (!Number.isFinite(value)) return "n/a";
+  const rounded = Math.abs(value) >= 10 ? value.toFixed(1) : value.toFixed(2);
+  return `${rounded}%/h`;
+}
+
+function formatDuration(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  if (days > 0) return `${days}d${hours}h`;
+  if (hours > 0) return `${hours}h${String(minutes).padStart(2, "0")}m`;
+  if (minutes > 0) return `${minutes}m${String(secs).padStart(2, "0")}s`;
+  return `${secs}s`;
+}
+
+function levelTag(level: SnapshotLevel, color: boolean): string {
+  switch (level) {
+    case "critical":
+      return paint(color, "red", "CRIT");
+    case "warn":
+      return paint(color, "yellow", "WARN");
+    default:
+      return paint(color, "green", " ok ");
+  }
+}
+
+function paintTrust(trust: ProviderSnapshot["trust"], color: boolean): string {
+  switch (trust) {
+    case "fresh":
+      return paint(color, "green", "fresh");
+    case "cached":
+      return paint(color, "dim", "cached");
+    case "stale":
+      return paint(color, "yellow", "stale");
+    case "unavailable":
+      return paint(color, "red", "unavailable");
+    default:
+      return trust;
+  }
+}
+
+function paint(color: boolean, style: keyof typeof ANSI, text: string): string {
+  if (!color || style === "reset") return text;
+  return `${ANSI[style]}${text}${ANSI.reset}`;
+}
+
+/** Exported for tests: red-line threshold labels only (levels come from data seat). */
+export function isRedLine(level: SnapshotLevel): boolean {
+  return level === "warn" || level === "critical";
+}

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -1,0 +1,75 @@
+import type { WatchSnapshot, WatchSnapshotOptions } from "./snapshot.js";
+import { renderWatchPane, type WatchRenderOptions } from "./watch-render.js";
+
+export type WatchLoopDeps = {
+  getSnapshot: (options: WatchSnapshotOptions) => Promise<WatchSnapshot>;
+  write: (chunk: string) => void;
+  clear?: () => void;
+  sleep?: (ms: number) => Promise<void>;
+  isTty?: boolean;
+  shouldContinue?: () => boolean;
+  onSignal?: (handler: () => void) => () => void;
+};
+
+export type WatchLoopOptions = {
+  intervalMs: number;
+  snapshot: WatchSnapshotOptions;
+  render: WatchRenderOptions;
+  /** When true, paint once and exit (test / smoke). */
+  once?: boolean;
+};
+
+/**
+ * Live watch loop: fetch snapshot, repaint pane, sleep, repeat.
+ * All I/O is injected so tests never touch providers.
+ */
+export async function runWatchLoop(
+  options: WatchLoopOptions,
+  deps: WatchLoopDeps,
+): Promise<void> {
+  const sleep = deps.sleep ?? defaultSleep;
+  const isTty = deps.isTty ?? false;
+  const shouldContinue = deps.shouldContinue ?? (() => true);
+  let stopped = false;
+
+  const stop = () => {
+    stopped = true;
+  };
+  const detach = deps.onSignal?.(stop);
+
+  try {
+    do {
+      const snapshot = await deps.getSnapshot(options.snapshot);
+      const pane = renderWatchPane(snapshot, {
+        ...options.render,
+        color: options.render.color ?? isTty,
+      });
+      if (deps.clear && isTty) deps.clear();
+      deps.write(`${pane}\n`);
+      if (options.once || stopped || !shouldContinue()) break;
+      await sleep(options.intervalMs);
+    } while (!stopped && shouldContinue());
+  } finally {
+    detach?.();
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export type WatchCliFlags = {
+  intervalSeconds: number;
+  providers?: string;
+  refresh: boolean;
+  full: boolean;
+  json: boolean;
+  allowKeychainPrompt: boolean;
+  once: boolean;
+};
+
+export function defaultWatchIntervalSeconds(): number {
+  return 30;
+}

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -115,5 +115,6 @@ function providerLabel(provider: ProviderId): string {
   if (provider === "codex") return "Codex";
   if (provider === "cursor") return "Cursor";
   if (provider === "copilot") return "GitHub Copilot";
+  if (provider === "agy") return "Antigravity";
   return "Grok";
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -68,6 +68,119 @@ describe("CLI argument parsing", () => {
       "unsupported provider",
     );
   });
+
+  it("parses watch command flags", () => {
+    expect(
+      parseArgs([
+        "watch",
+        "--interval",
+        "15",
+        "--provider",
+        "codex,grok",
+        "--once",
+      ]),
+    ).toMatchObject({
+      command: "watch",
+      providers: ["codex", "grok"],
+      intervalSeconds: 15,
+      once: true,
+      refresh: false,
+      full: false,
+    });
+    expect(parseArgs(["watch", "--refresh", "--json"])).toMatchObject({
+      command: "watch",
+      refresh: true,
+      json: true,
+    });
+  });
+
+  it("rejects invalid watch intervals", () => {
+    expect(() => parseArgs(["watch", "--interval", "0"])).toThrow(
+      "positive number",
+    );
+  });
+});
+
+describe("CLI watch rendering", () => {
+  it("renders once from injectable snapshot without provider fetches", async () => {
+    useTempCache();
+    let providerFetches = 0;
+    PROVIDERS.codex = {
+      id: "codex",
+      label: "Codex",
+      async fetchQuota() {
+        providerFetches += 1;
+        throw new Error("provider must not be called on default watch");
+      },
+      async inspectAuth() {
+        return { provider: "codex", sources: [] };
+      },
+    };
+    const chunks: string[] = [];
+    await main({
+      argv: ["watch", "--provider", "codex", "--once"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+        isTTY: false,
+      },
+      watchDeps: {
+        getSnapshot: async () => ({
+          generatedAt: "2026-07-09T11:20:00.000Z",
+          schemaVersion: 1 as const,
+          mode: "cache" as const,
+          providers: [
+            {
+              provider: "codex" as const,
+              label: "Codex",
+              trust: "cached" as const,
+              status: "stale" as const,
+              source: "cache" as const,
+              windows: [
+                {
+                  id: "five_hour",
+                  label: "session",
+                  kind: "session" as const,
+                  percentRemaining: 20,
+                  percentUsed: 80,
+                  resetsAt: "2026-07-09T16:00:00.000Z",
+                  resetInSeconds: 18000,
+                  burnRate: {
+                    available: false as const,
+                    reason: "insufficient_data" as const,
+                  },
+                  level: "warn" as const,
+                },
+              ],
+              primary: {
+                id: "five_hour",
+                label: "session",
+                kind: "session" as const,
+                percentRemaining: 20,
+                percentUsed: 80,
+                resetsAt: "2026-07-09T16:00:00.000Z",
+                resetInSeconds: 18000,
+                burnRate: {
+                  available: false as const,
+                  reason: "insufficient_data" as const,
+                },
+                level: "warn" as const,
+              },
+            },
+          ],
+        }),
+      },
+    });
+    const output = chunks.join("");
+    expect(providerFetches).toBe(0);
+    expect(output).toContain("Codex");
+    expect(output).toContain("WARN");
+    expect(output).toContain("RED LINE");
+    expect(output).not.toMatch(/\$\d/);
+  });
 });
 
 describe("CLI quota rendering", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -16,6 +16,7 @@ const originalCodexProvider = PROVIDERS.codex;
 const originalCursorProvider = PROVIDERS.cursor;
 const originalCopilotProvider = PROVIDERS.copilot;
 const originalGrokProvider = PROVIDERS.grok;
+const originalAgyProvider = PROVIDERS.agy;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
@@ -25,6 +26,7 @@ afterEach(() => {
   PROVIDERS.cursor = originalCursorProvider;
   PROVIDERS.copilot = originalCopilotProvider;
   PROVIDERS.grok = originalGrokProvider;
+  PROVIDERS.agy = originalAgyProvider;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -40,6 +42,7 @@ describe("CLI argument parsing", () => {
       "cursor",
       "copilot",
       "grok",
+      "agy",
     ]);
   });
 
@@ -50,6 +53,7 @@ describe("CLI argument parsing", () => {
       "copilot",
       "grok",
     ]);
+    expect(parseArgs(["--provider", "agy"]).providers).toEqual(["agy"]);
   });
 
   it("ignores a standalone argument separator", () => {

--- a/test/fixtures/agy/quota-summary.json
+++ b/test/fixtures/agy/quota-summary.json
@@ -1,0 +1,49 @@
+{
+  "response": {
+    "groups": [
+      {
+        "displayName": "Gemini Models",
+        "description": "Models within this group: Gemini Flash, Gemini Pro",
+        "buckets": [
+          {
+            "bucketId": "gemini-weekly",
+            "displayName": "Weekly Limit",
+            "description": "Fixture weekly reset",
+            "window": "weekly",
+            "remainingFraction": 0.82,
+            "resetTime": "2026-06-19T08:45:39Z"
+          },
+          {
+            "bucketId": "gemini-5h",
+            "displayName": "Five Hour Limit",
+            "window": "5h",
+            "remainingFraction": 0.91,
+            "resetTime": "2026-06-15T11:39:34Z"
+          }
+        ]
+      },
+      {
+        "displayName": "Claude and GPT models",
+        "description": "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
+        "buckets": [
+          {
+            "bucketId": "3p-weekly",
+            "displayName": "Weekly Limit",
+            "description": "Fixture third-party weekly reset",
+            "window": "weekly",
+            "remainingFraction": 0.64,
+            "resetTime": "2026-06-20T00:39:54Z"
+          },
+          {
+            "bucketId": "3p-5h",
+            "displayName": "Five Hour Limit",
+            "window": "5h",
+            "remainingFraction": 0.73,
+            "resetTime": "2026-06-15T12:52:10Z"
+          }
+        ]
+      }
+    ],
+    "description": "Fixture quota summary"
+  }
+}

--- a/test/fixtures/agy/user-status.json
+++ b/test/fixtures/agy/user-status.json
@@ -1,0 +1,37 @@
+{
+  "userStatus": {
+    "email": "person@example.invalid",
+    "planStatus": {
+      "planInfo": {
+        "planName": "Pro"
+      }
+    },
+    "cascadeModelConfigData": {
+      "clientModelConfigs": [
+        {
+          "label": "Gemini 3.5 Flash (Medium)",
+          "modelOrAlias": {
+            "model": "MODEL_FIXTURE_GEMINI_FLASH"
+          },
+          "quotaInfo": {
+            "remainingFraction": 1,
+            "resetTime": "2026-06-15T12:52:10Z"
+          }
+        },
+        {
+          "label": "Claude Sonnet Fixture",
+          "modelOrAlias": {
+            "model": "MODEL_FIXTURE_CLAUDE_SONNET"
+          },
+          "quotaInfo": {
+            "remainingFraction": 0.5,
+            "resetTime": "2026-06-15T12:52:10Z"
+          }
+        }
+      ]
+    },
+    "userTier": {
+      "name": "Google AI Pro"
+    }
+  }
+}

--- a/test/fixtures/watch/critical.json
+++ b/test/fixtures/watch/critical.json
@@ -1,0 +1,69 @@
+{
+  "generatedAt": "2026-07-09T11:20:00.000Z",
+  "schemaVersion": 1,
+  "mode": "cache",
+  "providers": [
+    {
+      "provider": "agy",
+      "label": "Antigravity",
+      "trust": "cached",
+      "status": "stale",
+      "source": "cache",
+      "refreshedAt": "2026-07-09T10:00:00.000Z",
+      "plan": "Google AI Pro",
+      "windows": [
+        {
+          "id": "gemini_5h",
+          "label": "Gemini 5-hour",
+          "kind": "session",
+          "percentRemaining": 5,
+          "percentUsed": 95,
+          "resetsAt": "2026-07-09T16:00:00.000Z",
+          "resetInSeconds": 18000,
+          "burnRate": {
+            "available": true,
+            "percentPerHour": 1.8
+          },
+          "level": "critical"
+        },
+        {
+          "id": "gemini_weekly",
+          "label": "Gemini weekly",
+          "kind": "weekly",
+          "percentRemaining": 82,
+          "percentUsed": 18,
+          "resetsAt": "2026-07-14T08:00:00.000Z",
+          "resetInSeconds": 420000,
+          "burnRate": {
+            "available": false,
+            "reason": "insufficient_data"
+          },
+          "level": "ok"
+        }
+      ],
+      "primary": {
+        "id": "gemini_5h",
+        "label": "Gemini 5-hour",
+        "kind": "session",
+        "percentRemaining": 5,
+        "percentUsed": 95,
+        "resetsAt": "2026-07-09T16:00:00.000Z",
+        "resetInSeconds": 18000,
+        "burnRate": {
+          "available": true,
+          "percentPerHour": 1.8
+        },
+        "level": "critical"
+      }
+    },
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "trust": "unavailable",
+      "status": "auth_required",
+      "source": "unavailable",
+      "windows": [],
+      "error": "credentials_missing"
+    }
+  ]
+}

--- a/test/fixtures/watch/sample.json
+++ b/test/fixtures/watch/sample.json
@@ -1,0 +1,69 @@
+{
+  "generatedAt": "2026-07-09T11:20:00.000Z",
+  "schemaVersion": 1,
+  "mode": "cache",
+  "providers": [
+    {
+      "provider": "agy",
+      "label": "Antigravity",
+      "trust": "cached",
+      "status": "stale",
+      "source": "cache",
+      "refreshedAt": "2026-07-09T10:00:00.000Z",
+      "plan": "Google AI Pro",
+      "windows": [
+        {
+          "id": "gemini_5h",
+          "label": "Gemini 5-hour",
+          "kind": "session",
+          "percentRemaining": 91,
+          "percentUsed": 9,
+          "resetsAt": "2026-07-09T16:00:00.000Z",
+          "resetInSeconds": 18000,
+          "burnRate": {
+            "available": true,
+            "percentPerHour": 1.8
+          },
+          "level": "ok"
+        },
+        {
+          "id": "gemini_weekly",
+          "label": "Gemini weekly",
+          "kind": "weekly",
+          "percentRemaining": 82,
+          "percentUsed": 18,
+          "resetsAt": "2026-07-14T08:00:00.000Z",
+          "resetInSeconds": 420000,
+          "burnRate": {
+            "available": false,
+            "reason": "insufficient_data"
+          },
+          "level": "ok"
+        }
+      ],
+      "primary": {
+        "id": "gemini_5h",
+        "label": "Gemini 5-hour",
+        "kind": "session",
+        "percentRemaining": 91,
+        "percentUsed": 9,
+        "resetsAt": "2026-07-09T16:00:00.000Z",
+        "resetInSeconds": 18000,
+        "burnRate": {
+          "available": true,
+          "percentPerHour": 1.8
+        },
+        "level": "ok"
+      }
+    },
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "trust": "unavailable",
+      "status": "auth_required",
+      "source": "unavailable",
+      "windows": [],
+      "error": "credentials_missing"
+    }
+  ]
+}

--- a/test/fixtures/watch/warn.json
+++ b/test/fixtures/watch/warn.json
@@ -1,0 +1,69 @@
+{
+  "generatedAt": "2026-07-09T11:20:00.000Z",
+  "schemaVersion": 1,
+  "mode": "cache",
+  "providers": [
+    {
+      "provider": "agy",
+      "label": "Antigravity",
+      "trust": "cached",
+      "status": "stale",
+      "source": "cache",
+      "refreshedAt": "2026-07-09T10:00:00.000Z",
+      "plan": "Google AI Pro",
+      "windows": [
+        {
+          "id": "gemini_5h",
+          "label": "Gemini 5-hour",
+          "kind": "session",
+          "percentRemaining": 20,
+          "percentUsed": 80,
+          "resetsAt": "2026-07-09T16:00:00.000Z",
+          "resetInSeconds": 18000,
+          "burnRate": {
+            "available": true,
+            "percentPerHour": 1.8
+          },
+          "level": "warn"
+        },
+        {
+          "id": "gemini_weekly",
+          "label": "Gemini weekly",
+          "kind": "weekly",
+          "percentRemaining": 82,
+          "percentUsed": 18,
+          "resetsAt": "2026-07-14T08:00:00.000Z",
+          "resetInSeconds": 420000,
+          "burnRate": {
+            "available": false,
+            "reason": "insufficient_data"
+          },
+          "level": "ok"
+        }
+      ],
+      "primary": {
+        "id": "gemini_5h",
+        "label": "Gemini 5-hour",
+        "kind": "session",
+        "percentRemaining": 20,
+        "percentUsed": 80,
+        "resetsAt": "2026-07-09T16:00:00.000Z",
+        "resetInSeconds": 18000,
+        "burnRate": {
+          "available": true,
+          "percentPerHour": 1.8
+        },
+        "level": "warn"
+      }
+    },
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "trust": "unavailable",
+      "status": "auth_required",
+      "source": "unavailable",
+      "windows": [],
+      "error": "credentials_missing"
+    }
+  ]
+}

--- a/test/providers/agy.test.ts
+++ b/test/providers/agy.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeCachedProviders } from "../../src/cache.js";
 import {
   fetchQuotaWithRuntime,
@@ -17,6 +17,10 @@ import type { ProviderQuota } from "../../src/types.js";
 
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
+
+beforeEach(() => {
+  useTempCache();
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -366,6 +370,7 @@ agy ${pid} test 8u IPv4 0x1 0t0 TCP 127.0.0.1:${port} (LISTEN)
 }
 
 function useTempCache(): void {
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = mkdtempSync(join(tmpdir(), "quota-axi-agy-cache-"));
   process.env.XDG_CACHE_HOME = tempDir;
 }

--- a/test/providers/agy.test.ts
+++ b/test/providers/agy.test.ts
@@ -1,0 +1,394 @@
+import { readFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeCachedProviders } from "../../src/cache.js";
+import {
+  fetchQuotaWithRuntime,
+  normalizeAgyQuotaSummary,
+  normalizeAgyUserStatus,
+  portsFromLsof,
+  processInfosFromPs,
+  type AgyConnectionEndpoint,
+  type AgyProbeRuntime,
+} from "../../src/providers/agy.js";
+import type { ProviderQuota } from "../../src/types.js";
+
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("Antigravity quota parsing", () => {
+  it("normalizes quota summary groups into session and weekly windows", () => {
+    const result = normalizeAgyQuotaSummary(fixture("quota-summary.json"));
+
+    expect(result?.windows).toMatchObject([
+      {
+        id: "gemini_5h",
+        label: "Gemini 5-hour",
+        kind: "session",
+        percentUsed: 9,
+        percentRemaining: 91,
+        resetsAt: "2026-06-15T11:39:34.000Z",
+        windowSeconds: 18000,
+      },
+      {
+        id: "gemini_weekly",
+        label: "Gemini weekly",
+        kind: "weekly",
+        percentUsed: 18,
+        percentRemaining: 82,
+        resetsAt: "2026-06-19T08:45:39.000Z",
+        windowSeconds: 604800,
+      },
+      {
+        id: "claude_gpt_5h",
+        label: "Claude/GPT 5-hour",
+        kind: "session",
+        percentUsed: 27,
+        percentRemaining: 73,
+        resetsAt: "2026-06-15T12:52:10.000Z",
+        windowSeconds: 18000,
+      },
+      {
+        id: "claude_gpt_weekly",
+        label: "Claude/GPT weekly",
+        kind: "weekly",
+        percentUsed: 36,
+        percentRemaining: 64,
+        resetsAt: "2026-06-20T00:39:54.000Z",
+        windowSeconds: 604800,
+      },
+    ]);
+  });
+
+  it("normalizes oneof remaining values", () => {
+    const result = normalizeAgyQuotaSummary({
+      groups: [
+        {
+          displayName: "Gemini Models",
+          buckets: [
+            {
+              bucketId: "gemini-weekly",
+              displayName: "Weekly Limit",
+              remaining: { case: "remainingFraction", value: 0.5 },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result?.windows[0]).toMatchObject({
+      id: "gemini_weekly",
+      percentUsed: 50,
+      percentRemaining: 50,
+    });
+  });
+
+  it("falls back to model windows from user status payloads", () => {
+    const result = normalizeAgyUserStatus(fixture("user-status.json"));
+
+    expect(result?.plan).toBe("Google AI Pro");
+    expect(result?.account?.email).toBe("person@example.invalid");
+    expect(result?.windows).toMatchObject([
+      {
+        id: "model:model_fixture_gemini_flash",
+        label: "Gemini 3.5 Flash (Medium)",
+        kind: "model",
+        percentRemaining: 100,
+      },
+      {
+        id: "model:model_fixture_claude_sonnet",
+        label: "Claude Sonnet Fixture",
+        kind: "model",
+        percentRemaining: 50,
+      },
+    ]);
+  });
+
+  it("parses Antigravity processes and listening ports without matching prompt text", () => {
+    const processes = processInfosFromPs(`
+      101 /Users/test/.local/bin/agy
+      102 /Applications/Google Antigravity.app/Contents/Resources/bin/language-server --csrf_token token --extension_server_port 64123
+      103 codex --prompt "run quota-axi --provider agy"
+    `);
+
+    expect(processes).toMatchObject([
+      { pid: 101, source: "agy" },
+      {
+        pid: 102,
+        source: "app",
+        csrfToken: "token",
+        extensionPort: 64123,
+      },
+    ]);
+    expect(
+      portsFromLsof(`
+COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+agy 101 test 8u IPv4 0x1 0t0 TCP 127.0.0.1:64440 (LISTEN)
+agy 101 test 9u IPv4 0x2 0t0 TCP 127.0.0.1:64441 (LISTEN)
+`),
+    ).toEqual([64440, 64441]);
+  });
+});
+
+describe("Antigravity provider", () => {
+  it("fetches quota from an already-running loopback endpoint and merges identity", async () => {
+    const runtime = runtimeWith({
+      ps: "123 /Users/test/.local/bin/agy\n",
+      lsof: lsofFor(123, 64440),
+      responses: {
+        "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+          fixture("quota-summary.json"),
+        "https:64440:/exa.language_server_pb.LanguageServerService/GetUserStatus":
+          fixture("user-status.json"),
+      },
+    });
+
+    const result = await fetchQuotaWithRuntime(runtime);
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.source).toBe("cli-rpc");
+    expect(result.plan).toBe("Google AI Pro");
+    expect(result.account?.email).toBe("person@example.invalid");
+    expect(result.windows.map((window) => window.id)).toEqual([
+      "gemini_5h",
+      "gemini_weekly",
+      "claude_gpt_5h",
+      "claude_gpt_weekly",
+    ]);
+  });
+
+  it("probes app language-server endpoints with CSRF before quota requests", async () => {
+    const calls: Array<{ endpoint: AgyConnectionEndpoint; path: string }> = [];
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({
+        ps: "123 /Applications/Google Antigravity.app/Contents/Resources/bin/language-server --csrf_token token\n",
+        lsof: lsofFor(123, 64440),
+        responses: {
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetUnleashData":
+            {},
+          "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            fixture("quota-summary.json"),
+        },
+        onRequest(endpoint, path) {
+          calls.push({ endpoint, path });
+        },
+      }),
+    );
+
+    expect(result.state.status).toBe("fresh");
+    expect(calls[0]?.path).toBe(
+      "/exa.language_server_pb.LanguageServerService/GetUnleashData",
+    );
+    expect(calls[0]?.endpoint).toMatchObject({
+      csrfToken: "token",
+      requiresCsrfToken: true,
+      requiresUnleashProbe: true,
+    });
+  });
+
+  it("reports unavailable without trying HTTP when Antigravity is not running", async () => {
+    const requestJson = vi.fn();
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({ ps: "", lsof: "", requestJson }),
+    );
+
+    expect(result.state.status).toBe("unavailable");
+    expect(result.state.error).toBe("Antigravity/agy is not running");
+    expect(requestJson).not.toHaveBeenCalled();
+  });
+
+  it("reports unavailable when discovered loopback endpoints are absent", async () => {
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({
+        ps: "123 /Users/test/.local/bin/agy\n",
+        lsof: lsofFor(123, 64440),
+        requestJson: async () => {
+          throw new Error("connect ECONNREFUSED 127.0.0.1:64440");
+        },
+      }),
+    );
+
+    expect(result.state.status).toBe("unavailable");
+    expect(result.state.error).toBe("connect ECONNREFUSED 127.0.0.1:64440");
+  });
+
+  it("falls back to model quotas when quota summary has no usable buckets", async () => {
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({
+        ps: "123 /Users/test/.local/bin/agy\n",
+        lsof: lsofFor(123, 64440),
+        responses: {
+          "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            { response: { groups: [] } },
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetUserStatus":
+            fixture("user-status.json"),
+        },
+      }),
+    );
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.windows.map((window) => window.id)).toEqual([
+      "model:model_fixture_gemini_flash",
+      "model:model_fixture_claude_sonnet",
+    ]);
+  });
+
+  it("continues past a malformed endpoint to a later valid port", async () => {
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({
+        ps: "123 /Users/test/.local/bin/agy\n",
+        lsof: `${lsofFor(123, 64440)}agy 123 test 9u IPv4 0x2 0t0 TCP 127.0.0.1:64441 (LISTEN)\n`,
+        responses: {
+          "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            { response: { groups: [] } },
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetUserStatus":
+            { response: { groups: [] } },
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs":
+            { response: { groups: [] } },
+          "https:64441:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            fixture("quota-summary.json"),
+        },
+      }),
+    );
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.windows[0]?.id).toBe("gemini_5h");
+  });
+
+  it("reports malformed loopback responses as errors", async () => {
+    const result = await fetchQuotaWithRuntime(
+      runtimeWith({
+        ps: "123 /Users/test/.local/bin/agy\n",
+        lsof: lsofFor(123, 64440),
+        responses: {
+          "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            { response: { groups: [] } },
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetUserStatus":
+            { response: { groups: [] } },
+          "https:64440:/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs":
+            { response: { groups: [] } },
+          "http:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+            { response: { groups: [] } },
+          "http:64440:/exa.language_server_pb.LanguageServerService/GetUserStatus":
+            { response: { groups: [] } },
+          "http:64440:/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs":
+            { response: { groups: [] } },
+        },
+      }),
+    );
+
+    expect(result.state.status).toBe("error");
+    expect(result.state.error).toBe("Antigravity quota summary malformed");
+  });
+
+  it("uses stale cache when the live loopback source is unavailable", async () => {
+    useTempCache();
+    writeCachedProviders([cachedAgyQuota()]);
+
+    const result = await fetchQuotaWithRuntime(runtimeWith({ ps: "" }));
+
+    expect(result.state.status).toBe("stale");
+    expect(result.source).toBe("cache");
+    expect(result.windows[0]).toMatchObject({
+      id: "gemini_5h",
+      percentRemaining: 88,
+    });
+  });
+
+  it("does not launch agy or any provider process", async () => {
+    const commands: string[] = [];
+    const runtime = runtimeWith({
+      ps: "123 /Users/test/.local/bin/agy\n",
+      lsof: lsofFor(123, 64440),
+      responses: {
+        "https:64440:/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary":
+          fixture("quota-summary.json"),
+      },
+      onExec(command) {
+        commands.push(command);
+      },
+    });
+
+    const result = await fetchQuotaWithRuntime(runtime);
+
+    expect(result.state.status).toBe("fresh");
+    expect(commands).toEqual(["ps", "lsof"]);
+    expect(commands).not.toContain("agy");
+  });
+});
+
+function runtimeWith(options: {
+  ps?: string;
+  lsof?: string;
+  requestJson?: AgyProbeRuntime["requestJson"];
+  responses?: Record<string, unknown>;
+  onExec?: (command: string) => void;
+  onRequest?: (endpoint: AgyConnectionEndpoint, path: string) => void;
+}): AgyProbeRuntime {
+  return {
+    async execFileText(command) {
+      options.onExec?.(command);
+      if (command === "ps") return options.ps ?? "";
+      if (command === "lsof") return options.lsof ?? "";
+      throw new Error(`unexpected command: ${command}`);
+    },
+    async requestJson(endpoint: AgyConnectionEndpoint, path: string) {
+      options.onRequest?.(endpoint, path);
+      if (options.requestJson) return options.requestJson(endpoint, path, 0);
+      const key = `${endpoint.scheme}:${endpoint.port}:${path}`;
+      if (options.responses && key in options.responses)
+        return options.responses[key];
+      throw new Error(`unexpected request: ${key}`);
+    },
+  };
+}
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join("test", "fixtures", "agy", name), "utf8"),
+  ) as unknown;
+}
+
+function lsofFor(pid: number, port: number): string {
+  return `COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+agy ${pid} test 8u IPv4 0x1 0t0 TCP 127.0.0.1:${port} (LISTEN)
+`;
+}
+
+function useTempCache(): void {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-agy-cache-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+}
+
+function cachedAgyQuota(): ProviderQuota {
+  return {
+    provider: "agy",
+    label: "Antigravity",
+    source: "cli-rpc",
+    windows: [
+      {
+        id: "gemini_5h",
+        label: "Gemini 5-hour",
+        kind: "session",
+        percentUsed: 12,
+        percentRemaining: 88,
+      },
+    ],
+    state: {
+      status: "fresh",
+      stale: false,
+      refreshedAt: "2026-06-15T11:39:34.000Z",
+      sourcesTried: ["loopback"],
+    },
+  };
+}

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -1,0 +1,335 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeCachedProviders } from "../src/cache.js";
+import { normalizeAgyQuotaSummary } from "../src/providers/agy.js";
+import {
+  buildWatchSnapshot,
+  deriveBurnRate,
+  getWatchSnapshot,
+  levelForRemaining,
+  selectPrimaryWindow,
+  toSnapshotWindow,
+} from "../src/snapshot.js";
+import type { ProviderId, ProviderQuota, QuotaWindow } from "../src/types.js";
+
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("buildWatchSnapshot", () => {
+  const now = new Date("2026-07-09T12:00:00.000Z");
+
+  it("maps agy fixture windows into render-ready fields", () => {
+    const normalized = normalizeAgyQuotaSummary(
+      fixture("agy/quota-summary.json"),
+    );
+    expect(normalized?.windows.length).toBeGreaterThan(0);
+
+    const provider = quota("agy", {
+      plan: "Google AI Pro",
+      windows: normalized!.windows,
+      status: "stale",
+      source: "cache",
+      stale: true,
+      refreshedAt: "2026-07-09T10:00:00.000Z",
+    });
+
+    const snapshot = buildWatchSnapshot([provider], {
+      mode: "cache",
+      now,
+      generatedAt: "2026-07-09T12:00:00.000Z",
+    });
+
+    expect(snapshot).toMatchObject({
+      schemaVersion: 1,
+      mode: "cache",
+      generatedAt: "2026-07-09T12:00:00.000Z",
+    });
+    expect(snapshot.providers).toHaveLength(1);
+    const agy = snapshot.providers[0];
+    expect(agy.trust).toBe("stale");
+    expect(agy.windows.map((window) => window.id)).toEqual(
+      normalized!.windows.map((window) => window.id),
+    );
+    expect(agy.primary?.kind).toBe("session");
+    for (const window of agy.windows) {
+      expect(window.level).toMatch(/^(ok|warn|critical)$/);
+      expect(window.resetInSeconds === null || window.resetInSeconds > 0).toBe(
+        true,
+      );
+      // Fixture resets are historical relative to `now`, so burn stays honest.
+      if (window.resetsAt && Date.parse(window.resetsAt) <= now.getTime()) {
+        expect(window.burnRate).toEqual({
+          available: false,
+          reason: "insufficient_data",
+        });
+        expect(window.resetInSeconds).toBeNull();
+      }
+    }
+  });
+
+  it("marks missing remaining levels and burn honestly", () => {
+    const provider = quota("claude", {
+      windows: [
+        {
+          id: "five_hour",
+          label: "5-hour",
+          kind: "session",
+          percentRemaining: 5,
+          percentUsed: 95,
+        },
+        {
+          id: "weekly",
+          label: "weekly",
+          kind: "weekly",
+          percentRemaining: 20,
+          percentUsed: 80,
+          resetsAt: "not-a-date",
+        },
+      ],
+      status: "fresh",
+      source: "oauth",
+    });
+
+    const snapshot = buildWatchSnapshot([provider], {
+      mode: "refresh",
+      now,
+    });
+    const [critical, warn] = snapshot.providers[0].windows;
+    expect(critical.level).toBe("critical");
+    expect(critical.burnRate).toEqual({
+      available: false,
+      reason: "insufficient_data",
+    });
+    expect(critical.resetInSeconds).toBeNull();
+    expect(warn.level).toBe("warn");
+    expect(warn.burnRate).toEqual({
+      available: false,
+      reason: "insufficient_data",
+    });
+    expect(snapshot.providers[0].trust).toBe("fresh");
+    expect(snapshot.providers[0].primary?.id).toBe("five_hour");
+  });
+
+  it("returns unavailable trust for auth failures with empty windows", () => {
+    const provider = quota("codex", {
+      windows: [],
+      status: "auth_required",
+      source: "unavailable",
+      error: "credentials_missing",
+    });
+    const snapshot = buildWatchSnapshot([provider], { mode: "cache", now });
+    expect(snapshot.providers[0]).toMatchObject({
+      trust: "unavailable",
+      status: "auth_required",
+      windows: [],
+      error: "credentials_missing",
+    });
+    expect(snapshot.providers[0].primary).toBeUndefined();
+  });
+});
+
+describe("getWatchSnapshot", () => {
+  const now = new Date("2026-07-09T12:00:00.000Z");
+
+  it("defaults to cache mode and never fetches providers", async () => {
+    useTempCache();
+    writeCachedProviders([
+      quota("claude", {
+        windows: [
+          {
+            id: "five_hour",
+            label: "5-hour",
+            kind: "session",
+            percentUsed: 40,
+            percentRemaining: 60,
+            resetsAt: "2026-07-09T15:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "fresh",
+        source: "oauth",
+        refreshedAt: "2026-07-09T11:00:00.000Z",
+      }),
+    ]);
+
+    const fetchProvider = vi.fn();
+    const snapshot = await getWatchSnapshot(
+      { providers: ["claude", "agy"], now },
+      { fetchProvider },
+    );
+
+    expect(fetchProvider).not.toHaveBeenCalled();
+    expect(snapshot.mode).toBe("cache");
+    expect(snapshot.providers.map((item) => item.provider)).toEqual([
+      "claude",
+      "agy",
+    ]);
+    expect(snapshot.providers[0].trust).toBe("cached");
+    expect(snapshot.providers[1]).toMatchObject({
+      provider: "agy",
+      trust: "unavailable",
+      error: "cache_miss",
+      windows: [],
+    });
+  });
+
+  it("refresh mode fetches, writes cache, and marks trust fresh", async () => {
+    useTempCache();
+    const live = quota("agy", {
+      windows: [
+        {
+          id: "gemini_5h",
+          label: "Gemini 5-hour",
+          kind: "session",
+          percentUsed: 10,
+          percentRemaining: 90,
+          resetsAt: "2026-07-09T16:00:00.000Z",
+          windowSeconds: 18000,
+        },
+      ],
+      status: "fresh",
+      source: "api",
+      refreshedAt: "2026-07-09T12:00:00.000Z",
+    });
+    const fetchProvider = vi.fn().mockResolvedValue(live);
+    const writeCache = vi.fn();
+
+    const snapshot = await getWatchSnapshot(
+      { providers: ["agy"], refresh: true, now },
+      { fetchProvider, writeCache, nowIso: () => "2026-07-09T12:00:00.000Z" },
+    );
+
+    expect(fetchProvider).toHaveBeenCalledOnce();
+    expect(writeCache).toHaveBeenCalledWith([live]);
+    expect(snapshot).toMatchObject({
+      mode: "refresh",
+      generatedAt: "2026-07-09T12:00:00.000Z",
+      providers: [{ provider: "agy", trust: "fresh", status: "fresh" }],
+    });
+  });
+});
+
+describe("snapshot helpers", () => {
+  const now = new Date("2026-07-09T12:00:00.000Z");
+
+  it("derives burn rate only with elapsed window data", () => {
+    const window: QuotaWindow = {
+      id: "session",
+      label: "session",
+      kind: "session",
+      percentUsed: 9,
+      resetsAt: "2026-07-09T17:00:00.000Z",
+      windowSeconds: 36000,
+    };
+    expect(deriveBurnRate(window, now)).toEqual({
+      available: true,
+      percentPerHour: 1.8,
+    });
+    expect(
+      deriveBurnRate({ ...window, windowSeconds: undefined }, now),
+    ).toEqual({ available: false, reason: "insufficient_data" });
+    expect(deriveBurnRate({ ...window, windowSeconds: 18000 }, now)).toEqual({
+      available: false,
+      reason: "insufficient_data",
+    });
+  });
+
+  it("classifies remaining thresholds", () => {
+    expect(levelForRemaining(undefined)).toBe("ok");
+    expect(levelForRemaining(50)).toBe("ok");
+    expect(levelForRemaining(25)).toBe("warn");
+    expect(levelForRemaining(10)).toBe("critical");
+    expect(levelForRemaining(0)).toBe("critical");
+  });
+
+  it("selects the most urgent session window as primary", () => {
+    const windows = [
+      toSnapshotWindow(
+        {
+          id: "weekly",
+          label: "weekly",
+          kind: "weekly",
+          percentRemaining: 5,
+        },
+        now,
+      ),
+      toSnapshotWindow(
+        {
+          id: "session_ok",
+          label: "session ok",
+          kind: "session",
+          percentRemaining: 40,
+        },
+        now,
+      ),
+      toSnapshotWindow(
+        {
+          id: "session_low",
+          label: "session low",
+          kind: "session",
+          percentRemaining: 12,
+        },
+        now,
+      ),
+    ];
+    expect(selectPrimaryWindow(windows)?.id).toBe("session_low");
+  });
+});
+
+function useTempCache(): void {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-snapshot-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+}
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "fixtures", name), "utf8"),
+  ) as unknown;
+}
+
+function quota(
+  provider: ProviderId,
+  args: {
+    windows: QuotaWindow[];
+    status: ProviderQuota["state"]["status"];
+    source: ProviderQuota["source"];
+    plan?: string;
+    stale?: boolean;
+    refreshedAt?: string;
+    error?: string;
+  },
+): ProviderQuota {
+  return {
+    provider,
+    label: providerLabel(provider),
+    source: args.source,
+    plan: args.plan,
+    windows: args.windows,
+    state: {
+      status: args.status,
+      stale: args.stale ?? false,
+      refreshedAt: args.refreshedAt,
+      error: args.error,
+      sourcesTried: [args.source],
+    },
+  };
+}
+
+function providerLabel(provider: ProviderId): string {
+  if (provider === "claude") return "Claude";
+  if (provider === "codex") return "Codex";
+  if (provider === "cursor") return "Cursor";
+  if (provider === "copilot") return "GitHub Copilot";
+  if (provider === "agy") return "Antigravity";
+  return "Grok";
+}

--- a/test/watch-render.test.ts
+++ b/test/watch-render.test.ts
@@ -1,0 +1,190 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { buildWatchSnapshot, levelForRemaining } from "../src/snapshot.js";
+import { isRedLine, renderWatchPane } from "../src/watch-render.js";
+import type { WatchSnapshot } from "../src/snapshot.js";
+import type { ProviderQuota } from "../src/types.js";
+import { runWatchLoop } from "../src/watch.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function loadFixture(name: string): WatchSnapshot {
+  const raw = readFileSync(join(here, "fixtures", "watch", name), "utf-8");
+  return JSON.parse(raw) as WatchSnapshot;
+}
+
+describe("renderWatchPane", () => {
+  it("renders schema sample with remaining, reset, burn, and trust", () => {
+    const snapshot = loadFixture("sample.json");
+    const pane = renderWatchPane(snapshot, { color: false });
+
+    expect(pane).toContain("quota-axi watch");
+    expect(pane).toContain("mode=cache");
+    expect(pane).toContain("Antigravity");
+    expect(pane).toContain("cached");
+    expect(pane).toContain("Gemini 5-hour");
+    expect(pane).toContain("rem  91%");
+    expect(pane).toContain("1.80%/h");
+    expect(pane).toContain("n/a");
+    expect(pane).toContain("Claude");
+    expect(pane).toContain("unavailable");
+    expect(pane).toContain("credentials_missing");
+    expect(pane).not.toMatch(/\$\d/);
+    expect(pane).not.toContain("USD");
+    expect(pane).not.toContain("RED LINE");
+  });
+
+  it("surfaces red-line WARN when a window is hot", () => {
+    const snapshot = loadFixture("warn.json");
+    const pane = renderWatchPane(snapshot, { color: false });
+
+    expect(pane).toContain("WARN");
+    expect(pane).toContain("RED LINE");
+    expect(pane).toContain("agy/gemini_5h remaining 20%");
+    expect(pane).not.toMatch(/\$\d/);
+  });
+
+  it("surfaces red-line CRIT when a window is critical", () => {
+    const snapshot = loadFixture("critical.json");
+    const pane = renderWatchPane(snapshot, { color: false });
+
+    expect(pane).toContain("CRIT");
+    expect(pane).toContain("RED LINE");
+    expect(pane).toContain("agy/gemini_5h remaining 5%");
+  });
+
+  it("never prints USD markers outside --full", () => {
+    const snapshot = loadFixture("sample.json");
+    const polluted: WatchSnapshot = {
+      ...snapshot,
+      providers: snapshot.providers.map((provider) => ({
+        ...provider,
+        plan: provider.plan ? `${provider.plan} $99 USD` : "$12",
+      })),
+    };
+    const pane = renderWatchPane(polluted, { color: false, full: false });
+    expect(pane).not.toMatch(/\$\d/);
+  });
+
+  it("marks primary window with *", () => {
+    const snapshot = loadFixture("sample.json");
+    const pane = renderWatchPane(snapshot, { color: false });
+    expect(pane).toMatch(/\* ok .*Gemini 5-hour/);
+  });
+});
+
+describe("red-line thresholds (data contract)", () => {
+  it("maps remaining to ok/warn/critical", () => {
+    expect(levelForRemaining(50)).toBe("ok");
+    expect(levelForRemaining(25)).toBe("warn");
+    expect(levelForRemaining(20)).toBe("warn");
+    expect(levelForRemaining(10)).toBe("critical");
+    expect(levelForRemaining(5)).toBe("critical");
+    expect(levelForRemaining(undefined)).toBe("ok");
+  });
+
+  it("isRedLine only for warn and critical", () => {
+    expect(isRedLine("ok")).toBe(false);
+    expect(isRedLine("warn")).toBe(true);
+    expect(isRedLine("critical")).toBe(true);
+  });
+});
+
+describe("runWatchLoop", () => {
+  it("paints once with injectable snapshot and never calls providers", async () => {
+    const snapshot = loadFixture("sample.json");
+    let fetches = 0;
+    const chunks: string[] = [];
+
+    await runWatchLoop(
+      {
+        intervalMs: 1,
+        snapshot: { refresh: false },
+        render: { color: false },
+        once: true,
+      },
+      {
+        getSnapshot: async () => {
+          fetches += 1;
+          return snapshot;
+        },
+        write: (chunk) => {
+          chunks.push(chunk);
+        },
+        isTty: false,
+      },
+    );
+
+    expect(fetches).toBe(1);
+    expect(chunks.join("")).toContain("Antigravity");
+    expect(chunks.join("")).toContain("mode=cache");
+  });
+
+  it("stops when shouldContinue becomes false", async () => {
+    const snapshot = loadFixture("warn.json");
+    let fetches = 0;
+    let ticks = 0;
+
+    await runWatchLoop(
+      {
+        intervalMs: 1,
+        snapshot: { refresh: false },
+        render: { color: false },
+      },
+      {
+        getSnapshot: async () => {
+          fetches += 1;
+          return snapshot;
+        },
+        write: () => undefined,
+        sleep: async () => {
+          ticks += 1;
+        },
+        shouldContinue: () => ticks < 2,
+        isTty: false,
+      },
+    );
+
+    expect(fetches).toBeGreaterThanOrEqual(2);
+    expect(fetches).toBeLessThanOrEqual(3);
+  });
+});
+
+describe("buildWatchSnapshot levels feed renderer", () => {
+  it("critical remaining paints CRIT via snapshot build", () => {
+    const providers: ProviderQuota[] = [
+      {
+        provider: "codex",
+        label: "Codex",
+        source: "cache",
+        windows: [
+          {
+            id: "five_hour",
+            label: "session",
+            kind: "session",
+            percentRemaining: 5,
+            percentUsed: 95,
+            resetsAt: "2026-07-09T20:00:00.000Z",
+            windowSeconds: 5 * 3600,
+          },
+        ],
+        state: {
+          status: "stale",
+          stale: true,
+          refreshedAt: "2026-07-09T10:00:00.000Z",
+          sourcesTried: ["cache"],
+        },
+      },
+    ];
+    const snapshot = buildWatchSnapshot(providers, {
+      now: new Date("2026-07-09T11:20:00.000Z"),
+      mode: "cache",
+    });
+    const pane = renderWatchPane(snapshot, { color: false });
+    expect(snapshot.providers[0].windows[0].level).toBe("critical");
+    expect(pane).toContain("CRIT");
+    expect(pane).toContain("RED LINE");
+  });
+});

--- a/test/watch.pipeline.test.ts
+++ b/test/watch.pipeline.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Watch pipeline integration harness (test seat).
+ * Pins fixture providers through getWatchSnapshot → renderWatchPane / CLI
+ * watch end to end: fresh / stale / rate_limited / missing-data, red-line
+ * thresholds, and the untaxed agent path (default refresh=false never fetches).
+ */
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeCachedProviders } from "../src/cache.js";
+import { main } from "../src/cli.js";
+import { normalizeAgyQuotaSummary } from "../src/providers/agy.js";
+import { PROVIDERS } from "../src/providers/index.js";
+import {
+  buildWatchSnapshot,
+  getWatchSnapshot,
+  levelForRemaining,
+  type WatchSnapshot,
+} from "../src/snapshot.js";
+import type {
+  ProviderId,
+  ProviderOptions,
+  ProviderQuota,
+  QuotaWindow,
+} from "../src/types.js";
+import { renderWatchPane } from "../src/watch-render.js";
+
+const originalClaudeProvider = PROVIDERS.claude;
+const originalCodexProvider = PROVIDERS.codex;
+const originalCursorProvider = PROVIDERS.cursor;
+const originalCopilotProvider = PROVIDERS.copilot;
+const originalGrokProvider = PROVIDERS.grok;
+const originalAgyProvider = PROVIDERS.agy;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  PROVIDERS.claude = originalClaudeProvider;
+  PROVIDERS.codex = originalCodexProvider;
+  PROVIDERS.cursor = originalCursorProvider;
+  PROVIDERS.copilot = originalCopilotProvider;
+  PROVIDERS.grok = originalGrokProvider;
+  PROVIDERS.agy = originalAgyProvider;
+  if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+  process.exitCode = undefined;
+});
+
+const NOW = new Date("2026-07-09T12:00:00.000Z");
+
+describe("watch pipeline: fixture providers e2e", () => {
+  it("builds a multi-provider snapshot for fresh, stale, throttled, and missing-data cases", async () => {
+    const agyWindows =
+      normalizeAgyQuotaSummary(fixture("agy/quota-summary.json"))?.windows ??
+      [];
+    expect(agyWindows.length).toBeGreaterThan(0);
+
+    const fixtures: ProviderQuota[] = [
+      quota("agy", {
+        windows: agyWindows.map((window) => ({
+          ...window,
+          // Keep resets in the future so countdown/burn can compute.
+          resetsAt: "2026-07-09T17:00:00.000Z",
+          windowSeconds: window.windowSeconds ?? 18000,
+        })),
+        status: "fresh",
+        source: "cli-rpc",
+        refreshedAt: "2026-07-09T11:55:00.000Z",
+        plan: "Google AI Pro",
+      }),
+      quota("claude", {
+        windows: [
+          {
+            id: "five_hour",
+            label: "5-hour",
+            kind: "session",
+            percentUsed: 40,
+            percentRemaining: 60,
+            resetsAt: "2026-07-09T15:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "stale",
+        source: "cache",
+        stale: true,
+        refreshedAt: "2026-07-09T08:00:00.000Z",
+      }),
+      quota("codex", {
+        windows: [
+          {
+            id: "five_hour",
+            label: "5-hour",
+            kind: "session",
+            percentUsed: 70,
+            percentRemaining: 30,
+            resetsAt: "2026-07-09T14:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "rate_limited",
+        source: "api",
+        error: "retry_after",
+        retryAfter: "2026-07-09T12:05:00.000Z",
+      }),
+      quota("grok", {
+        windows: [],
+        status: "auth_required",
+        source: "unavailable",
+        error: "credentials_missing",
+      }),
+    ];
+
+    const snapshot = buildWatchSnapshot(fixtures, {
+      mode: "refresh",
+      now: NOW,
+      generatedAt: NOW.toISOString(),
+    });
+
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.mode).toBe("refresh");
+    expect(snapshot.providers).toHaveLength(4);
+
+    const byId = Object.fromEntries(
+      snapshot.providers.map((provider) => [provider.provider, provider]),
+    );
+
+    // fresh live source
+    expect(byId.agy).toMatchObject({
+      trust: "fresh",
+      status: "fresh",
+      source: "cli-rpc",
+      plan: "Google AI Pro",
+    });
+    expect(byId.agy.windows.length).toBeGreaterThan(0);
+    expect(byId.agy.primary?.kind).toBe("session");
+    expect(byId.agy.windows.every((window) => window.level)).toBeTruthy();
+
+    // stale cached
+    expect(byId.claude).toMatchObject({
+      trust: "stale",
+      status: "stale",
+      source: "cache",
+    });
+    expect(byId.claude.windows[0]?.resetInSeconds).toBe(3 * 3600);
+
+    // throttled / rate_limited
+    expect(byId.codex).toMatchObject({
+      trust: "unavailable",
+      status: "rate_limited",
+      error: "retry_after",
+    });
+    expect(byId.codex.windows[0]?.percentRemaining).toBe(30);
+
+    // missing data / auth required
+    expect(byId.grok).toMatchObject({
+      trust: "unavailable",
+      status: "auth_required",
+      windows: [],
+      error: "credentials_missing",
+    });
+    expect(byId.grok.primary).toBeUndefined();
+  });
+
+  it("refresh path fetches fixture providers once and writes cache", async () => {
+    useTempCache();
+    const live = quota("cursor", {
+      windows: [
+        {
+          id: "included_usage",
+          label: "included",
+          kind: "monthly",
+          percentUsed: 12,
+          percentRemaining: 88,
+          resetsAt: "2026-08-01T00:00:00.000Z",
+          windowSeconds: 30 * 86400,
+        },
+      ],
+      status: "fresh",
+      source: "web",
+      refreshedAt: NOW.toISOString(),
+    });
+    const fetchProvider = vi.fn(
+      async (_provider: ProviderId, _options: ProviderOptions) => live,
+    );
+    const writeCache = vi.fn();
+
+    const snapshot = await getWatchSnapshot(
+      { providers: ["cursor"], refresh: true, now: NOW },
+      {
+        fetchProvider,
+        writeCache,
+        nowIso: () => NOW.toISOString(),
+      },
+    );
+
+    expect(fetchProvider).toHaveBeenCalledOnce();
+    expect(writeCache).toHaveBeenCalledWith([live]);
+    expect(snapshot).toMatchObject({
+      mode: "refresh",
+      generatedAt: NOW.toISOString(),
+      providers: [{ provider: "cursor", trust: "fresh", status: "fresh" }],
+    });
+  });
+});
+
+describe("watch pipeline: red-line thresholds", () => {
+  it.each([
+    { remaining: 50, level: "ok" as const },
+    { remaining: 26, level: "ok" as const },
+    { remaining: 25, level: "warn" as const },
+    { remaining: 11, level: "warn" as const },
+    { remaining: 10, level: "critical" as const },
+    { remaining: 0, level: "critical" as const },
+    { remaining: undefined, level: "ok" as const },
+  ])("remaining $remaining maps to $level", ({ remaining, level }) => {
+    expect(levelForRemaining(remaining)).toBe(level);
+  });
+
+  it("propagates red-line levels through buildWatchSnapshot for ok/warn/critical", () => {
+    const snapshot = buildWatchSnapshot(
+      [
+        quota("claude", {
+          windows: [
+            sessionWindow("ok", 50),
+            sessionWindow("warn", 20),
+            sessionWindow("critical", 5),
+          ],
+          status: "fresh",
+          source: "oauth",
+        }),
+      ],
+      { mode: "refresh", now: NOW },
+    );
+
+    const levels = snapshot.providers[0].windows.map((window) => ({
+      id: window.id,
+      level: window.level,
+    }));
+    expect(levels).toEqual([
+      { id: "ok", level: "ok" },
+      { id: "warn", level: "warn" },
+      { id: "critical", level: "critical" },
+    ]);
+    // Primary is most urgent session window.
+    expect(snapshot.providers[0].primary?.id).toBe("critical");
+    expect(snapshot.providers[0].primary?.level).toBe("critical");
+  });
+});
+
+describe("watch pipeline: agent read path untaxed", () => {
+  it("default getWatchSnapshot uses cache only and never fetches providers", async () => {
+    useTempCache();
+    writeCachedProviders([
+      quota("claude", {
+        windows: [
+          {
+            id: "five_hour",
+            label: "5-hour",
+            kind: "session",
+            percentUsed: 15,
+            percentRemaining: 85,
+            resetsAt: "2026-07-09T16:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "fresh",
+        source: "oauth",
+        refreshedAt: "2026-07-09T11:00:00.000Z",
+      }),
+    ]);
+
+    const fetchProvider = vi.fn(async () => {
+      throw new Error("live provider must not be called on agent path");
+    });
+
+    const snapshot = await getWatchSnapshot(
+      { providers: ["claude", "agy"], now: NOW },
+      { fetchProvider },
+    );
+
+    expect(fetchProvider).not.toHaveBeenCalled();
+    expect(snapshot.mode).toBe("cache");
+    expect(snapshot.providers).toHaveLength(2);
+    expect(snapshot.providers[0]).toMatchObject({
+      provider: "claude",
+      trust: "cached",
+      status: "fresh",
+    });
+    expect(snapshot.providers[1]).toMatchObject({
+      provider: "agy",
+      trust: "unavailable",
+      error: "cache_miss",
+      windows: [],
+    });
+  });
+
+  it("render-ready snapshot from cache path carries levels without live I/O", async () => {
+    useTempCache();
+    writeCachedProviders([
+      quota("codex", {
+        windows: [sessionWindow("hot", 8), sessionWindow("warm", 22)],
+        status: "fresh",
+        source: "oauth",
+        refreshedAt: "2026-07-09T10:00:00.000Z",
+      }),
+    ]);
+
+    const fetchProvider = vi.fn();
+    const snapshot = await getWatchSnapshot(
+      { providers: ["codex"], refresh: false, now: NOW },
+      { fetchProvider },
+    );
+
+    expect(fetchProvider).not.toHaveBeenCalled();
+    assertRenderReady(snapshot);
+    expect(snapshot.providers[0].windows.map((w) => w.level)).toEqual([
+      "critical",
+      "warn",
+    ]);
+  });
+});
+
+describe("watch pipeline: snapshot → render e2e", () => {
+  it("renders red-line markers for multi-provider fixture matrix", () => {
+    const snapshot = buildWatchSnapshot(
+      [
+        quota("agy", {
+          windows: [
+            {
+              ...sessionWindow("gemini_5h", 5),
+              label: "Gemini 5-hour",
+            },
+          ],
+          status: "fresh",
+          source: "cli-rpc",
+          plan: "Google AI Pro",
+        }),
+        quota("claude", {
+          windows: [
+            {
+              ...sessionWindow("five_hour", 20),
+              label: "5-hour",
+            },
+          ],
+          status: "stale",
+          source: "cache",
+          stale: true,
+          refreshedAt: "2026-07-09T08:00:00.000Z",
+        }),
+        quota("codex", {
+          windows: [
+            {
+              ...sessionWindow("five_hour", 55),
+              label: "5-hour",
+            },
+          ],
+          status: "rate_limited",
+          source: "api",
+          error: "retry_after",
+        }),
+        quota("grok", {
+          windows: [],
+          status: "auth_required",
+          source: "unavailable",
+          error: "credentials_missing",
+        }),
+      ],
+      { mode: "cache", now: NOW, generatedAt: NOW.toISOString() },
+    );
+
+    const pane = renderWatchPane(snapshot, { color: false });
+
+    expect(pane).toContain("quota-axi watch");
+    expect(pane).toContain("mode=cache");
+    expect(pane).toContain("Antigravity");
+    expect(pane).toContain("CRIT");
+    expect(pane).toContain("WARN");
+    expect(pane).toContain("RED LINE");
+    expect(pane).toContain("agy/gemini_5h remaining 5%");
+    expect(pane).toContain("claude/five_hour remaining 20%");
+    expect(pane).toContain("unavailable");
+    expect(pane).toContain("credentials_missing");
+    expect(pane).toContain("retry_after");
+    expect(pane).not.toMatch(/\$\d/);
+    expect(pane).not.toContain("USD");
+  });
+
+  it("cache getWatchSnapshot output paints without live provider calls", async () => {
+    useTempCache();
+    writeCachedProviders([
+      quota("agy", {
+        windows: [
+          {
+            id: "gemini_5h",
+            label: "Gemini 5-hour",
+            kind: "session",
+            percentUsed: 95,
+            percentRemaining: 5,
+            resetsAt: "2026-07-09T17:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "fresh",
+        source: "cli-rpc",
+        refreshedAt: "2026-07-09T11:00:00.000Z",
+      }),
+    ]);
+
+    const fetchProvider = vi.fn(async () => {
+      throw new Error("live provider must not be called on render path");
+    });
+    const snapshot = await getWatchSnapshot(
+      { providers: ["agy"], refresh: false, now: NOW },
+      { fetchProvider },
+    );
+    const pane = renderWatchPane(snapshot, { color: false });
+
+    expect(fetchProvider).not.toHaveBeenCalled();
+    expect(snapshot.mode).toBe("cache");
+    expect(pane).toContain("CRIT");
+    expect(pane).toContain("RED LINE");
+    expect(pane).toContain("rem   5%");
+  });
+});
+
+describe("watch pipeline: CLI default path untaxed", () => {
+  it("quota-axi watch uses cache snapshot and never calls PROVIDERS", async () => {
+    useTempCache();
+    writeCachedProviders([
+      quota("codex", {
+        windows: [
+          {
+            id: "five_hour",
+            label: "session",
+            kind: "session",
+            percentUsed: 80,
+            percentRemaining: 20,
+            resetsAt: "2026-07-09T17:00:00.000Z",
+            windowSeconds: 18000,
+          },
+        ],
+        status: "fresh",
+        source: "oauth",
+        refreshedAt: "2026-07-09T11:00:00.000Z",
+      }),
+    ]);
+
+    let providerFetches = 0;
+    const boom = async () => {
+      providerFetches += 1;
+      throw new Error("live provider must not be called on default watch");
+    };
+    for (const id of [
+      "claude",
+      "codex",
+      "cursor",
+      "copilot",
+      "grok",
+      "agy",
+    ] as const) {
+      PROVIDERS[id] = {
+        id,
+        label: id,
+        fetchQuota: boom,
+        inspectAuth: async () => ({ provider: id, sources: [] }),
+      };
+    }
+
+    const chunks: string[] = [];
+    await main({
+      argv: ["watch", "--provider", "codex", "--once"],
+      binPath: "quota-axi",
+      stdout: {
+        write(chunk) {
+          chunks.push(String(chunk));
+          return true;
+        },
+        isTTY: false,
+      },
+      // Intentionally no watchDeps.getSnapshot: exercise real cache path.
+    });
+
+    const output = chunks.join("");
+    expect(providerFetches).toBe(0);
+    expect(output).toContain("quota-axi watch");
+    expect(output).toContain("mode=cache");
+    expect(output).toContain("WARN");
+    expect(output).toContain("RED LINE");
+    expect(output).toContain("rem  20%");
+    expect(output).not.toMatch(/\$\d/);
+  });
+});
+
+function assertRenderReady(snapshot: WatchSnapshot): void {
+  expect(snapshot.schemaVersion).toBe(1);
+  expect(["cache", "refresh"]).toContain(snapshot.mode);
+  expect(typeof snapshot.generatedAt).toBe("string");
+  for (const provider of snapshot.providers) {
+    expect(provider.provider).toBeTruthy();
+    expect(provider.trust).toMatch(/^(fresh|cached|stale|unavailable)$/);
+    for (const window of provider.windows) {
+      expect(window.level).toMatch(/^(ok|warn|critical)$/);
+      expect(
+        window.burnRate.available === true ||
+          window.burnRate.available === false,
+      ).toBe(true);
+      expect(
+        window.resetInSeconds === null ||
+          typeof window.resetInSeconds === "number",
+      ).toBe(true);
+    }
+  }
+}
+
+function sessionWindow(id: string, percentRemaining: number): QuotaWindow {
+  return {
+    id,
+    label: id,
+    kind: "session",
+    percentRemaining,
+    percentUsed: 100 - percentRemaining,
+    resetsAt: "2026-07-09T17:00:00.000Z",
+    windowSeconds: 18000,
+  };
+}
+
+function useTempCache(): void {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-watch-pipeline-"));
+  process.env.XDG_CACHE_HOME = tempDir;
+}
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "fixtures", name), "utf8"),
+  ) as unknown;
+}
+
+function quota(
+  provider: ProviderId,
+  args: {
+    windows: QuotaWindow[];
+    status: ProviderQuota["state"]["status"];
+    source: ProviderQuota["source"];
+    plan?: string;
+    stale?: boolean;
+    refreshedAt?: string;
+    error?: string;
+    retryAfter?: string;
+  },
+): ProviderQuota {
+  return {
+    provider,
+    label: providerLabel(provider),
+    source: args.source,
+    plan: args.plan,
+    windows: args.windows,
+    state: {
+      status: args.status,
+      stale: args.stale ?? false,
+      refreshedAt: args.refreshedAt,
+      error: args.error,
+      retryAfter: args.retryAfter,
+      sourcesTried: [args.source],
+    },
+  };
+}
+
+function providerLabel(provider: ProviderId): string {
+  switch (provider) {
+    case "claude":
+      return "Claude";
+    case "codex":
+      return "Codex";
+    case "cursor":
+      return "Cursor";
+    case "copilot":
+      return "GitHub Copilot";
+    case "agy":
+      return "Antigravity";
+    case "grok":
+      return "Grok";
+  }
+}


### PR DESCRIPTION
# TL;DR

Shipped the `quota-axi watch` TUI layer on branch `fm/quota-tui-s1`. The branch adds a cache-default `WatchSnapshot` data contract, a live pane renderer/loop/CLI, red-line warning markers, and fixture-backed coverage; the agent read path remains untaxed unless `--refresh` is explicit, and USD/account data stays out of the default watch surface.

# Evidence

- Isolation: `pwd -P` and `git rev-parse --show-toplevel` both resolved to `/Users/gilbertpolanco/.treehouse/quota-axi-f43f0e/1/quota-axi`.
- Branch: `fm/quota-tui-s1`, pushed to `origin/fm/quota-tui-s1`.
- Bus proof: workers joined; TUI asked data for the snapshot schema over fm-bus (`quota-tui-s1-tui#1`), data replied with the schema, test pinned contracts via bus, and lead emitted digests `0001`, `0002`, `0003`, and final `0004`.
- Stream commits on top of the agy worktree baseline: `d9a06ae` data snapshot, `25c6918` watch TUI renderer/CLI, `0368fb7` watch pipeline tests, `1571377` agy test cache isolation.
- Validation: `pnpm run build` passed; `pnpm run lint` passed; `pnpm run format:check` passed; `pnpm test` passed with 16 files and 123 tests; `pnpm run build:skill -- --check` passed.
- PR: https://github.com/kunchenguid/quota-axi/pull/17
