### PR TITLE
feat(providers): isolate managed Claude and Codex profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
 - JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
 - macOS Claude Keychain value reads are skipped on plain calls until a successful value read records the non-secret access marker under the quota-axi cache directory; after that, plain calls may reuse the existing grant and read live Claude quota.
+- Claude credential discovery honors `$CLAUDE_CONFIG_DIR` for both `.credentials.json` and the path-hashed macOS Keychain service; custom-home Keychain markers are namespaced by that literal config path.
 - `--allow-keychain-prompt` is the first-time opt-in that permits the Claude Keychain value read which can prompt, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
 - Codex uses `$CODEX_HOME/auth.json` or `~/.codex/auth.json` OAuth before the CLI fallback.
 - Codex `auth.json` support is OAuth-token only; never treat `OPENAI_API_KEY` as valid quota auth or send API keys to ChatGPT quota endpoints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,10 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
 - macOS Claude Keychain value reads are skipped on plain calls until a successful value read records the non-secret access marker under the quota-axi cache directory; after that, plain calls may reuse the existing grant and read live Claude quota.
 - Claude credential discovery honors `$CLAUDE_CONFIG_DIR` for both `.credentials.json` and the path-hashed macOS Keychain service; custom-home Keychain markers are namespaced by that literal config path.
+- Claude quota reads also query the first-party `/api/oauth/profile` endpoint with the same OAuth credential. Only the authoritative root `account.uuid` is normalized as `account.accountId`; unrecognized responses are marked `identityStatus: unverified`, and account identity is never cached.
 - `--allow-keychain-prompt` is the first-time opt-in that permits the Claude Keychain value read which can prompt, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
 - Codex uses `$CODEX_HOME/auth.json` or `~/.codex/auth.json` OAuth before the CLI fallback.
+- `$QUOTA_AXI_CODEX_BINARY` may pin the Codex auth inspection and app-server fallback to one absolute executable path; invalid or non-executable overrides fail closed instead of falling back to `PATH`.
 - Codex `auth.json` support is OAuth-token only; never treat `OPENAI_API_KEY` as valid quota auth or send API keys to ChatGPT quota endpoints.
 - Never launch the Claude CLI to probe quota, because that would spend the quota being measured.
 - The read-only Codex app-server JSON-RPC probe is the only CLI fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,9 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
 - JSON provider reports include `provider`, `label`, `source`, `windows`, and `state`; `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
 - macOS Claude Keychain value reads are skipped on plain calls until a successful value read records the non-secret access marker under the quota-axi cache directory; after that, plain calls may reuse the existing grant and read live Claude quota.
-- Claude credential discovery honors `$CLAUDE_CONFIG_DIR` for both `.credentials.json` and the path-hashed macOS Keychain service; custom-home Keychain markers are namespaced by that literal config path.
-- Claude quota reads also query the first-party `/api/oauth/profile` endpoint with the same OAuth credential. Only the authoritative root `account.uuid` is normalized as `account.accountId`; unrecognized responses are marked `identityStatus: unverified`, and account identity is never cached.
+- Managed-profile, Claude identity, and Codex executable-override contracts are documented in [README Security Posture](README.md#security-posture).
 - `--allow-keychain-prompt` is the first-time opt-in that permits the Claude Keychain value read which can prompt, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
 - Codex uses `$CODEX_HOME/auth.json` or `~/.codex/auth.json` OAuth before the CLI fallback.
-- `$QUOTA_AXI_CODEX_BINARY` may pin the Codex auth inspection and app-server fallback to one absolute executable path; invalid or non-executable overrides fail closed instead of falling back to `PATH`.
 - Codex `auth.json` support is OAuth-token only; never treat `OPENAI_API_KEY` as valid quota auth or send API keys to ChatGPT quota endpoints.
 - Never launch the Claude CLI to probe quota, because that would spend the quota being measured.
 - The read-only Codex app-server JSON-RPC probe is the only CLI fallback.

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 | Provider       | Credential sources read                                                                                                                                                                                                                                          |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Claude         | `$CLAUDE_CONFIG_DIR/.credentials.json` or `~/.claude/.credentials.json`; on macOS, the corresponding default or path-hashed Claude Code Keychain value with `--allow-keychain-prompt` or, after a profile-scoped non-secret access marker exists, on plain calls |
-| Codex          | `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback                                                                                                                                                                                |
+| Codex          | `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback; `$QUOTA_AXI_CODEX_BINARY` can pin that fallback to an absolute executable path                                                                                                |
 | Cursor         | `$CURSOR_STATE_DB` when set or the platform Cursor state database path                                                                                                                                                                                           |
 | GitHub Copilot | `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file                                                                                                                                                                                         |
 | Grok           | `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`                                                                                                                                                       |
@@ -308,11 +308,13 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 - quota-axi records the non-secret access marker after any successful Keychain value read.
 - When that marker exists, plain calls read the Keychain value again so an already-approved "Always Allow" grant keeps live Claude quota fresh.
 - Without the flag or marker, quota-axi may perform a non-secret Keychain item presence check so it only suggests Keychain access when a Claude credential item exists.
+- After a successful usage read, quota-axi queries Anthropic's first-party OAuth profile endpoint with the same credential. Its authoritative root `account.uuid` is exposed as `account.accountId` only in `--full` output; if that field is absent, `identityStatus` is `unverified` instead of deriving an identity from email, organization data, or cached account metadata.
 
 **Codex**
 
 - Codex `auth.json` support is OAuth-token only; API key values such as `OPENAI_API_KEY` are treated as invalid for quota usage calls and are not sent to ChatGPT usage endpoints.
 - It may run `codex -s read-only -a untrusted app-server` for Codex JSON-RPC fallback.
+- Set `QUOTA_AXI_CODEX_BINARY` to an absolute executable path when the fallback must use a specific Codex installation. Auth inspection and the app-server probe resolve the same path, and an invalid override fails closed instead of consulting `PATH`.
 
 **Cursor**
 

--- a/README.md
+++ b/README.md
@@ -293,13 +293,13 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 
 ### Provider credential sources
 
-| Provider       | Credential sources read                                                                                                                                                          |
-| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude         | `~/.claude/.credentials.json`; on macOS, the `Claude Code-credentials` Keychain value with `--allow-keychain-prompt` or, after a non-secret access marker exists, on plain calls |
-| Codex          | `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback                                                                                                |
-| Cursor         | `$CURSOR_STATE_DB` when set or the platform Cursor state database path                                                                                                           |
-| GitHub Copilot | `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file                                                                                                         |
-| Grok           | `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`                                                                       |
+| Provider       | Credential sources read                                                                                                                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Claude         | `$CLAUDE_CONFIG_DIR/.credentials.json` or `~/.claude/.credentials.json`; on macOS, the corresponding default or path-hashed Claude Code Keychain value with `--allow-keychain-prompt` or, after a profile-scoped non-secret access marker exists, on plain calls |
+| Codex          | `$CODEX_HOME/auth.json` or `~/.codex/auth.json` before the read-only CLI fallback                                                                                                                                                                                |
+| Cursor         | `$CURSOR_STATE_DB` when set or the platform Cursor state database path                                                                                                                                                                                           |
+| GitHub Copilot | `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file                                                                                                                                                                                         |
+| Grok           | `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`                                                                                                                                                       |
 
 ### Provider notes
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ auth[7]{provider,source,path,status,error}:
   claude,oauth-file,~/.claude/.credentials.json,available,none
   claude,keychain,none,skipped,keychain_prompt_required
   codex,auth-json,~/.codex/auth.json,available,none
-  codex,cli-rpc,none,available,none
+  codex,cli-rpc,~/.local/bin/codex,available,none
   cursor,state-vscdb,~/Library/Application Support/Cursor/User/globalStorage/state.vscdb,available,none
   copilot,apps-json,~/.config/github-copilot/apps.json,available,none
   grok,auth-json,~/.grok/auth.json,available,none
@@ -224,8 +224,10 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 | Quota report                  | `providers`                                                                                |
 | Provider report               | `provider`, `label`, `source`, `windows`, `state`, optional `plan`, and optional `credits` |
 | Provider report with `--full` | Optional `account` identity and per-source `attempts`                                      |
+| Account identity (`--full`)   | Optional `email`, `organization`, `accountId`, and `identityStatus`                        |
 
 Account identity and per-source `attempts` are omitted unless `--full` is passed.
+Claude `identityStatus` is `verified` only when Anthropic returns an authoritative account identifier; `email` and `organization` are display-only and must not be used for duplicate detection.
 
 ### Provider `state`
 
@@ -342,15 +344,15 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 
 ### Cache
 
-| Item                                   | Behavior                                                                                                                                |
-| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Quota cache                            | Lives at `~/.cache/quota-axi/quotas.json` or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set.                           |
-| Quota cache permissions                | Uses `0600` file permissions.                                                                                                           |
-| Quota cache contents                   | Stores normalized non-secret snapshots only.                                                                                            |
-| Claude Keychain access marker          | Lives alongside the quota cache as `claude-keychain-access-granted`, uses `0600` file permissions, and contains no credential material. |
-| Cached reports                         | Only fresh provider snapshots with windows are cached.                                                                                  |
-| Fresh provider reports with no windows | Clear any cached snapshot for that provider, so entitlement-only reports do not leave stale quota windows behind.                       |
-| Reports and details not cached         | Failed providers, stale providers, account identity, and source attempts are not cached.                                                |
+| Item                                   | Behavior                                                                                                                                                                                                                                      |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Quota cache                            | Lives at `~/.cache/quota-axi/quotas.json` or under `$XDG_CACHE_HOME/quota-axi/` when `XDG_CACHE_HOME` is set.                                                                                                                                 |
+| Quota cache permissions                | Uses `0600` file permissions.                                                                                                                                                                                                                 |
+| Quota cache contents                   | Stores normalized non-secret snapshots only.                                                                                                                                                                                                  |
+| Claude Keychain access marker          | Lives alongside the quota cache as `claude-keychain-access-granted` for the default profile or with an eight-character path-hash suffix for a `$CLAUDE_CONFIG_DIR` profile; uses `0600` file permissions and contains no credential material. |
+| Cached reports                         | Only fresh provider snapshots with windows are cached.                                                                                                                                                                                        |
+| Fresh provider reports with no windows | Clear any cached snapshot for that provider, so entitlement-only reports do not leave stale quota windows behind.                                                                                                                             |
+| Reports and details not cached         | Failed providers, stale providers, account identity, and source attempts are not cached.                                                                                                                                                      |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ quota-axi --provider claude --json
       "state": {
         "status": "fresh",
         "stale": false,
-        "sourcesTried": ["oauth"],
+        "sourcesTried": ["oauth", "oauth-profile"],
         "refreshedAt": "2026-03-15T16:41:55.000Z"
       }
     }

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -68,8 +68,9 @@ examples:
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
-- Claude `--full` output includes the authoritative OAuth profile `account.uuid` when Anthropic
-  returns one; otherwise the account identity is explicitly marked unverified rather than inferred.
+- Claude `--full` output exposes the authoritative OAuth profile `account.uuid` as
+  `account.accountId` when Anthropic returns one; otherwise the account identity is explicitly
+  marked unverified rather than inferred.
 - The quota cache at `~/.cache/quota-axi/quotas.json` only ever holds normalized
   non-secret snapshots.
   Fresh provider reports with no windows clear stale provider snapshots instead of caching

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -39,6 +39,9 @@ or when comparing supported local provider headroom side by side.
    `quota-axi --allow-keychain-prompt` once and approve Keychain access ("Always Allow").
    After that successful grant, plain `quota-axi` calls reuse the existing Keychain access
    marker to refresh live Claude quota without requiring the flag.
+7. For a managed Codex installation, set `QUOTA_AXI_CODEX_BINARY` to its absolute executable
+   path. quota-axi uses that exact executable for auth inspection and the read-only app-server
+   fallback, and fails closed if the override is invalid.
 
 ## Usage
 
@@ -65,6 +68,8 @@ examples:
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
+- Claude `--full` output includes the authoritative OAuth profile `account.uuid` when Anthropic
+  returns one; otherwise the account identity is explicitly marked unverified rather than inferred.
 - The quota cache at `~/.cache/quota-axi/quotas.json` only ever holds normalized
   non-secret snapshots.
   Fresh provider reports with no windows clear stale provider snapshots instead of caching

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 
@@ -47,8 +48,11 @@ export function cacheFilePath(): string {
   return join(cacheDirPath(), "quotas.json");
 }
 
-export function claudeKeychainAccessMarkerPath(): string {
-  return join(cacheDirPath(), "claude-keychain-access-granted");
+export function claudeKeychainAccessMarkerPath(configDir?: string): string {
+  const suffix = configDir
+    ? `-${createHash("sha256").update(configDir).digest("hex").slice(0, 8)}`
+    : "";
+  return join(cacheDirPath(), `claude-keychain-access-granted${suffix}`);
 }
 
 function cacheDirPath(): string {

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -49,9 +49,10 @@ export function cacheFilePath(): string {
 }
 
 export function claudeKeychainAccessMarkerPath(configDir?: string): string {
-  const suffix = configDir
-    ? `-${createHash("sha256").update(configDir).digest("hex").slice(0, 8)}`
-    : "";
+  const suffix =
+    configDir === undefined
+      ? ""
+      : `-${createHash("sha256").update(configDir).digest("hex").slice(0, 8)}`;
   return join(cacheDirPath(), `claude-keychain-access-granted${suffix}`);
 }
 

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -49,10 +49,9 @@ export function cacheFilePath(): string {
 }
 
 export function claudeKeychainAccessMarkerPath(configDir?: string): string {
-  const suffix =
-    configDir === undefined
-      ? ""
-      : `-${createHash("sha256").update(configDir).digest("hex").slice(0, 8)}`;
+  const suffix = configDir
+    ? `-${createHash("sha256").update(configDir).digest("hex").slice(0, 8)}`
+    : "";
   return join(cacheDirPath(), `claude-keychain-access-granted${suffix}`);
 }
 

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -65,6 +65,11 @@ type ClaudeIdentityResult = {
   account: ClaudeAccount;
   error?: string;
 };
+type ClaudeProfileLocations = {
+  credentialFile: string;
+  keychainService: string;
+  keychainAccessMarker: string;
+};
 
 type RawUsageWindow = {
   utilization?: unknown;
@@ -203,15 +208,15 @@ export async function fetchQuota(
 export async function inspectAuth(
   options: ProviderOptions,
 ): Promise<AuthProviderReport> {
-  const credentialFile = claudeCredentialFile();
-  const states = await readCredentialStates(options);
+  const locations = resolveClaudeProfileLocations();
+  const states = await readCredentialStates(options, locations);
   const sources = states.map((state): AuthSourceReport => {
     if (state.status === "available") {
       return {
         source: state.credentials.source,
         path:
           state.credentials.source === "oauth-file"
-            ? credentialFile
+            ? locations.credentialFile
             : undefined,
         status: "available",
       };
@@ -352,30 +357,32 @@ function slugify(value: string): string {
 
 async function readCredentialStates(
   options: ProviderOptions,
+  locations = resolveClaudeProfileLocations(),
 ): Promise<CredentialState[]> {
   const states: CredentialState[] = [];
-  const credentialFile = claudeCredentialFile();
 
   const fileState = extractCredentialState(
-    readJsonFileResult(credentialFile),
+    readJsonFileResult(locations.credentialFile),
     "oauth-file",
-    credentialFile,
+    locations.credentialFile,
   );
   states.push(fileState);
 
   if (process.platform === "darwin") {
-    if (options.allowKeychainPrompt || hasKeychainAccessMarker()) {
-      states.push(await readKeychainCredentialState());
+    if (options.allowKeychainPrompt || hasKeychainAccessMarker(locations)) {
+      states.push(await readKeychainCredentialState(locations));
     } else {
-      states.push(await readSkippedKeychainCredentialState());
+      states.push(await readSkippedKeychainCredentialState(locations));
     }
   }
 
   return states;
 }
 
-async function readSkippedKeychainCredentialState(): Promise<CredentialState> {
-  const presence = await readKeychainItemPresence();
+async function readSkippedKeychainCredentialState(
+  locations: ClaudeProfileLocations,
+): Promise<CredentialState> {
+  const presence = await readKeychainItemPresence(locations);
   if (presence === "present") {
     return {
       status: "skipped",
@@ -403,11 +410,13 @@ async function readSkippedKeychainCredentialState(): Promise<CredentialState> {
   };
 }
 
-async function readKeychainItemPresence(): Promise<KeychainItemPresence> {
+async function readKeychainItemPresence(
+  locations: ClaudeProfileLocations,
+): Promise<KeychainItemPresence> {
   try {
     await execFileText(
       "security",
-      ["find-generic-password", "-s", claudeKeychainService()],
+      ["find-generic-password", "-s", locations.keychainService],
       KEYCHAIN_PRESENCE_TIMEOUT_MS,
     );
     return "present";
@@ -416,18 +425,20 @@ async function readKeychainItemPresence(): Promise<KeychainItemPresence> {
   }
 }
 
-async function readKeychainCredentialState(): Promise<CredentialState> {
+async function readKeychainCredentialState(
+  locations: ClaudeProfileLocations,
+): Promise<CredentialState> {
   let blob: string;
   try {
     blob = await execFileText(
       "security",
-      ["find-generic-password", "-s", claudeKeychainService(), "-w"],
+      ["find-generic-password", "-s", locations.keychainService, "-w"],
       KEYCHAIN_PROMPT_TIMEOUT_MS,
     );
   } catch (error) {
     return keychainFailureState(error);
   }
-  writeKeychainAccessMarkerBestEffort();
+  writeKeychainAccessMarkerBestEffort(locations);
   try {
     return extractCredentialState(
       { status: "success", value: JSON.parse(blob) },
@@ -445,15 +456,15 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
   }
 }
 
-function hasKeychainAccessMarker(): boolean {
-  return existsSync(
-    claudeKeychainAccessMarkerPath(process.env.CLAUDE_CONFIG_DIR),
-  );
+function hasKeychainAccessMarker(locations: ClaudeProfileLocations): boolean {
+  return existsSync(locations.keychainAccessMarker);
 }
 
-function writeKeychainAccessMarkerBestEffort(): void {
+function writeKeychainAccessMarkerBestEffort(
+  locations: ClaudeProfileLocations,
+): void {
   try {
-    const file = claudeKeychainAccessMarkerPath(process.env.CLAUDE_CONFIG_DIR);
+    const file = locations.keychainAccessMarker;
     ensurePrivateParent(file);
     const temp = `${file}.${process.pid}.tmp`;
     writeFileSync(temp, "granted\n", { mode: 0o600 });
@@ -466,15 +477,28 @@ function writeKeychainAccessMarkerBestEffort(): void {
 }
 
 export function claudeCredentialFile(): string {
-  return join(
-    process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"),
-    ".credentials.json",
-  );
+  return resolveClaudeProfileLocations().credentialFile;
 }
 
 export function claudeKeychainService(): string {
-  const configDir = process.env.CLAUDE_CONFIG_DIR;
-  if (!configDir) return DEFAULT_KEYCHAIN_SERVICE;
+  return resolveClaudeProfileLocations().keychainService;
+}
+
+function resolveClaudeProfileLocations(): ClaudeProfileLocations {
+  const configuredDir = process.env.CLAUDE_CONFIG_DIR;
+  const configDir = (configuredDir ?? join(homedir(), ".claude")).normalize(
+    "NFC",
+  );
+  const profileConfigDir = configuredDir === undefined ? undefined : configDir;
+  return {
+    credentialFile: join(configDir, ".credentials.json"),
+    keychainService: keychainServiceForConfigDir(profileConfigDir),
+    keychainAccessMarker: claudeKeychainAccessMarkerPath(profileConfigDir),
+  };
+}
+
+function keychainServiceForConfigDir(configDir?: string): string {
+  if (configDir === undefined) return DEFAULT_KEYCHAIN_SERVICE;
   const suffix = createHash("sha256")
     .update(configDir)
     .digest("hex")

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -489,16 +489,16 @@ function resolveClaudeProfileLocations(): ClaudeProfileLocations {
   const configDir = (configuredDir ?? join(homedir(), ".claude")).normalize(
     "NFC",
   );
-  const profileConfigDir = configuredDir === undefined ? undefined : configDir;
+  const keychainConfigDir = configuredDir ? configDir : undefined;
   return {
     credentialFile: join(configDir, ".credentials.json"),
-    keychainService: keychainServiceForConfigDir(profileConfigDir),
-    keychainAccessMarker: claudeKeychainAccessMarkerPath(profileConfigDir),
+    keychainService: keychainServiceForConfigDir(keychainConfigDir),
+    keychainAccessMarker: claudeKeychainAccessMarkerPath(keychainConfigDir),
   };
 }
 
 function keychainServiceForConfigDir(configDir?: string): string {
-  if (configDir === undefined) return DEFAULT_KEYCHAIN_SERVICE;
+  if (!configDir) return DEFAULT_KEYCHAIN_SERVICE;
   const suffix = createHash("sha256")
     .update(configDir)
     .digest("hex")

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -1,4 +1,5 @@
 import { chmodSync, existsSync, renameSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { readCachedProvider } from "../cache.js";
@@ -35,8 +36,7 @@ const API_TIMEOUT_MS = 15_000;
 const KEYCHAIN_PROMPT_TIMEOUT_MS = 60_000;
 const KEYCHAIN_PRESENCE_TIMEOUT_MS = 5_000;
 const KEYCHAIN_ITEM_NOT_FOUND_EXIT_CODE = 44;
-const CREDENTIAL_FILE = join(homedir(), ".claude", ".credentials.json");
-const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const DEFAULT_KEYCHAIN_SERVICE = "Claude Code-credentials";
 
 type ClaudeCredentials = {
   source: "oauth-file" | "keychain";
@@ -188,6 +188,7 @@ export async function fetchQuota(
 export async function inspectAuth(
   options: ProviderOptions,
 ): Promise<AuthProviderReport> {
+  const credentialFile = claudeCredentialFile();
   const states = await readCredentialStates(options);
   const sources = states.map((state): AuthSourceReport => {
     if (state.status === "available") {
@@ -195,7 +196,7 @@ export async function inspectAuth(
         source: state.credentials.source,
         path:
           state.credentials.source === "oauth-file"
-            ? CREDENTIAL_FILE
+            ? credentialFile
             : undefined,
         status: "available",
       };
@@ -311,11 +312,12 @@ async function readCredentialStates(
   options: ProviderOptions,
 ): Promise<CredentialState[]> {
   const states: CredentialState[] = [];
+  const credentialFile = claudeCredentialFile();
 
   const fileState = extractCredentialState(
-    readJsonFileResult(CREDENTIAL_FILE),
+    readJsonFileResult(credentialFile),
     "oauth-file",
-    CREDENTIAL_FILE,
+    credentialFile,
   );
   states.push(fileState);
 
@@ -363,7 +365,7 @@ async function readKeychainItemPresence(): Promise<KeychainItemPresence> {
   try {
     await execFileText(
       "security",
-      ["find-generic-password", "-s", KEYCHAIN_SERVICE],
+      ["find-generic-password", "-s", claudeKeychainService()],
       KEYCHAIN_PRESENCE_TIMEOUT_MS,
     );
     return "present";
@@ -377,7 +379,7 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
   try {
     blob = await execFileText(
       "security",
-      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-w"],
+      ["find-generic-password", "-s", claudeKeychainService(), "-w"],
       KEYCHAIN_PROMPT_TIMEOUT_MS,
     );
   } catch (error) {
@@ -402,12 +404,14 @@ async function readKeychainCredentialState(): Promise<CredentialState> {
 }
 
 function hasKeychainAccessMarker(): boolean {
-  return existsSync(claudeKeychainAccessMarkerPath());
+  return existsSync(
+    claudeKeychainAccessMarkerPath(process.env.CLAUDE_CONFIG_DIR),
+  );
 }
 
 function writeKeychainAccessMarkerBestEffort(): void {
   try {
-    const file = claudeKeychainAccessMarkerPath();
+    const file = claudeKeychainAccessMarkerPath(process.env.CLAUDE_CONFIG_DIR);
     ensurePrivateParent(file);
     const temp = `${file}.${process.pid}.tmp`;
     writeFileSync(temp, "granted\n", { mode: 0o600 });
@@ -417,6 +421,23 @@ function writeKeychainAccessMarkerBestEffort(): void {
   } catch {
     return;
   }
+}
+
+export function claudeCredentialFile(): string {
+  return join(
+    process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"),
+    ".credentials.json",
+  );
+}
+
+export function claudeKeychainService(): string {
+  const configDir = process.env.CLAUDE_CONFIG_DIR;
+  if (!configDir) return DEFAULT_KEYCHAIN_SERVICE;
+  const suffix = createHash("sha256")
+    .update(configDir)
+    .digest("hex")
+    .slice(0, 8);
+  return `${DEFAULT_KEYCHAIN_SERVICE}-${suffix}`;
 }
 
 function isKeychainItemNotFound(error: unknown): boolean {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -30,6 +30,7 @@ import {
 } from "./common.js";
 
 const API_URL = "https://api.anthropic.com/api/oauth/usage";
+const PROFILE_API_URL = "https://api.anthropic.com/api/oauth/profile";
 const OAUTH_BETA = "oauth-2025-04-20";
 const CLAUDE_CODE_USER_AGENT = "claude-code/2.1.202";
 const API_TIMEOUT_MS = 15_000;
@@ -59,6 +60,11 @@ type CredentialState =
   | UnavailableCredentialState
   | SkippedCredentialState;
 type KeychainItemPresence = "present" | "missing" | "unknown";
+type ClaudeAccount = NonNullable<ProviderQuota["account"]>;
+type ClaudeIdentityResult = {
+  account: ClaudeAccount;
+  error?: string;
+};
 
 type RawUsageWindow = {
   utilization?: unknown;
@@ -142,6 +148,15 @@ export async function fetchQuota(
       try {
         const quota = await fetchOauthUsage(credential);
         attempts[attempts.length - 1] = { source: "oauth", status: "success" };
+        attempts.push(
+          quota.identityError
+            ? {
+                source: "oauth-profile",
+                status: "failed",
+                error: quota.identityError,
+              }
+            : { source: "oauth-profile", status: "success" },
+        );
         return successProvider({
           provider: "claude",
           label: "Claude",
@@ -237,6 +252,33 @@ export function normalizeClaudeApiUsage(
 
   if (windows.length === 0) return undefined;
   return { plan, windows, refreshedAt: nowIso() };
+}
+
+export function normalizeClaudeProfile(
+  raw: unknown,
+): ClaudeAccount | undefined {
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  const account = objectValue(data.account);
+  const accountId = stringValue(account?.uuid);
+  if (!accountId) return undefined;
+
+  const organization = objectValue(data.organization);
+  return {
+    accountId,
+    email:
+      stringValue(account?.email) ??
+      stringValue(account?.email_address) ??
+      stringValue(account?.emailAddress) ??
+      stringValue(data.email_address) ??
+      stringValue(data.emailAddress) ??
+      stringValue(data.email),
+    organization:
+      stringValue(organization?.name) ??
+      stringValue(data.organization_name) ??
+      stringValue(data.organizationName),
+    identityStatus: "verified",
+  };
 }
 
 function normalizeScopedLimits(raw: unknown): QuotaWindow[] {
@@ -516,6 +558,7 @@ function extractCredentialState(
 async function fetchOauthUsage(credentials: ClaudeCredentials): Promise<{
   plan?: string;
   account?: ProviderQuota["account"];
+  identityError?: string;
   windows: QuotaWindow[];
   refreshedAt: string;
 }> {
@@ -538,10 +581,58 @@ async function fetchOauthUsage(credentials: ClaudeCredentials): Promise<{
       credentials.plan,
     );
     if (!quota) throw new Error("Claude quota unavailable");
-    return quota;
+    const identity = await fetchOauthProfile(credentials);
+    return {
+      ...quota,
+      account: identity.account,
+      identityError: identity.error,
+    };
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function fetchOauthProfile(
+  credentials: ClaudeCredentials,
+): Promise<ClaudeIdentityResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const response = await fetch(PROFILE_API_URL, {
+      headers: {
+        authorization: `Bearer ${credentials.accessToken}`,
+        "User-Agent": CLAUDE_CODE_USER_AGENT,
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+        accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      return unverifiedClaudeIdentity(
+        `identity_profile_http_${response.status}`,
+      );
+    }
+    const account = normalizeClaudeProfile(await response.json());
+    return account
+      ? { account }
+      : unverifiedClaudeIdentity("identity_profile_unrecognized");
+  } catch (error) {
+    return unverifiedClaudeIdentity(
+      error instanceof Error && error.name === "AbortError"
+        ? "identity_profile_timeout"
+        : "identity_profile_unavailable",
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function unverifiedClaudeIdentity(error: string): ClaudeIdentityResult {
+  return {
+    account: { identityStatus: "unverified" },
+    error,
+  };
 }
 
 // Anthropic's OAuth usage endpoint follows plain HTTP semantics: 401/403 mean

--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -1,9 +1,9 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { spawn } from "node:child_process";
 import { readCachedProvider } from "../cache.js";
 import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
-import { commandExists, terminateChild } from "../lib/process.js";
+import { findCommandPath, terminateChild } from "../lib/process.js";
 import {
   clampPercent,
   nowIso,
@@ -35,6 +35,11 @@ const ENDPOINTS = [
 const API_TIMEOUT_MS = 15_000;
 const CLI_TIMEOUT_MS = 15_000;
 const RPC_TIMEOUT_MS = 8_000;
+const CODEX_BINARY_ENV = "QUOTA_AXI_CODEX_BINARY";
+
+type CodexBinaryState =
+  | { status: "available"; path: string }
+  | { status: "missing"; path?: string; error?: string };
 
 type CodexCredentials = {
   accessToken: string;
@@ -161,13 +166,16 @@ export async function inspectAuth(
 ): Promise<AuthProviderReport> {
   const authFile = codexAuthFile();
   const credentialState = readCredentialState(authFile);
+  const binary = await resolveCodexBinary();
   return {
     provider: "codex",
     sources: [
       credentialState.source,
       {
         source: "cli-rpc",
-        status: (await commandExists("codex")) ? "available" : "missing",
+        path: binary.path,
+        status: binary.status,
+        error: binary.status === "missing" ? binary.error : undefined,
       },
     ],
   };
@@ -461,10 +469,12 @@ async function probeCodexCli(): Promise<{
   credits?: ProviderQuota["credits"];
   refreshedAt: string;
 }> {
-  if (!(await commandExists("codex")))
-    throw new Error("Codex quota unavailable");
+  const binary = await resolveCodexBinary();
+  if (binary.status === "missing") {
+    throw new Error(codexBinaryErrorMessage(binary));
+  }
   const child = spawn(
-    "codex",
+    binary.path,
     ["-s", "read-only", "-a", "untrusted", "app-server"],
     {
       stdio: ["pipe", "pipe", "pipe"],
@@ -568,6 +578,45 @@ async function probeCodexCli(): Promise<{
   } finally {
     terminateChild(child);
   }
+}
+
+async function resolveCodexBinary(): Promise<CodexBinaryState> {
+  const configured = process.env[CODEX_BINARY_ENV];
+  if (configured !== undefined) {
+    const path = configured.trim();
+    if (!path || !isAbsolute(path)) {
+      return {
+        status: "missing",
+        error: "codex_binary_override_not_absolute",
+      };
+    }
+    const executable = await findCommandPath(path);
+    if (!executable) {
+      return {
+        status: "missing",
+        path,
+        error: "codex_binary_override_not_executable",
+      };
+    }
+    return { status: "available", path: executable };
+  }
+
+  const executable = await findCommandPath("codex");
+  return executable
+    ? { status: "available", path: executable }
+    : { status: "missing" };
+}
+
+function codexBinaryErrorMessage(
+  binary: Extract<CodexBinaryState, { status: "missing" }>,
+): string {
+  if (binary.error === "codex_binary_override_not_absolute") {
+    return "Configured Codex binary must be an absolute executable path";
+  }
+  if (binary.error === "codex_binary_override_not_executable") {
+    return "Configured Codex binary is not executable";
+  }
+  return "Codex quota unavailable";
 }
 
 function sendRpc(

--- a/src/render.ts
+++ b/src/render.ts
@@ -59,6 +59,7 @@ export function renderQuotaToon(
       email: provider.account?.email ?? "hidden",
       organization: provider.account?.organization ?? "none",
       accountId: provider.account?.accountId ?? "none",
+      identityStatus: provider.account?.identityStatus ?? "unknown",
     }));
     const attempts = response.providers.flatMap((provider) =>
       (provider.attempts ?? []).map((attempt) => attemptRow(provider, attempt)),

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -80,6 +80,9 @@ or when comparing supported local provider headroom side by side.
    \`quota-axi --allow-keychain-prompt\` once and approve Keychain access ("Always Allow").
    After that successful grant, plain \`quota-axi\` calls reuse the existing Keychain access
    marker to refresh live Claude quota without requiring the flag.
+7. For a managed Codex installation, set \`QUOTA_AXI_CODEX_BINARY\` to its absolute executable
+   path. quota-axi uses that exact executable for auth inspection and the read-only app-server
+   fallback, and fails closed if the override is invalid.
 
 ## Usage
 
@@ -95,6 +98,8 @@ ${TOP_HELP.trimEnd()}
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
+- Claude \`--full\` output includes the authoritative OAuth profile \`account.uuid\` when Anthropic
+  returns one; otherwise the account identity is explicitly marked unverified rather than inferred.
 - The quota cache at \`~/.cache/quota-axi/quotas.json\` only ever holds normalized
   non-secret snapshots.
   Fresh provider reports with no windows clear stale provider snapshots instead of caching

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -98,8 +98,9 @@ ${TOP_HELP.trimEnd()}
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
-- Claude \`--full\` output includes the authoritative OAuth profile \`account.uuid\` when Anthropic
-  returns one; otherwise the account identity is explicitly marked unverified rather than inferred.
+- Claude \`--full\` output exposes the authoritative OAuth profile \`account.uuid\` as
+  \`account.accountId\` when Anthropic returns one; otherwise the account identity is explicitly
+  marked unverified rather than inferred.
 - The quota cache at \`~/.cache/quota-axi/quotas.json\` only ever holds normalized
   non-secret snapshots.
   Fresh provider reports with no windows clear stale provider snapshots instead of caching

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type ProviderQuota = {
     email?: string;
     organization?: string;
     accountId?: string;
+    identityStatus?: "verified" | "unverified";
   };
   windows: QuotaWindow[];
   credits?: {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -61,6 +61,7 @@ describe("quota cache", () => {
       payload.providers.find((provider) => provider.provider === "codex")
         ?.windows[0].percentUsed,
     ).toBe(20);
+    expect(payload.providers.every((provider) => !provider.account)).toBe(true);
   });
 
   it("clears a stale snapshot after a fresh no-window report", () => {
@@ -98,7 +99,11 @@ function quota(provider: ProviderId, percentUsed: number): ProviderQuota {
       refreshedAt: "2026-07-06T18:10:00Z",
       sourcesTried: ["oauth"],
     },
-    account: { email: "person@example.invalid" },
+    account: {
+      email: "person@example.invalid",
+      accountId: "fixture-account",
+      identityStatus: "verified",
+    },
     attempts: [{ source: "oauth", status: "success" }],
   };
 }

--- a/test/fixtures/claude/oauth-profile.json
+++ b/test/fixtures/claude/oauth-profile.json
@@ -1,0 +1,10 @@
+{
+  "account": {
+    "uuid": "11111111-2222-4333-8444-555555555555",
+    "email": "person@example.invalid"
+  },
+  "organization": {
+    "uuid": "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    "name": "Fixture Organization"
+  }
+}

--- a/test/lib/fs.test.ts
+++ b/test/lib/fs.test.ts
@@ -63,7 +63,7 @@ describe("cache paths", () => {
       /^\/tmp\/quota-cache\/quota-axi\/claude-keychain-access-granted-[0-9a-f]{8}$/,
     );
     expect(claudeKeychainAccessMarkerPath("")).toBe(
-      "/tmp/quota-cache/quota-axi/claude-keychain-access-granted-e3b0c442",
+      "/tmp/quota-cache/quota-axi/claude-keychain-access-granted",
     );
   });
 });

--- a/test/lib/fs.test.ts
+++ b/test/lib/fs.test.ts
@@ -59,5 +59,8 @@ describe("cache paths", () => {
     expect(claudeKeychainAccessMarkerPath()).toBe(
       "/tmp/quota-cache/quota-axi/claude-keychain-access-granted",
     );
+    expect(claudeKeychainAccessMarkerPath("/tmp/claude-profile")).toMatch(
+      /^\/tmp\/quota-cache\/quota-axi\/claude-keychain-access-granted-[0-9a-f]{8}$/,
+    );
   });
 });

--- a/test/lib/fs.test.ts
+++ b/test/lib/fs.test.ts
@@ -62,5 +62,8 @@ describe("cache paths", () => {
     expect(claudeKeychainAccessMarkerPath("/tmp/claude-profile")).toMatch(
       /^\/tmp\/quota-cache\/quota-axi\/claude-keychain-access-granted-[0-9a-f]{8}$/,
     );
+    expect(claudeKeychainAccessMarkerPath("")).toBe(
+      "/tmp/quota-cache/quota-axi/claude-keychain-access-granted-e3b0c442",
+    );
   });
 });

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -120,7 +120,6 @@ describe("Claude credential-state reporting", () => {
     usePlatform("darwin");
     const home = useTempHome();
     process.env.CLAUDE_CONFIG_DIR = "";
-    const suffix = createHash("sha256").update("").digest("hex").slice(0, 8);
     const { claudeKeychainAccessMarkerPath } =
       await import("../../src/lib/fs.js");
     const marker = claudeKeychainAccessMarkerPath("");
@@ -142,21 +141,11 @@ describe("Claude credential-state reporting", () => {
 
     expect(claudeCredentialFile()).toBe(".credentials.json");
     expect(marker).toBe(
-      join(
-        home,
-        "cache",
-        "quota-axi",
-        `claude-keychain-access-granted-${suffix}`,
-      ),
+      join(home, "cache", "quota-axi", "claude-keychain-access-granted"),
     );
     expect(execFileText).toHaveBeenCalledWith(
       "security",
-      [
-        "find-generic-password",
-        "-s",
-        `Claude Code-credentials-${suffix}`,
-        "-w",
-      ],
+      ["find-generic-password", "-s", "Claude Code-credentials", "-w"],
       expect.any(Number),
     );
     expect(auth.sources).toContainEqual({

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -116,6 +116,114 @@ describe("Claude credential-state reporting", () => {
     );
   });
 
+  it("preserves an empty-present CLAUDE_CONFIG_DIR across profile derivations", async () => {
+    usePlatform("darwin");
+    const home = useTempHome();
+    process.env.CLAUDE_CONFIG_DIR = "";
+    const suffix = createHash("sha256").update("").digest("hex").slice(0, 8);
+    const { claudeKeychainAccessMarkerPath } =
+      await import("../../src/lib/fs.js");
+    const marker = claudeKeychainAccessMarkerPath("");
+    mkdirSync(dirname(marker), { recursive: true, mode: 0o700 });
+    writeFileSync(marker, "granted\n", { mode: 0o600 });
+    const execFileText = vi.fn(async () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-keychain-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+
+    const { claudeCredentialFile, inspectAuth } =
+      await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(claudeCredentialFile()).toBe(".credentials.json");
+    expect(marker).toBe(
+      join(
+        home,
+        "cache",
+        "quota-axi",
+        `claude-keychain-access-granted-${suffix}`,
+      ),
+    );
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      [
+        "find-generic-password",
+        "-s",
+        `Claude Code-credentials-${suffix}`,
+        "-w",
+      ],
+      expect.any(Number),
+    );
+    expect(auth.sources).toContainEqual({
+      source: "keychain",
+      status: "available",
+    });
+  });
+
+  it("normalizes a decomposed CLAUDE_CONFIG_DIR before profile derivations", async () => {
+    usePlatform("darwin");
+    const home = useTempHome();
+    const decomposedConfigDir = join(home, "managed-e\u0301");
+    const normalizedConfigDir = decomposedConfigDir.normalize("NFC");
+    process.env.CLAUDE_CONFIG_DIR = decomposedConfigDir;
+    mkdirSync(normalizedConfigDir, { recursive: true });
+    writeFileSync(
+      join(normalizedConfigDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-file-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    const { claudeKeychainAccessMarkerPath } =
+      await import("../../src/lib/fs.js");
+    const marker = claudeKeychainAccessMarkerPath(normalizedConfigDir);
+    mkdirSync(dirname(marker), { recursive: true, mode: 0o700 });
+    writeFileSync(marker, "granted\n", { mode: 0o600 });
+    const suffix = createHash("sha256")
+      .update(normalizedConfigDir)
+      .digest("hex")
+      .slice(0, 8);
+    const execFileText = vi.fn(async () =>
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-keychain-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+
+    const { inspectAuth } = await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(auth.sources[0]).toMatchObject({
+      source: "oauth-file",
+      path: join(normalizedConfigDir, ".credentials.json"),
+      status: "available",
+    });
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      [
+        "find-generic-password",
+        "-s",
+        `Claude Code-credentials-${suffix}`,
+        "-w",
+      ],
+      expect.any(Number),
+    );
+    expect(auth.sources).toContainEqual({
+      source: "keychain",
+      status: "available",
+    });
+  });
+
   it("surfaces expired file credentials as a skipped attempt and auth_required", async () => {
     const home = useTempHome();
     mkdirSync(join(home, ".claude"), { recursive: true });

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -209,6 +209,99 @@ describe("Claude credential-state reporting", () => {
     );
   });
 
+  it("fetches a profile with the same OAuth credential and exposes a verified account identity", async () => {
+    const home = useTempHome();
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      if (String(input).endsWith("/api/oauth/profile")) {
+        return new Response(
+          JSON.stringify({
+            account: {
+              uuid: "11111111-2222-4333-8444-555555555555",
+              email: "person@example.invalid",
+            },
+            organization: { name: "Fixture Organization" },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchQuota } = await import("../../src/providers/claude.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.account).toEqual({
+      accountId: "11111111-2222-4333-8444-555555555555",
+      email: "person@example.invalid",
+      organization: "Fixture Organization",
+      identityStatus: "verified",
+    });
+    expect(result.attempts).toContainEqual({
+      source: "oauth-profile",
+      status: "success",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.anthropic.com/api/oauth/profile",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          authorization: "Bearer fresh-token",
+          "Cache-Control": "no-cache",
+        }),
+      }),
+    );
+  });
+
+  it("marks identity unverified when the profile response lacks a stable account id", async () => {
+    const home = useTempHome();
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) =>
+        String(input).endsWith("/api/oauth/profile")
+          ? new Response(
+              JSON.stringify({ email_address: "person@example.invalid" }),
+              { status: 200 },
+            )
+          : new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+              status: 200,
+            }),
+      ),
+    );
+
+    const { fetchQuota } = await import("../../src/providers/claude.js");
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.account).toEqual({ identityStatus: "unverified" });
+    expect(result.attempts).toContainEqual({
+      source: "oauth-profile",
+      status: "failed",
+      error: "identity_profile_unrecognized",
+    });
+  });
+
   it("surfaces missing file credentials as a skipped attempt and auth_required", async () => {
     useTempHome();
 

--- a/test/providers/claude-auth.test.ts
+++ b/test/providers/claude-auth.test.ts
@@ -5,6 +5,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 let tempDir: string | undefined;
 
@@ -32,6 +34,9 @@ afterEach(() => {
   else process.env.USERPROFILE = originalUserProfile;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
+  if (originalClaudeConfigDir === undefined)
+    delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
   tempDir = undefined;
 });
@@ -52,6 +57,65 @@ function usePlatform(platform: NodeJS.Platform): void {
 }
 
 describe("Claude credential-state reporting", () => {
+  it("uses CLAUDE_CONFIG_DIR for file credentials", async () => {
+    const home = useTempHome();
+    const configDir = join(home, "managed-claude");
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, ".credentials.json"),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: "fresh-token",
+          expiresAt: "2035-01-01T00:00:00.000Z",
+        },
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ five_hour: { utilization: 12 } }), {
+            status: 200,
+          }),
+      ),
+    );
+
+    const { fetchQuota, inspectAuth } =
+      await import("../../src/providers/claude.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+    const result = await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(auth.sources[0]).toMatchObject({
+      source: "oauth-file",
+      path: join(configDir, ".credentials.json"),
+      status: "available",
+    });
+    expect(result.state.status).toBe("fresh");
+  });
+
+  it("derives the custom-config Keychain service from the literal config path", async () => {
+    usePlatform("darwin");
+    const home = useTempHome();
+    const configDir = join(home, "managed-claude");
+    process.env.CLAUDE_CONFIG_DIR = configDir;
+    const suffix = createHash("sha256")
+      .update(configDir)
+      .digest("hex")
+      .slice(0, 8);
+    const execFileText = vi.fn(async () => "");
+    vi.doMock("../../src/lib/process.js", () => ({ execFileText }));
+
+    const { inspectAuth } = await import("../../src/providers/claude.js");
+    await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(execFileText).toHaveBeenCalledWith(
+      "security",
+      ["find-generic-password", "-s", `Claude Code-credentials-${suffix}`],
+      expect.any(Number),
+    );
+  });
+
   it("surfaces expired file credentials as a skipped attempt and auth_required", async () => {
     const home = useTempHome();
     mkdirSync(join(home, ".claude"), { recursive: true });

--- a/test/providers/claude.test.ts
+++ b/test/providers/claude.test.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { normalizeClaudeApiUsage } from "../../src/providers/claude.js";
+import {
+  normalizeClaudeApiUsage,
+  normalizeClaudeProfile,
+} from "../../src/providers/claude.js";
 
 const fixtureDir = join(import.meta.dirname, "..", "fixtures", "claude");
 
@@ -84,5 +87,40 @@ describe("Claude quota parsing", () => {
         limitUsd: 20,
       },
     ]);
+  });
+});
+
+describe("Claude OAuth profile parsing", () => {
+  it("normalizes the stable account UUID and non-secret full-output fields", () => {
+    const raw = JSON.parse(
+      readFileSync(join(fixtureDir, "oauth-profile.json"), "utf8"),
+    ) as unknown;
+
+    expect(normalizeClaudeProfile(raw)).toEqual({
+      accountId: "11111111-2222-4333-8444-555555555555",
+      email: "person@example.invalid",
+      organization: "Fixture Organization",
+      identityStatus: "verified",
+    });
+  });
+
+  it("does not invent an identity from email or organization UUID", () => {
+    expect(
+      normalizeClaudeProfile({
+        email_address: "person@example.invalid",
+        organization: {
+          uuid: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not treat cached camelCase account metadata as an authoritative profile", () => {
+    expect(
+      normalizeClaudeProfile({
+        accountUuid: "11111111-2222-4333-8444-555555555555",
+        emailAddress: "person@example.invalid",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/test/providers/codex-auth.test.ts
+++ b/test/providers/codex-auth.test.ts
@@ -1,9 +1,13 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalCodexHome = process.env.CODEX_HOME;
+const originalCodexBinary = process.env.QUOTA_AXI_CODEX_BINARY;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
@@ -14,7 +18,7 @@ beforeEach(() => {
   process.env.CODEX_HOME = tempDir;
   process.env.XDG_CACHE_HOME = join(tempDir, "cache");
   vi.doMock("../../src/lib/process.js", () => ({
-    commandExists: vi.fn(async () => false),
+    findCommandPath: vi.fn(async () => undefined),
     terminateChild: vi.fn(),
   }));
 });
@@ -22,9 +26,13 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.doUnmock("../../src/lib/process.js");
+  vi.doUnmock("node:child_process");
   vi.resetModules();
   if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
   else process.env.CODEX_HOME = originalCodexHome;
+  if (originalCodexBinary === undefined)
+    delete process.env.QUOTA_AXI_CODEX_BINARY;
+  else process.env.QUOTA_AXI_CODEX_BINARY = originalCodexBinary;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -47,6 +55,83 @@ function jwt(payload: Record<string, unknown>): string {
 }
 
 describe("Codex credential-state reporting", () => {
+  it("uses the configured absolute executable for auth inspection and RPC fallback", async () => {
+    const binary = join(tempDir!, "pinned", "codex");
+    process.env.QUOTA_AXI_CODEX_BINARY = binary;
+    const findCommandPath = vi.fn(async (command: string) => command);
+    const terminateChild = vi.fn();
+    vi.doMock("../../src/lib/process.js", () => ({
+      findCommandPath,
+      terminateChild,
+    }));
+    const child = failingChild();
+    const spawn = vi.fn(() => {
+      queueMicrotask(() => child.emit("error", new Error("fixture stop")));
+      return child;
+    });
+    vi.doMock("node:child_process", () => ({ spawn }));
+
+    const { fetchQuota, inspectAuth } =
+      await import("../../src/providers/codex.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+    await fetchQuota({ allowKeychainPrompt: false });
+
+    expect(auth.sources[1]).toEqual({
+      source: "cli-rpc",
+      path: binary,
+      status: "available",
+    });
+    expect(findCommandPath).toHaveBeenCalledWith(binary);
+    expect(findCommandPath).not.toHaveBeenCalledWith("codex");
+    expect(spawn).toHaveBeenCalledWith(
+      binary,
+      ["-s", "read-only", "-a", "untrusted", "app-server"],
+      expect.any(Object),
+    );
+  });
+
+  it("fails closed instead of consulting PATH for a non-absolute override", async () => {
+    process.env.QUOTA_AXI_CODEX_BINARY = "codex-from-path";
+    const findCommandPath = vi.fn(async () => "/unexpected/codex");
+    vi.doMock("../../src/lib/process.js", () => ({
+      findCommandPath,
+      terminateChild: vi.fn(),
+    }));
+
+    const { inspectAuth } = await import("../../src/providers/codex.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(auth.sources[1]).toEqual({
+      source: "cli-rpc",
+      path: undefined,
+      status: "missing",
+      error: "codex_binary_override_not_absolute",
+    });
+    expect(findCommandPath).not.toHaveBeenCalled();
+  });
+
+  it("reports an absolute override that is not executable without falling back", async () => {
+    const binary = join(tempDir!, "missing", "codex");
+    process.env.QUOTA_AXI_CODEX_BINARY = binary;
+    const findCommandPath = vi.fn(async () => undefined);
+    vi.doMock("../../src/lib/process.js", () => ({
+      findCommandPath,
+      terminateChild: vi.fn(),
+    }));
+
+    const { inspectAuth } = await import("../../src/providers/codex.js");
+    const auth = await inspectAuth({ allowKeychainPrompt: false });
+
+    expect(auth.sources[1]).toEqual({
+      source: "cli-rpc",
+      path: binary,
+      status: "missing",
+      error: "codex_binary_override_not_executable",
+    });
+    expect(findCommandPath).toHaveBeenCalledOnce();
+    expect(findCommandPath).toHaveBeenCalledWith(binary);
+  });
+
   it("does not send OPENAI_API_KEY to ChatGPT OAuth usage endpoints", async () => {
     writeAuth({ OPENAI_API_KEY: "sk-test" });
     const fetchMock = vi.fn();
@@ -138,3 +223,16 @@ describe("Codex credential-state reporting", () => {
     });
   });
 });
+
+function failingChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as ChildProcessWithoutNullStreams;
+  Object.assign(child, {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    exitCode: null,
+    signalCode: null,
+    kill: vi.fn(() => true),
+  });
+  return child;
+}


### PR DESCRIPTION
## Intent

Ship the existing quota-axi managed-profile support to its existing GitHub repository without touching the default branch. Preserve profile-scoped Claude credential discovery via CLAUDE_CONFIG_DIR and its path-hashed macOS Keychain service. Add a fail-closed QUOTA_AXI_CODEX_BINARY absolute executable override used consistently by auth inspection and the read-only Codex app-server fallback so managed CODEX_HOME profiles do not accidentally execute a desktop/PATH binary. Query Anthropic's first-party /api/oauth/profile with the same OAuth bearer as usage and expose only authoritative root account.uuid as the non-secret Claude accountId for duplicate detection; email is display-only, identity is explicitly unverified when account.uuid is absent, and account identity must never be cached or inferred from email, organization, or cached metadata. Do not invoke provider login/logout or expose credential values. Validate code, tests, lint, docs, push the feature branch to the authorized ruby-dlee fork, and open a PR against kunchenguid/quota-axi main; do not merge.

## What Changed

- Respect `CLAUDE_CONFIG_DIR` across credential files, path-hashed Keychain services, and profile-scoped access markers, including normalized and empty-present paths.
- Query Anthropic’s OAuth profile after usage reads, exposing only verified root account UUIDs in `--full`, marking UUID-less identities unverified, and excluding account metadata from cache.
- Add a fail-closed `QUOTA_AXI_CODEX_BINARY` override shared by auth inspection and the read-only app-server fallback, with updated documentation and managed-profile regression coverage.

## Risk Assessment

✅ Low: The managed-profile edge cases now match Claude’s credential and Keychain naming behavior, and the remaining Claude identity and Codex override changes are consistently scoped and fail closed.

## Testing

After resolving the initial Node 20/pnpm mismatch with an installed Node 22 runtime, the frozen install, complete automated suite, generated documentation check, and isolated end-to-end CLI scenarios all passed; the transcript demonstrates profile-scoped Claude discovery and identity safety, identity-free 0600 caching, consistent pinned Codex execution, and fail-closed PATH behavior, with the worktree left clean.

<details>
<summary>Evidence: Managed-profile end-to-end CLI transcript</summary>

```text
Managed Claude auth inspection (custom credential path and path-hashed Keychain service)
{
  "generatedAt": "2026-07-18T03:20:44.628Z",
  "schemaVersion": 1,
  "auth": [
    {
      "provider": "claude",
      "sources": [
        {
          "source": "oauth-file",
          "path": "/var/folders/y_/bfdbj_vx20l9b9tw7crgkzwm0000gn/T/no-mistakes-evidence/01KXSHA5A3G51T6ZZVAJ3ACAB2/claude-profile/.credentials.json",
          "status": "available"
        },
        {
          "source": "keychain",
          "status": "missing"
        }
      ]
    }
  ]
}
{"expectedKeychainService":"Claude Code-credentials-54c91745","securityInvocation":"find-generic-password -s Claude Code-credentials-54c91745"}
Managed Claude quota with authoritative root account.uuid
[mock-anthropic] /api/oauth/usage oauth-bearer=matched
[mock-anthropic] /api/oauth/profile oauth-bearer=matched
{
  "generatedAt": "2026-07-18T03:20:45.098Z",
  "schemaVersion": 2,
  "providers": [
    {
      "provider": "claude",
      "label": "Claude",
      "source": "oauth",
      "plan": "Managed Pro",
      "account": {
        "accountId": "11111111-2222-4333-8444-555555555555",
        "email": "person@example.invalid",
        "organization": "Fixture Organization",
        "identityStatus": "verified"
      },
      "windows": [
        {
          "id": "five_hour",
          "label": "session",
          "kind": "session",
          "percentUsed": 18,
          "resetsAt": "2026-07-18T02:00:00.000Z",
          "percentRemaining": 82
        },
        {
          "id": "seven_day",
          "label": "week",
          "kind": "weekly",
          "percentUsed": 36,
          "resetsAt": "2026-07-24T02:00:00.000Z",
          "percentRemaining": 64
        }
      ],
      "attempts": [
        {
          "source": "keychain",
          "status": "skipped",
          "error": "credentials_missing"
        },
        {
          "source": "oauth",
          "status": "success"
        },
        {
          "source": "oauth-profile",
          "status": "success"
        }
      ],
      "state": {
        "status": "fresh",
        "stale": false,
        "refreshedAt": "2026-07-18T03:20:45.097Z",
        "sourcesTried": [
          "keychain",
          "oauth",
          "oauth-profile"
        ]
      }
    }
  ]
}
Managed Claude quota when profile has email and organization UUID but no root account.uuid
[mock-anthropic] /api/oauth/usage oauth-bearer=matched
[mock-anthropic] /api/oauth/profile oauth-bearer=matched
{
  "generatedAt": "2026-07-18T03:20:45.550Z",
  "schemaVersion": 2,
  "providers": [
    {
      "provider": "claude",
      "label": "Claude",
      "source": "oauth",
      "plan": "Managed Pro",
      "account": {
        "identityStatus": "unverified"
      },
      "windows": [
        {
          "id": "five_hour",
          "label": "session",
          "kind": "session",
          "percentUsed": 18,
          "resetsAt": "2026-07-18T02:00:00.000Z",
          "percentRemaining": 82
        },
        {
          "id": "seven_day",
          "label": "week",
          "kind": "weekly",
          "percentUsed": 36,
          "resetsAt": "2026-07-24T02:00:00.000Z",
          "percentRemaining": 64
        }
      ],
      "attempts": [
        {
          "source": "keychain",
          "status": "skipped",
          "error": "credentials_missing"
        },
        {
          "source": "oauth",
          "status": "success"
        },
        {
          "source": "oauth-profile",
          "status": "failed",
          "error": "identity_profile_unrecognized"
        }
      ],
      "state": {
        "status": "fresh",
        "stale": false,
        "refreshedAt": "2026-07-18T03:20:45.549Z",
        "sourcesTried": [
          "keychain",
          "oauth",
          "oauth-profile"
        ]
      }
    }
  ]
}
Persisted cache identity check
{"providerKeys":["provider","label","source","windows","state","plan"],"containsAccount":false,"containsIdentityText":false,"mode":"600"}
Managed Codex auth inspection with absolute executable override
{
  "generatedAt": "2026-07-18T03:20:46.017Z",
  "schemaVersion": 1,
  "auth": [
    {
      "provider": "codex",
      "sources": [
        {
          "source": "auth-json",
          "path": "/var/folders/y_/bfdbj_vx20l9b9tw7crgkzwm0000gn/T/no-mistakes-evidence/01KXSHA5A3G51T6ZZVAJ3ACAB2/codex-home/auth.json",
          "status": "missing"
        },
        {
          "source": "cli-rpc",
          "path": "/var/folders/y_/bfdbj_vx20l9b9tw7crgkzwm0000gn/T/no-mistakes-evidence/01KXSHA5A3G51T6ZZVAJ3ACAB2/pinned-codex",
          "status": "available"
        }
      ]
    }
  ]
}
Managed Codex read-only app-server fallback
{
  "generatedAt": "2026-07-18T03:20:46.499Z",
  "schemaVersion": 2,
  "providers": [
    {
      "provider": "codex",
      "label": "Codex",
      "source": "cli-rpc",
      "plan": "team",
      "account": {
        "email": "codex-profile@example.invalid",
        "accountId": "codex-profile-account"
      },
      "windows": [
        {
          "id": "five_hour",
          "label": "session",
          "kind": "session",
          "percentUsed": 21,
          "windowSeconds": 18000,
          "percentRemaining": 79
        },
        {
          "id": "weekly",
          "label": "week",
          "kind": "weekly",
          "percentUsed": 47,
          "windowSeconds": 604800,
          "percentRemaining": 53
        }
      ],
      "attempts": [
        {
          "source": "oauth",
          "status": "skipped",
          "error": "credentials_missing"
        },
        {
          "source": "cli-rpc",
          "status": "success"
        }
      ],
      "state": {
        "status": "fresh",
        "stale": false,
        "refreshedAt": "2026-07-18T03:20:46.499Z",
        "sourcesTried": [
          "oauth",
          "cli-rpc"
        ]
      }
    }
  ]
}
{"spawnedArguments":[["-s","read-only","-a","untrusted","app-server"]]}
Fail-closed relative Codex override with a same-named PATH decoy
{
  "generatedAt": "2026-07-18T03:20:46.947Z",
  "schemaVersion": 1,
  "auth": [
    {
      "provider": "codex",
      "sources": [
        {
          "source": "auth-json",
          "path": "/var/folders/y_/bfdbj_vx20l9b9tw7crgkzwm0000gn/T/no-mistakes-evidence/01KXSHA5A3G51T6ZZVAJ3ACAB2/codex-home/auth.json",
          "status": "missing"
        },
        {
          "source": "cli-rpc",
          "status": "missing",
          "error": "codex_binary_override_not_absolute"
        }
      ]
    }
  ]
}
{
  "generatedAt": "2026-07-18T03:20:47.379Z",
  "schemaVersion": 2,
  "providers": [
    {
      "provider": "codex",
      "label": "Codex",
      "source": "unavailable",
      "windows": [],
      "state": {
        "status": "error",
        "stale": false,
        "error": "Configured Codex binary must be an absolute executable path",
        "sourcesTried": [
          "oauth",
          "cli-rpc"
        ]
      },
      "attempts": [
        {
          "source": "oauth",
          "status": "skipped",
          "error": "credentials_missing"
        },
        {
          "source": "cli-rpc",
          "status": "failed",
          "error": "Configured Codex binary must be an absolute executable path"
        }
      ]
    }
  ]
}
{"quotaExitCode":1,"pathDecoyLaunched":false}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- 🚨 `src/providers/claude.ts:470` - The required criterion says “Preserve profile-scoped Claude credential discovery via CLAUDE_CONFIG_DIR and its path-hashed macOS Keychain service,” but this uses `||` fallback and hashes the raw value. Claude Code preserves a present empty value and NFC-normalizes the directory before file lookup and Keychain hashing. Empty or canonically decomposed paths can therefore make quota-axi inspect a different profile or send the default profile’s token. Derive one nullish/NFC-normalized config directory and reuse it for the credential file, Keychain service, and marker hash.

🔧 Fix: Normalize Claude profile paths across credential sources
1 error still open:
- 🚨 `src/providers/claude.ts:501` - The criterion says “Preserve profile-scoped Claude credential discovery via CLAUDE_CONFIG_DIR and its path-hashed macOS Keychain service,” but `if (configDir === undefined)` makes an empty-present value use `Claude Code-credentials-e3b0c442`. Claude Code suppresses the hash when `CLAUDE_CONFIG_DIR` is empty and uses the unsuffixed `Claude Code-credentials` item. Consequently, the new empty-value path reads the intended local credential file but cannot discover the actual macOS Keychain credential. Confirm that empty should mirror Claude’s service naming, then adjust this branch and its regression expectation accordingly.

🔧 Fix: Align empty Claude profile Keychain scope
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git branch --show-current && git status --short && git rev-parse HEAD`
- `git diff --stat 05b1eb32effed1afbe2d8e9ac0d72d103f9e3c84..b6926ffd08d5a1949a37df2f45d994e70d26b18e`
- `PATH=/Users/dongkeun/.nvm/versions/node/v22.22.0/bin:$PATH pnpm install --frozen-lockfile`
- <code>`pnpm test -- test/providers/claude-auth.test.ts test/providers/claude.test.ts test/providers/codex-auth.test.ts test/cache.test.ts test/lib/fs.test.ts test/cli.test.ts` (the wrapper exercised the complete Vitest suite)</code>
- `pnpm run build:skill -- --check`
- <code>End-to-end Claude CLI checks with isolated `CLAUDE_CONFIG_DIR`, recording Keychain and Anthropic mocks, verified and UUID-missing profiles, and persisted-cache inspection</code>
- `End-to-end Codex CLI checks with an absolute pinned app-server executable and an invalid relative override plus PATH decoy`
- `Credential-value absence check on the evidence transcript and final clean-worktree verification`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
