### PR TITLE
fix(providers): keep Kimi credential inspection read-only

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-kimi-pi-auth-readonly-f1/built-cli-empty-home.txt
+++ b/.no-mistakes/evidence/fm/quota-axi-kimi-pi-auth-readonly-f1/built-cli-empty-home.txt
@@ -1,0 +1,60 @@
+$ node dist/bin/quota-axi.js auth --provider kimi --json --full
+{
+  "generatedAt": "2026-07-21T01:31:52.333Z",
+  "schemaVersion": 1,
+  "auth": [
+    {
+      "provider": "kimi",
+      "sources": [
+        {
+          "source": "pi:kimi-coding",
+          "status": "missing"
+        },
+        {
+          "source": "kimi-code-cli",
+          "status": "missing"
+        }
+      ]
+    }
+  ]
+}
+auth_exit=0
+
+$ node dist/bin/quota-axi.js --provider kimi --json --full
+{
+  "generatedAt": "2026-07-21T01:31:52.716Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "kimi",
+      "label": "Kimi",
+      "source": "unavailable",
+      "windows": [],
+      "state": {
+        "status": "auth_required",
+        "stale": false,
+        "error": "kimi_credential_unavailable",
+        "sourcesTried": [
+          "pi:kimi-coding",
+          "kimi-code-cli"
+        ]
+      },
+      "attempts": [
+        {
+          "source": "pi:kimi-coding",
+          "status": "skipped",
+          "error": "kimi_credential_unavailable"
+        },
+        {
+          "source": "kimi-code-cli",
+          "status": "skipped",
+          "error": "kimi_code_cli_credential_unavailable"
+        }
+      ]
+    }
+  ]
+}
+quota_exit=1
+
+$ find isolated-home -mindepth 1 -print
+pi_state_exists=no

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 
 **Kimi**
 
-- It asks Pi's supported credential API to resolve only `kimi-coding`, rejects stored non-API-key credential types before resolution, and ignores any resolver-provided origin or headers.
+- It uses Pi's supported one-off credential access with non-persisting storage to resolve only `kimi-coding`, rejects stored non-API-key credential types before resolution, and ignores any resolver-provided origin or headers. Auth and quota inspection do not initialize or write Pi provider state.
 - If Pi has no supported credential, it reads the official Kimi Code CLI credential at `$KIMI_CODE_HOME/credentials/kimi-code.json`, defaulting to `$HOME/.kimi-code/credentials/kimi-code.json`. It accepts only a non-empty `access_token` whose Unix-seconds `expires_at` (a JSON number or numeric string) is more than 60 seconds in the future.
 - The Pi source always has priority. Transport, decoding, timeout, cancellation, and server failures do not trigger credential switching.
 - It sends one redirect-disabled `GET` to the fixed `https://api.kimi.com/coding/v1/usages` endpoint with a 15 second total deadline and a 262,144-byte decoded-body cap.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "node": ">=22.19"
   },
   "dependencies": {
+    "@earendil-works/pi-ai": "0.80.10",
     "@earendil-works/pi-coding-agent": "0.80.10",
     "@toon-format/toon": "2.1.0",
     "axi-sdk-js": "^0.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,9 @@ settings:
 importers:
   .:
     dependencies:
+      "@earendil-works/pi-ai":
+        specifier: 0.80.10
+        version: 0.80.10(ws@8.21.0)(zod@4.4.3)
       "@earendil-works/pi-coding-agent":
         specifier: 0.80.10
         version: 0.80.10(ws@8.21.0)(zod@4.4.3)

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -1,8 +1,15 @@
-import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
-import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import type { Credential } from "@earendil-works/pi-ai";
+import { execSync } from "node:child_process";
+import { closeSync, constants, fstatSync, openSync, readSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const PI_PROVIDER_ID = "kimi-coding";
+const PI_AUTH_READ_LIMIT_BYTES = 1_048_576;
+const COMMAND_OUTPUT_LIMIT_BYTES = 16_384;
+const UNRESOLVED_CREDENTIAL = "\0";
+const ENV_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)$/;
+const BRACED_ENV_REFERENCE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
 
 export type KimiCredentialResolution =
   | { status: "available"; apiKey: string }
@@ -28,7 +35,6 @@ type PiModelRuntime = {
       }
     | undefined
   >;
-  checkAuth(providerId: string): Promise<{ type: string } | undefined>;
 };
 
 type BrokerDependencies = {
@@ -47,8 +53,8 @@ export function createPiKimiCredentialBroker(
           return { status: "unsupported" };
         }
         const resolved = await runtime.getAuth(PI_PROVIDER_ID);
-        const apiKey = resolved?.auth.apiKey;
-        return typeof apiKey === "string" && apiKey.trim().length > 0
+        const apiKey = usableApiKey(resolved?.auth.apiKey);
+        return apiKey !== undefined
           ? { status: "available", apiKey }
           : { status: "missing" };
       } catch {
@@ -63,9 +69,10 @@ export function createPiKimiCredentialBroker(
         if (storedType !== undefined && storedType !== "api_key") {
           return "unsupported";
         }
-        return (await runtime.checkAuth(PI_PROVIDER_ID))
-          ? "available"
-          : "missing";
+        const resolved = await runtime.getAuth(PI_PROVIDER_ID);
+        return usableApiKey(resolved?.auth.apiKey) === undefined
+          ? "missing"
+          : "available";
       } catch {
         return "error";
       }
@@ -82,22 +89,14 @@ async function storedCredentialType(
 }
 
 async function loadPiRuntime(): Promise<PiModelRuntime> {
-  const [{ ModelRuntime, readStoredCredential }, { InMemoryCredentialStore }] =
-    await Promise.all([
-      import("@earendil-works/pi-coding-agent"),
-      import("@earendil-works/pi-ai"),
-    ]);
+  const [{ ModelRuntime }, { InMemoryCredentialStore }] = await Promise.all([
+    import("@earendil-works/pi-coding-agent"),
+    import("@earendil-works/pi-ai"),
+  ]);
   const credentials = new InMemoryCredentialStore();
-  const storedCredential = readStoredCredential(PI_PROVIDER_ID);
+  const storedCredential = readKimiCredential();
   if (storedCredential !== undefined) {
-    const { AuthStorage } = await loadPiAuthStorage();
-    return ModelRuntime.create({
-      credentials: AuthStorage.inMemory({
-        [PI_PROVIDER_ID]: storedCredential,
-      }),
-      allowModelNetwork: false,
-      modelsPath: null,
-    });
+    await credentials.modify(PI_PROVIDER_ID, async () => storedCredential);
   }
   return ModelRuntime.create({
     credentials,
@@ -106,23 +105,170 @@ async function loadPiRuntime(): Promise<PiModelRuntime> {
   });
 }
 
-async function loadPiAuthStorage(): Promise<{
-  AuthStorage: {
-    inMemory(data: Record<string, Credential>): CredentialStore;
-  };
-}> {
-  const entryUrl =
-    typeof import.meta.resolve === "function"
-      ? import.meta.resolve("@earendil-works/pi-coding-agent")
-      : pathToFileURL(
-          resolve(
-            "node_modules",
-            "@earendil-works",
-            "pi-coding-agent",
-            "dist",
-            "index.js",
-          ),
-        ).href;
-  const moduleUrl = new URL("./core/auth-storage.js", entryUrl);
-  return import(/* @vite-ignore */ moduleUrl.href);
+function readKimiCredential(): Credential | undefined {
+  const authPath = join(piAgentDirectory(), "auth.json");
+  let content: string | undefined;
+  try {
+    content = readBoundedUtf8File(authPath);
+  } catch {
+    return blockedCredential();
+  }
+  if (content === undefined) return undefined;
+
+  let data: unknown;
+  try {
+    data = JSON.parse(content);
+  } catch {
+    return blockedCredential();
+  }
+  if (!isRecord(data)) return blockedCredential();
+  if (!Object.prototype.hasOwnProperty.call(data, PI_PROVIDER_ID)) {
+    return undefined;
+  }
+
+  const credential = data[PI_PROVIDER_ID];
+  if (!isRecord(credential) || typeof credential.type !== "string") {
+    return blockedCredential();
+  }
+  if (credential.type !== "api_key") {
+    return unsupportedCredential();
+  }
+  if (credential.key !== undefined && typeof credential.key !== "string") {
+    return blockedCredential();
+  }
+  const environment = credentialEnvironment(credential.env);
+  if (credential.env !== undefined && environment === undefined) {
+    return blockedCredential();
+  }
+  if (credential.key === undefined) {
+    return { type: "api_key", ...(environment ? { env: environment } : {}) };
+  }
+
+  const key = resolveCredentialValue(credential.key, environment);
+  return key === undefined
+    ? blockedCredential()
+    : {
+        type: "api_key",
+        key,
+        ...(environment ? { env: environment } : {}),
+      };
+}
+
+function readBoundedUtf8File(path: string): string | undefined {
+  let descriptor: number;
+  try {
+    descriptor = openSync(path, constants.O_RDONLY);
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") return undefined;
+    throw error;
+  }
+
+  try {
+    const metadata = fstatSync(descriptor);
+    if (!metadata.isFile() || metadata.size > PI_AUTH_READ_LIMIT_BYTES) {
+      throw new Error("auth_invalid");
+    }
+    const buffer = Buffer.allocUnsafe(PI_AUTH_READ_LIMIT_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const bytesRead = readSync(
+        descriptor,
+        buffer,
+        offset,
+        buffer.length - offset,
+        null,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > PI_AUTH_READ_LIMIT_BYTES) throw new Error("auth_too_large");
+    return new TextDecoder("utf-8", { fatal: true }).decode(
+      buffer.subarray(0, offset),
+    );
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function resolveCredentialValue(
+  value: string,
+  environment: Record<string, string> | undefined,
+): string | undefined {
+  const envName =
+    ENV_REFERENCE.exec(value)?.[1] ?? BRACED_ENV_REFERENCE.exec(value)?.[1];
+  if (envName !== undefined) {
+    return usableApiKey(environment?.[envName] || process.env[envName]);
+  }
+  if (value.startsWith("!")) {
+    const command = value.slice(1).trim();
+    if (command.length === 0) return undefined;
+    try {
+      return usableApiKey(
+        execSync(command, {
+          encoding: "utf8",
+          maxBuffer: COMMAND_OUTPUT_LIMIT_BYTES,
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 10_000,
+        }),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+  if (value.includes("$")) return undefined;
+  return usableApiKey(value);
+}
+
+function usableApiKey(value: unknown): string | undefined {
+  if (
+    typeof value !== "string" ||
+    value === UNRESOLVED_CREDENTIAL ||
+    value.trim().length === 0 ||
+    value.startsWith("!") ||
+    value.includes("$") ||
+    /[\0-\x1f\x7f]/.test(value)
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function credentialEnvironment(
+  value: unknown,
+): Record<string, string> | undefined {
+  if (value === undefined) return {};
+  if (!isRecord(value)) return undefined;
+  const entries = Object.entries(value);
+  if (entries.some(([, entry]) => typeof entry !== "string")) {
+    return undefined;
+  }
+  return Object.fromEntries(entries) as Record<string, string>;
+}
+
+function piAgentDirectory(): string {
+  const configured = process.env.PI_CODING_AGENT_DIR;
+  if (configured === undefined || configured.length === 0) {
+    return join(homedir(), ".pi", "agent");
+  }
+  if (configured === "~") return homedir();
+  if (configured.startsWith("~/")) {
+    return join(homedir(), configured.slice(2));
+  }
+  return configured;
+}
+
+function blockedCredential(): Credential {
+  return { type: "api_key", key: UNRESOLVED_CREDENTIAL };
+}
+
+function unsupportedCredential(): Credential {
+  return { type: "oauth", access: "", refresh: "", expires: 0 };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error;
 }

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -209,7 +209,7 @@ function resolveCredentialValue(
           maxBuffer: COMMAND_OUTPUT_LIMIT_BYTES,
           stdio: ["ignore", "pipe", "ignore"],
           timeout: 10_000,
-        }),
+        }).trim(),
       );
     } catch {
       return undefined;

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -78,8 +78,18 @@ async function storedCredentialType(
 }
 
 async function loadPiRuntime(): Promise<PiModelRuntime> {
-  const { ModelRuntime } = await import("@earendil-works/pi-coding-agent");
+  const [{ ModelRuntime, readStoredCredential }, { InMemoryCredentialStore }] =
+    await Promise.all([
+      import("@earendil-works/pi-coding-agent"),
+      import("@earendil-works/pi-ai"),
+    ]);
+  const credentials = new InMemoryCredentialStore();
+  const storedCredential = readStoredCredential(PI_PROVIDER_ID);
+  if (storedCredential !== undefined) {
+    await credentials.modify(PI_PROVIDER_ID, async () => storedCredential);
+  }
   return ModelRuntime.create({
+    credentials,
     allowModelNetwork: false,
     modelsPath: null,
   });

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -251,7 +251,10 @@ function piAgentDirectory(): string {
     return join(homedir(), ".pi", "agent");
   }
   if (configured === "~") return homedir();
-  if (configured.startsWith("~/")) {
+  if (
+    configured.startsWith("~/") ||
+    (process.platform === "win32" && configured.startsWith("~\\"))
+  ) {
     return join(homedir(), configured.slice(2));
   }
   return configured;

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -1,3 +1,7 @@
+import type { Credential, CredentialStore } from "@earendil-works/pi-ai";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
 const PI_PROVIDER_ID = "kimi-coding";
 
 export type KimiCredentialResolution =
@@ -86,11 +90,39 @@ async function loadPiRuntime(): Promise<PiModelRuntime> {
   const credentials = new InMemoryCredentialStore();
   const storedCredential = readStoredCredential(PI_PROVIDER_ID);
   if (storedCredential !== undefined) {
-    await credentials.modify(PI_PROVIDER_ID, async () => storedCredential);
+    const { AuthStorage } = await loadPiAuthStorage();
+    return ModelRuntime.create({
+      credentials: AuthStorage.inMemory({
+        [PI_PROVIDER_ID]: storedCredential,
+      }),
+      allowModelNetwork: false,
+      modelsPath: null,
+    });
   }
   return ModelRuntime.create({
     credentials,
     allowModelNetwork: false,
     modelsPath: null,
   });
+}
+
+async function loadPiAuthStorage(): Promise<{
+  AuthStorage: {
+    inMemory(data: Record<string, Credential>): CredentialStore;
+  };
+}> {
+  const entryUrl =
+    typeof import.meta.resolve === "function"
+      ? import.meta.resolve("@earendil-works/pi-coding-agent")
+      : pathToFileURL(
+          resolve(
+            "node_modules",
+            "@earendil-works",
+            "pi-coding-agent",
+            "dist",
+            "index.js",
+          ),
+        ).href;
+  const moduleUrl = new URL("./core/auth-storage.js", entryUrl);
+  return import(/* @vite-ignore */ moduleUrl.href);
 }

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -109,7 +109,10 @@ function usableApiKey(value: unknown): string | undefined {
     value.trim().length === 0 ||
     value.startsWith("!") ||
     value.includes("$") ||
-    /[\0-\x1f\x7f]/.test(value)
+    [...value].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x1f || code === 0x7f;
+    })
   ) {
     return undefined;
   }

--- a/src/providers/pi-kimi-credential.ts
+++ b/src/providers/pi-kimi-credential.ts
@@ -1,15 +1,8 @@
-import type { Credential } from "@earendil-works/pi-ai";
-import { execSync } from "node:child_process";
-import { closeSync, constants, fstatSync, openSync, readSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const PI_PROVIDER_ID = "kimi-coding";
-const PI_AUTH_READ_LIMIT_BYTES = 1_048_576;
-const COMMAND_OUTPUT_LIMIT_BYTES = 16_384;
 const UNRESOLVED_CREDENTIAL = "\0";
-const ENV_REFERENCE = /^\$([A-Za-z_][A-Za-z0-9_]*)$/;
-const BRACED_ENV_REFERENCE = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/;
 
 export type KimiCredentialResolution =
   | { status: "available"; apiKey: string }
@@ -89,12 +82,16 @@ async function storedCredentialType(
 }
 
 async function loadPiRuntime(): Promise<PiModelRuntime> {
-  const [{ ModelRuntime }, { InMemoryCredentialStore }] = await Promise.all([
-    import("@earendil-works/pi-coding-agent"),
-    import("@earendil-works/pi-ai"),
-  ]);
+  const [{ ModelRuntime, readStoredCredential }, { InMemoryCredentialStore }] =
+    await Promise.all([
+      import("@earendil-works/pi-coding-agent"),
+      import("@earendil-works/pi-ai"),
+    ]);
   const credentials = new InMemoryCredentialStore();
-  const storedCredential = readKimiCredential();
+  const storedCredential = readStoredCredential(
+    PI_PROVIDER_ID,
+    join(piAgentDirectory(), "auth.json"),
+  );
   if (storedCredential !== undefined) {
     await credentials.modify(PI_PROVIDER_ID, async () => storedCredential);
   }
@@ -103,120 +100,6 @@ async function loadPiRuntime(): Promise<PiModelRuntime> {
     allowModelNetwork: false,
     modelsPath: null,
   });
-}
-
-function readKimiCredential(): Credential | undefined {
-  const authPath = join(piAgentDirectory(), "auth.json");
-  let content: string | undefined;
-  try {
-    content = readBoundedUtf8File(authPath);
-  } catch {
-    return blockedCredential();
-  }
-  if (content === undefined) return undefined;
-
-  let data: unknown;
-  try {
-    data = JSON.parse(content);
-  } catch {
-    return blockedCredential();
-  }
-  if (!isRecord(data)) return blockedCredential();
-  if (!Object.prototype.hasOwnProperty.call(data, PI_PROVIDER_ID)) {
-    return undefined;
-  }
-
-  const credential = data[PI_PROVIDER_ID];
-  if (!isRecord(credential) || typeof credential.type !== "string") {
-    return blockedCredential();
-  }
-  if (credential.type !== "api_key") {
-    return unsupportedCredential();
-  }
-  if (credential.key !== undefined && typeof credential.key !== "string") {
-    return blockedCredential();
-  }
-  const environment = credentialEnvironment(credential.env);
-  if (credential.env !== undefined && environment === undefined) {
-    return blockedCredential();
-  }
-  if (credential.key === undefined) {
-    return { type: "api_key", ...(environment ? { env: environment } : {}) };
-  }
-
-  const key = resolveCredentialValue(credential.key, environment);
-  return key === undefined
-    ? blockedCredential()
-    : {
-        type: "api_key",
-        key,
-        ...(environment ? { env: environment } : {}),
-      };
-}
-
-function readBoundedUtf8File(path: string): string | undefined {
-  let descriptor: number;
-  try {
-    descriptor = openSync(path, constants.O_RDONLY);
-  } catch (error) {
-    if (isNodeError(error) && error.code === "ENOENT") return undefined;
-    throw error;
-  }
-
-  try {
-    const metadata = fstatSync(descriptor);
-    if (!metadata.isFile() || metadata.size > PI_AUTH_READ_LIMIT_BYTES) {
-      throw new Error("auth_invalid");
-    }
-    const buffer = Buffer.allocUnsafe(PI_AUTH_READ_LIMIT_BYTES + 1);
-    let offset = 0;
-    while (offset < buffer.length) {
-      const bytesRead = readSync(
-        descriptor,
-        buffer,
-        offset,
-        buffer.length - offset,
-        null,
-      );
-      if (bytesRead === 0) break;
-      offset += bytesRead;
-    }
-    if (offset > PI_AUTH_READ_LIMIT_BYTES) throw new Error("auth_too_large");
-    return new TextDecoder("utf-8", { fatal: true }).decode(
-      buffer.subarray(0, offset),
-    );
-  } finally {
-    closeSync(descriptor);
-  }
-}
-
-function resolveCredentialValue(
-  value: string,
-  environment: Record<string, string> | undefined,
-): string | undefined {
-  const envName =
-    ENV_REFERENCE.exec(value)?.[1] ?? BRACED_ENV_REFERENCE.exec(value)?.[1];
-  if (envName !== undefined) {
-    return usableApiKey(environment?.[envName] || process.env[envName]);
-  }
-  if (value.startsWith("!")) {
-    const command = value.slice(1).trim();
-    if (command.length === 0) return undefined;
-    try {
-      return usableApiKey(
-        execSync(command, {
-          encoding: "utf8",
-          maxBuffer: COMMAND_OUTPUT_LIMIT_BYTES,
-          stdio: ["ignore", "pipe", "ignore"],
-          timeout: 10_000,
-        }).trim(),
-      );
-    } catch {
-      return undefined;
-    }
-  }
-  if (value.includes("$")) return undefined;
-  return usableApiKey(value);
 }
 
 function usableApiKey(value: unknown): string | undefined {
@@ -233,18 +116,6 @@ function usableApiKey(value: unknown): string | undefined {
   return value;
 }
 
-function credentialEnvironment(
-  value: unknown,
-): Record<string, string> | undefined {
-  if (value === undefined) return {};
-  if (!isRecord(value)) return undefined;
-  const entries = Object.entries(value);
-  if (entries.some(([, entry]) => typeof entry !== "string")) {
-    return undefined;
-  }
-  return Object.fromEntries(entries) as Record<string, string>;
-}
-
 function piAgentDirectory(): string {
   const configured = process.env.PI_CODING_AGENT_DIR;
   if (configured === undefined || configured.length === 0) {
@@ -258,20 +129,4 @@ function piAgentDirectory(): string {
     return join(homedir(), configured.slice(2));
   }
   return configured;
-}
-
-function blockedCredential(): Credential {
-  return { type: "api_key", key: UNRESOLVED_CREDENTIAL };
-}
-
-function unsupportedCredential(): Credential {
-  return { type: "oauth", access: "", refresh: "", expires: 0 };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isNodeError(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error;
 }

--- a/test/kimi-cli-readonly.test.ts
+++ b/test/kimi-cli-readonly.test.ts
@@ -205,6 +205,90 @@ globalThis.fetch = async (input, init) => {
       ],
     });
   });
+
+  it("falls back to Kimi Code CLI for an unresolved Pi reference", () => {
+    const fixture = isolatedFixture();
+    const authPath = join(fixture.home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": {
+          type: "api_key",
+          key: "$MISSING_PI_KIMI_REFERENCE_462",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const credentialPath = join(
+      fixture.kimiCodeHome,
+      "credentials",
+      "kimi-code.json",
+    );
+    mkdirSync(dirname(credentialPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      credentialPath,
+      JSON.stringify({
+        access_token: "fallback-cli-token-714",
+        refresh_token: "ignored-fallback-refresh-221",
+        expires_at: 4_102_444_800,
+      }),
+      { mode: 0o600 },
+    );
+    const preload = join(fixture.root, "mock-unresolved-reference-fetch.mjs");
+    writeFileSync(
+      preload,
+      `globalThis.fetch = async (input, init) => {
+  if (String(input) !== "https://api.kimi.com/coding/v1/usages") {
+    throw new Error("Unexpected Kimi request origin");
+  }
+  if (new Headers(init?.headers).get("authorization") !== "Bearer fallback-cli-token-714") {
+    throw new Error("Unresolved Pi reference did not fall back safely");
+  }
+  return new Response(JSON.stringify({
+    usage: { limit: 100, used: 10, resetTime: "2099-01-08T00:00:00Z" },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+      { mode: 0o600 },
+    );
+    const before = readFileSync(authPath, "utf8");
+
+    const result = runCli(
+      fixture,
+      ["--provider", "kimi", "--json", "--full"],
+      preload,
+      { KIMI_API_KEY: "ambient-key-must-not-win-558" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("MISSING_PI_KIMI_REFERENCE_462");
+    expect(result.stdout).not.toContain("fallback-cli-token-714");
+    expect(result.stdout).not.toContain("ignored-fallback-refresh-221");
+    expect(result.stdout).not.toContain("ambient-key-must-not-win-558");
+    expect(readFileSync(authPath, "utf8")).toBe(before);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "api",
+          windows: [{ id: "weekly", percentRemaining: 90 }],
+          state: {
+            status: "fresh",
+            sourcesTried: ["pi:kimi-coding", "kimi-code-cli"],
+          },
+          attempts: [
+            { source: "pi:kimi-coding", status: "skipped" },
+            { source: "kimi-code-cli", status: "success" },
+          ],
+        },
+      ],
+    });
+  });
 });
 
 type IsolatedFixture = {

--- a/test/kimi-cli-readonly.test.ts
+++ b/test/kimi-cli-readonly.test.ts
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const CLI_ENTRYPOINT = resolve("bin/quota-axi.ts");
+let temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  temporaryDirectories = [];
+});
+
+describe("Kimi CLI credential inspection is read-only", () => {
+  it("does not create Pi auth state while inspecting auth in an empty home", () => {
+    const fixture = isolatedFixture();
+
+    const result = runCli(fixture, [
+      "auth",
+      "--provider",
+      "kimi",
+      "--json",
+      "--full",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(existsSync(join(fixture.home, ".pi"))).toBe(false);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      auth: [
+        {
+          provider: "kimi",
+          sources: [
+            { source: "pi:kimi-coding", status: "missing" },
+            { source: "kimi-code-cli", status: "missing" },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("does not create Pi auth state while inspecting quota in an empty home", () => {
+    const fixture = isolatedFixture();
+
+    const result = runCli(fixture, ["--provider", "kimi", "--json", "--full"]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(existsSync(join(fixture.home, ".pi"))).toBe(false);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "unavailable",
+          state: {
+            status: "auth_required",
+            sourcesTried: ["pi:kimi-coding", "kimi-code-cli"],
+          },
+        },
+      ],
+    });
+  });
+
+  it("reaches a Kimi Code CLI fallback before any Pi state exists", () => {
+    const fixture = isolatedFixture();
+    const credentialPath = join(
+      fixture.kimiCodeHome,
+      "credentials",
+      "kimi-code.json",
+    );
+    mkdirSync(dirname(credentialPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      credentialPath,
+      JSON.stringify({
+        access_token: "synthetic-cli-token-836",
+        refresh_token: "ignored-refresh-token-219",
+        expires_at: 4_102_444_800,
+      }),
+      { mode: 0o600 },
+    );
+    const preload = join(fixture.root, "mock-kimi-fetch.mjs");
+    writeFileSync(
+      preload,
+      `import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+globalThis.fetch = async (input, init) => {
+  if (existsSync(join(process.env.HOME, ".pi"))) {
+    throw new Error("Pi state existed before Kimi Code CLI fallback");
+  }
+  if (String(input) !== "https://api.kimi.com/coding/v1/usages") {
+    throw new Error("Unexpected Kimi request origin");
+  }
+  if (init?.method !== "GET" || init?.redirect !== "manual" || init?.credentials !== "omit") {
+    throw new Error("Unexpected Kimi request options");
+  }
+  return new Response(JSON.stringify({
+    usage: { limit: 100, used: 20, resetTime: "2099-01-08T00:00:00Z" },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+      { mode: 0o600 },
+    );
+
+    const result = runCli(
+      fixture,
+      ["--provider", "kimi", "--json", "--full"],
+      preload,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(existsSync(join(fixture.home, ".pi"))).toBe(false);
+    expect(result.stdout).not.toContain("synthetic-cli-token-836");
+    expect(result.stdout).not.toContain("ignored-refresh-token-219");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "api",
+          windows: [{ id: "weekly", percentRemaining: 80 }],
+          state: {
+            status: "fresh",
+            sourcesTried: ["pi:kimi-coding", "kimi-code-cli"],
+          },
+          attempts: [
+            { source: "pi:kimi-coding", status: "skipped" },
+            { source: "kimi-code-cli", status: "success" },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+type IsolatedFixture = {
+  root: string;
+  home: string;
+  cacheHome: string;
+  kimiCodeHome: string;
+};
+
+function isolatedFixture(): IsolatedFixture {
+  const root = mkdtempSync(join(tmpdir(), "quota-axi-kimi-cli-readonly-"));
+  temporaryDirectories.push(root);
+  const fixture = {
+    root,
+    home: join(root, "home"),
+    cacheHome: join(root, "cache"),
+    kimiCodeHome: join(root, "kimi-code"),
+  };
+  mkdirSync(fixture.home, { mode: 0o700 });
+  return fixture;
+}
+
+function runCli(
+  fixture: IsolatedFixture,
+  args: string[],
+  preload?: string,
+): { status: number | null; stdout: string; stderr: string } {
+  const imports = ["tsx", ...(preload ? [pathToFileURL(preload).href] : [])];
+  const result = spawnSync(
+    process.execPath,
+    [
+      ...imports.flatMap((specifier) => ["--import", specifier]),
+      CLI_ENTRYPOINT,
+      ...args,
+    ],
+    {
+      encoding: "utf8",
+      timeout: 15_000,
+      env: {
+        HOME: fixture.home,
+        XDG_CACHE_HOME: fixture.cacheHome,
+        KIMI_CODE_HOME: fixture.kimiCodeHome,
+        PATH: process.env.PATH ?? "",
+      },
+    },
+  );
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}

--- a/test/kimi-cli-readonly.test.ts
+++ b/test/kimi-cli-readonly.test.ts
@@ -3,6 +3,7 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -144,6 +145,66 @@ globalThis.fetch = async (input, init) => {
       ],
     });
   });
+
+  it("resolves a Pi environment reference without exposing credential data", () => {
+    const fixture = isolatedFixture();
+    const authPath = join(fixture.home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": { type: "api_key", key: "$KIMI_API_KEY" },
+      }),
+      { mode: 0o600 },
+    );
+    const preload = join(fixture.root, "mock-pi-reference-fetch.mjs");
+    writeFileSync(
+      preload,
+      `globalThis.fetch = async (input, init) => {
+  if (String(input) !== "https://api.kimi.com/coding/v1/usages") {
+    throw new Error("Unexpected Kimi request origin");
+  }
+  if (new Headers(init?.headers).get("authorization") !== "Bearer pi-reference-fixture-key-628") {
+    throw new Error("Pi reference was not resolved at request time");
+  }
+  return new Response(JSON.stringify({
+    usage: { limit: 100, used: 15, resetTime: "2099-01-08T00:00:00Z" },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+      { mode: 0o600 },
+    );
+    const before = readFileSync(authPath, "utf8");
+
+    const result = runCli(
+      fixture,
+      ["--provider", "kimi", "--json", "--full"],
+      preload,
+      { KIMI_API_KEY: "pi-reference-fixture-key-628" },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("pi-reference-fixture-key-628");
+    expect(result.stdout).not.toContain("$KIMI_API_KEY");
+    expect(readFileSync(authPath, "utf8")).toBe(before);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "api",
+          windows: [{ id: "weekly", percentRemaining: 85 }],
+          state: {
+            status: "fresh",
+            sourcesTried: ["pi:kimi-coding"],
+          },
+        },
+      ],
+    });
+  });
 });
 
 type IsolatedFixture = {
@@ -170,6 +231,7 @@ function runCli(
   fixture: IsolatedFixture,
   args: string[],
   preload?: string,
+  extraEnv: Record<string, string> = {},
 ): { status: number | null; stdout: string; stderr: string } {
   const imports = ["tsx", ...(preload ? [pathToFileURL(preload).href] : [])];
   const result = spawnSync(
@@ -187,6 +249,7 @@ function runCli(
         XDG_CACHE_HOME: fixture.cacheHome,
         KIMI_CODE_HOME: fixture.kimiCodeHome,
         PATH: process.env.PATH ?? "",
+        ...extraEnv,
       },
     },
   );

--- a/test/kimi-cli-readonly.test.ts
+++ b/test/kimi-cli-readonly.test.ts
@@ -206,6 +206,72 @@ globalThis.fetch = async (input, init) => {
     });
   });
 
+  it("trims and redacts newline-terminated Pi command output", () => {
+    const fixture = isolatedFixture();
+    const commandPath = join(fixture.root, "newline-credential-command.mjs");
+    writeFileSync(
+      commandPath,
+      'process.stdout.write("newline-command-fixture-key-573\\n");\n',
+      { mode: 0o600 },
+    );
+    const command = `!${JSON.stringify(process.execPath)} ${JSON.stringify(commandPath)}`;
+    const authPath = join(fixture.home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": { type: "api_key", key: command },
+      }),
+      { mode: 0o600 },
+    );
+    const preload = join(fixture.root, "mock-command-reference-fetch.mjs");
+    writeFileSync(
+      preload,
+      `globalThis.fetch = async (input, init) => {
+  if (String(input) !== "https://api.kimi.com/coding/v1/usages") {
+    throw new Error("Unexpected Kimi request origin");
+  }
+  if (new Headers(init?.headers).get("authorization") !== "Bearer newline-command-fixture-key-573") {
+    throw new Error("Pi command output was not trimmed");
+  }
+  return new Response(JSON.stringify({
+    usage: { limit: 100, used: 5, resetTime: "2099-01-08T00:00:00Z" },
+  }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+      { mode: 0o600 },
+    );
+    const before = readFileSync(authPath, "utf8");
+
+    const result = runCli(
+      fixture,
+      ["--provider", "kimi", "--json", "--full"],
+      preload,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("newline-command-fixture-key-573");
+    expect(result.stdout).not.toContain(command);
+    expect(readFileSync(authPath, "utf8")).toBe(before);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "api",
+          windows: [{ id: "weekly", percentRemaining: 95 }],
+          state: {
+            status: "fresh",
+            sourcesTried: ["pi:kimi-coding"],
+          },
+        },
+      ],
+    });
+  });
+
   it("falls back to Kimi Code CLI for an unresolved Pi reference", () => {
     const fixture = isolatedFixture();
     const authPath = join(fixture.home, ".pi", "agent", "auth.json");

--- a/test/kimi-cli-readonly.test.ts
+++ b/test/kimi-cli-readonly.test.ts
@@ -146,17 +146,8 @@ globalThis.fetch = async (input, init) => {
     });
   });
 
-  it("resolves a Pi environment reference without exposing credential data", () => {
+  it("resolves KIMI_API_KEY through Pi without creating Pi state", () => {
     const fixture = isolatedFixture();
-    const authPath = join(fixture.home, ".pi", "agent", "auth.json");
-    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
-    writeFileSync(
-      authPath,
-      JSON.stringify({
-        "kimi-coding": { type: "api_key", key: "$KIMI_API_KEY" },
-      }),
-      { mode: 0o600 },
-    );
     const preload = join(fixture.root, "mock-pi-reference-fetch.mjs");
     writeFileSync(
       preload,
@@ -177,7 +168,6 @@ globalThis.fetch = async (input, init) => {
 `,
       { mode: 0o600 },
     );
-    const before = readFileSync(authPath, "utf8");
 
     const result = runCli(
       fixture,
@@ -189,8 +179,7 @@ globalThis.fetch = async (input, init) => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
     expect(result.stdout).not.toContain("pi-reference-fixture-key-628");
-    expect(result.stdout).not.toContain("$KIMI_API_KEY");
-    expect(readFileSync(authPath, "utf8")).toBe(before);
+    expect(existsSync(join(fixture.home, ".pi"))).toBe(false);
     expect(JSON.parse(result.stdout)).toMatchObject({
       providers: [
         {
@@ -206,21 +195,17 @@ globalThis.fetch = async (input, init) => {
     });
   });
 
-  it("trims and redacts newline-terminated Pi command output", () => {
+  it("uses a Pi-managed credential without changing Pi auth state", () => {
     const fixture = isolatedFixture();
-    const commandPath = join(fixture.root, "newline-credential-command.mjs");
-    writeFileSync(
-      commandPath,
-      'process.stdout.write("newline-command-fixture-key-573\\n");\n',
-      { mode: 0o600 },
-    );
-    const command = `!${JSON.stringify(process.execPath)} ${JSON.stringify(commandPath)}`;
     const authPath = join(fixture.home, ".pi", "agent", "auth.json");
     mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
     writeFileSync(
       authPath,
       JSON.stringify({
-        "kimi-coding": { type: "api_key", key: command },
+        "kimi-coding": {
+          type: "api_key",
+          key: "pi-managed-fixture-key-573",
+        },
       }),
       { mode: 0o600 },
     );
@@ -231,8 +216,8 @@ globalThis.fetch = async (input, init) => {
   if (String(input) !== "https://api.kimi.com/coding/v1/usages") {
     throw new Error("Unexpected Kimi request origin");
   }
-  if (new Headers(init?.headers).get("authorization") !== "Bearer newline-command-fixture-key-573") {
-    throw new Error("Pi command output was not trimmed");
+  if (new Headers(init?.headers).get("authorization") !== "Bearer pi-managed-fixture-key-573") {
+    throw new Error("Pi-managed credential was not used");
   }
   return new Response(JSON.stringify({
     usage: { limit: 100, used: 5, resetTime: "2099-01-08T00:00:00Z" },
@@ -254,8 +239,7 @@ globalThis.fetch = async (input, init) => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
-    expect(result.stdout).not.toContain("newline-command-fixture-key-573");
-    expect(result.stdout).not.toContain(command);
+    expect(result.stdout).not.toContain("pi-managed-fixture-key-573");
     expect(readFileSync(authPath, "utf8")).toBe(before);
     expect(JSON.parse(result.stdout)).toMatchObject({
       providers: [

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -124,8 +124,10 @@ describe("Pi Kimi credential broker", () => {
     expect(() => statSync(markerPath)).toThrow();
   });
 
-  it("resolves a stored environment reference without exposing the reference", async () => {
-    const fixture = piAuthFixture("$KIMI_API_KEY");
+  it("resolves the official environment API key through Pi", async () => {
+    const home = temporaryDirectory();
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = join(home, ".pi", "agent");
     process.env.KIMI_API_KEY = "environment-reference-fixture-key-742";
     const broker = createPiKimiCredentialBroker();
 
@@ -136,7 +138,7 @@ describe("Pi Kimi credential broker", () => {
       apiKey: "environment-reference-fixture-key-742",
     });
     expect(JSON.stringify(resolution)).not.toContain("$KIMI_API_KEY");
-    expectPiAuthUnchanged(fixture);
+    expect(readdirSync(home)).toEqual([]);
   });
 
   it("reports a missing stored environment reference without transmitting it", async () => {
@@ -163,12 +165,13 @@ describe("Pi Kimi credential broker", () => {
     expectPiAuthUnchanged(fixture);
   });
 
-  it("resolves a supported stored command reference", async () => {
+  it("does not execute a stored command reference itself", async () => {
     const home = temporaryDirectory();
     const scriptPath = join(home, "credential-command.mjs");
+    const markerPath = join(home, "credential-command-ran");
     writeFileSync(
       scriptPath,
-      'process.stdout.write("command-reference-fixture-key-419\\n");\n',
+      `import { writeFileSync } from "node:fs";\nwriteFileSync(${JSON.stringify(markerPath)}, "bad");\n`,
       { mode: 0o600 },
     );
     const fixture = piAuthFixture(
@@ -177,10 +180,8 @@ describe("Pi Kimi credential broker", () => {
     );
     const broker = createPiKimiCredentialBroker();
 
-    await expect(broker.resolve()).resolves.toEqual({
-      status: "available",
-      apiKey: "command-reference-fixture-key-419",
-    });
+    await expect(broker.resolve()).resolves.toEqual({ status: "missing" });
+    expect(() => statSync(markerPath)).toThrow();
     expectPiAuthUnchanged(fixture, ["auth.json"]);
   });
 
@@ -204,8 +205,14 @@ describe("Pi Kimi credential broker", () => {
     expectPiAuthUnchanged(fixture);
   });
 
-  it("rejects an oversized Pi auth file without reading beyond the bound", async () => {
-    const fixture = piAuthFixture("x".repeat(1_048_576));
+  it("reports malformed Pi auth state as missing without changing it", async () => {
+    const home = temporaryDirectory();
+    const authPath = join(home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(authPath, "{ malformed", { mode: 0o600 });
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = dirname(authPath);
+    const fixture = { authPath, before: readFileSync(authPath, "utf8") };
     const broker = createPiKimiCredentialBroker();
 
     await expect(broker.resolve()).resolves.toEqual({ status: "missing" });
@@ -331,17 +338,16 @@ describe("Pi Kimi credential broker", () => {
     }
   });
 
-  it("uses a bounded direct read and only Pi's public runtime APIs", () => {
+  it("uses Pi's supported one-off read and public runtime APIs", () => {
     const implementation = readFileSync(
       new URL("../../src/providers/pi-kimi-credential.ts", import.meta.url),
       "utf8",
     );
 
     expect(implementation).toContain("new InMemoryCredentialStore()");
-    expect(implementation).toContain("PI_AUTH_READ_LIMIT_BYTES + 1");
-    expect(implementation).toContain("readSync(");
+    expect(implementation).toContain("readStoredCredential(");
     expect(implementation).not.toMatch(
-      /dist\/core|AuthStorage|import\.meta\.resolve|readStoredCredential/,
+      /dist\/core|AuthStorage|import\.meta\.resolve|JSON\.parse|readFileSync/,
     );
   });
 

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -168,7 +168,7 @@ describe("Pi Kimi credential broker", () => {
     const scriptPath = join(home, "credential-command.mjs");
     writeFileSync(
       scriptPath,
-      'process.stdout.write("command-reference-fixture-key-419");\n',
+      'process.stdout.write("command-reference-fixture-key-419\\n");\n',
       { mode: 0o600 },
     );
     const fixture = piAuthFixture(

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -1,6 +1,35 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPiKimiCredentialBroker } from "../../src/providers/pi-kimi-credential.js";
+
+const originalHome = process.env.HOME;
+const originalPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+const originalKimiApiKey = process.env.KIMI_API_KEY;
+let temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalPiAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+  else process.env.PI_CODING_AGENT_DIR = originalPiAgentDir;
+  if (originalKimiApiKey === undefined) delete process.env.KIMI_API_KEY;
+  else process.env.KIMI_API_KEY = originalKimiApiKey;
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  temporaryDirectories = [];
+});
 
 type FakeRuntime = {
   listCredentials: ReturnType<typeof vi.fn>;
@@ -30,10 +59,40 @@ describe("Pi Kimi credential broker", () => {
     expectNoModelActivity(runtime);
   });
 
+  it("resolves a synthetic Pi-managed API key without changing Pi auth state", async () => {
+    const home = temporaryDirectory();
+    const authPath = join(home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": {
+          type: "api_key",
+          key: "runtime-managed-fixture-key-264",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = dirname(authPath);
+    delete process.env.KIMI_API_KEY;
+    const before = readFileSync(authPath, "utf8");
+    const broker = createPiKimiCredentialBroker();
+
+    await expect(broker.resolve()).resolves.toEqual({
+      status: "available",
+      apiKey: "runtime-managed-fixture-key-264",
+    });
+    expect(readFileSync(authPath, "utf8")).toBe(before);
+    expect(statSync(authPath).mode & 0o777).toBe(0o600);
+    expect(readdirSync(home)).toEqual([".pi"]);
+    expect(readdirSync(dirname(authPath))).toEqual(["auth.json"]);
+  });
+
   it("resolves a managed API key through the real network-disabled Pi runtime", async () => {
     const credential = {
       type: "api_key" as const,
-      key: "runtime-managed-fixture-key-264",
+      key: "runtime-managed-fixture-key-691",
     };
     const credentials = {
       read: vi.fn(async (providerId: string) =>
@@ -56,7 +115,7 @@ describe("Pi Kimi credential broker", () => {
 
     await expect(broker.resolve()).resolves.toEqual({
       status: "available",
-      apiKey: "runtime-managed-fixture-key-264",
+      apiKey: "runtime-managed-fixture-key-691",
     });
     expect(credentials.modify).not.toHaveBeenCalled();
     expect(credentials.delete).not.toHaveBeenCalled();
@@ -78,7 +137,6 @@ describe("Pi Kimi credential broker", () => {
   });
 
   it("resolves an environment API key through the real Pi runtime", async () => {
-    const original = process.env.KIMI_API_KEY;
     process.env.KIMI_API_KEY = "runtime-environment-fixture-key-851";
     const credentials = {
       read: vi.fn(async () => undefined),
@@ -86,26 +144,48 @@ describe("Pi Kimi credential broker", () => {
       modify: vi.fn(async () => undefined),
       delete: vi.fn(async () => undefined),
     };
-    try {
-      const broker = createPiKimiCredentialBroker({
-        loadRuntime: async () =>
-          ModelRuntime.create({
-            credentials,
-            allowModelNetwork: false,
-            modelsPath: null,
-          }),
-      });
+    const broker = createPiKimiCredentialBroker({
+      loadRuntime: async () =>
+        ModelRuntime.create({
+          credentials,
+          allowModelNetwork: false,
+          modelsPath: null,
+        }),
+    });
 
-      await expect(broker.resolve()).resolves.toEqual({
-        status: "available",
-        apiKey: "runtime-environment-fixture-key-851",
-      });
-      expect(credentials.modify).not.toHaveBeenCalled();
-      expect(credentials.delete).not.toHaveBeenCalled();
-    } finally {
-      if (original === undefined) delete process.env.KIMI_API_KEY;
-      else process.env.KIMI_API_KEY = original;
-    }
+    await expect(broker.resolve()).resolves.toEqual({
+      status: "available",
+      apiKey: "runtime-environment-fixture-key-851",
+    });
+    expect(credentials.modify).not.toHaveBeenCalled();
+    expect(credentials.delete).not.toHaveBeenCalled();
+  });
+
+  it("uses Pi's environment resolution without creating Pi auth state", async () => {
+    const home = temporaryDirectory();
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = join(home, ".pi", "agent");
+    process.env.KIMI_API_KEY = "runtime-environment-fixture-key-357";
+    const broker = createPiKimiCredentialBroker();
+
+    await expect(broker.resolve()).resolves.toEqual({
+      status: "available",
+      apiKey: "runtime-environment-fixture-key-357",
+    });
+    expect(readdirSync(home)).toEqual([]);
+  });
+
+  it("uses only Pi's supported one-off read and in-memory credential APIs", () => {
+    const implementation = readFileSync(
+      new URL("../../src/providers/pi-kimi-credential.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(implementation).toContain("readStoredCredential(PI_PROVIDER_ID)");
+    expect(implementation).toContain("new InMemoryCredentialStore()");
+    expect(implementation).not.toMatch(
+      /node:fs|auth\.json|readFile|JSON\.parse|writeFile|mkdir|rename|unlink/,
+    );
   });
 
   it("ignores resolver-provided base URLs and arbitrary headers", async () => {
@@ -205,6 +285,12 @@ describe("Pi Kimi credential broker", () => {
     expectNoModelActivity(available);
   });
 });
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "quota-axi-pi-kimi-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
 
 function fakeRuntime(options: {
   credentials?: Array<{ providerId: string; type: string }>;

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -298,6 +298,39 @@ describe("Pi Kimi credential broker", () => {
     expect(readdirSync(home)).toEqual([]);
   });
 
+  it("expands a Windows tilde Pi agent directory", async () => {
+    const home = temporaryDirectory();
+    const agentDirectory = join(home, ".pi\\agent");
+    const authPath = join(agentDirectory, "auth.json");
+    mkdirSync(agentDirectory, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": {
+          type: "api_key",
+          key: "windows-tilde-fixture-key-326",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = "~\\.pi\\agent";
+    const before = readFileSync(authPath, "utf8");
+    const platform = vi
+      .spyOn(process, "platform", "get")
+      .mockReturnValue("win32");
+
+    try {
+      await expect(createPiKimiCredentialBroker().resolve()).resolves.toEqual({
+        status: "available",
+        apiKey: "windows-tilde-fixture-key-326",
+      });
+      expect(readFileSync(authPath, "utf8")).toBe(before);
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
   it("uses a bounded direct read and only Pi's public runtime APIs", () => {
     const implementation = readFileSync(
       new URL("../../src/providers/pi-kimi-credential.ts", import.meta.url),

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -93,7 +93,38 @@ describe("Pi Kimi credential broker", () => {
     expect(readdirSync(dirname(authPath))).toEqual(["auth.json"]);
   });
 
-  it("resolves a stored environment reference through Pi without exposing the reference", async () => {
+  it("does not resolve credentials for unrelated Pi providers", async () => {
+    const home = temporaryDirectory();
+    const markerPath = join(home, "unrelated-command-ran");
+    const authPath = join(home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        unrelated: {
+          type: "api_key",
+          key: `!${JSON.stringify(process.execPath)} -e ${JSON.stringify(
+            `require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "bad")`,
+          )}`,
+        },
+        "kimi-coding": {
+          type: "api_key",
+          key: "exact-provider-fixture-key-615",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    process.env.HOME = home;
+    process.env.PI_CODING_AGENT_DIR = dirname(authPath);
+
+    await expect(createPiKimiCredentialBroker().resolve()).resolves.toEqual({
+      status: "available",
+      apiKey: "exact-provider-fixture-key-615",
+    });
+    expect(() => statSync(markerPath)).toThrow();
+  });
+
+  it("resolves a stored environment reference without exposing the reference", async () => {
     const fixture = piAuthFixture("$KIMI_API_KEY");
     process.env.KIMI_API_KEY = "environment-reference-fixture-key-742";
     const broker = createPiKimiCredentialBroker();
@@ -123,7 +154,16 @@ describe("Pi Kimi credential broker", () => {
     expectPiAuthUnchanged(fixture);
   });
 
-  it("resolves a supported stored command reference through Pi", async () => {
+  it("rejects an environment value that is still a reference", async () => {
+    const fixture = piAuthFixture("$KIMI_API_KEY");
+    process.env.KIMI_API_KEY = "$STILL_UNRESOLVED_KIMI_KEY";
+    const broker = createPiKimiCredentialBroker();
+
+    await expect(broker.resolve()).resolves.toEqual({ status: "missing" });
+    expectPiAuthUnchanged(fixture);
+  });
+
+  it("resolves a supported stored command reference", async () => {
     const home = temporaryDirectory();
     const scriptPath = join(home, "credential-command.mjs");
     writeFileSync(
@@ -142,6 +182,34 @@ describe("Pi Kimi credential broker", () => {
       apiKey: "command-reference-fixture-key-419",
     });
     expectPiAuthUnchanged(fixture, ["auth.json"]);
+  });
+
+  it.each([
+    ["unknown template", "prefix-$KIMI_API_KEY"],
+    ["malformed reference", "${KIMI_API_KEY"],
+    ["empty command", "!   "],
+    [
+      "failing command",
+      `!${JSON.stringify(process.execPath)} -e ${JSON.stringify("process.exit(1)")}`,
+    ],
+  ])("rejects a %s without exposing it", async (_label, key) => {
+    const fixture = piAuthFixture(key);
+    process.env.KIMI_API_KEY = "ambient-key-must-not-replace-bad-reference";
+    const broker = createPiKimiCredentialBroker();
+
+    const resolution = await broker.resolve();
+
+    expect(resolution).toEqual({ status: "missing" });
+    expect(JSON.stringify(resolution)).not.toContain(key);
+    expectPiAuthUnchanged(fixture);
+  });
+
+  it("rejects an oversized Pi auth file without reading beyond the bound", async () => {
+    const fixture = piAuthFixture("x".repeat(1_048_576));
+    const broker = createPiKimiCredentialBroker();
+
+    await expect(broker.resolve()).resolves.toEqual({ status: "missing" });
+    expectPiAuthUnchanged(fixture);
   });
 
   it("resolves a managed API key through the real network-disabled Pi runtime", async () => {
@@ -230,17 +298,17 @@ describe("Pi Kimi credential broker", () => {
     expect(readdirSync(home)).toEqual([]);
   });
 
-  it("uses only Pi's supported one-off read and in-memory credential APIs", () => {
+  it("uses a bounded direct read and only Pi's public runtime APIs", () => {
     const implementation = readFileSync(
       new URL("../../src/providers/pi-kimi-credential.ts", import.meta.url),
       "utf8",
     );
 
-    expect(implementation).toContain("readStoredCredential(PI_PROVIDER_ID)");
     expect(implementation).toContain("new InMemoryCredentialStore()");
-    expect(implementation).toContain("AuthStorage.inMemory");
+    expect(implementation).toContain("PI_AUTH_READ_LIMIT_BYTES + 1");
+    expect(implementation).toContain("readSync(");
     expect(implementation).not.toMatch(
-      /node:fs|auth\.json|readFile|JSON\.parse|writeFile|mkdir|rename|unlink/,
+      /dist\/core|AuthStorage|import\.meta\.resolve|readStoredCredential/,
     );
   });
 
@@ -314,7 +382,7 @@ describe("Pi Kimi credential broker", () => {
   });
 
   it("inspects only availability and credential type", async () => {
-    const available = fakeRuntime({ authAvailable: true });
+    const available = fakeRuntime({ apiKey: "inspection-fixture-key-907" });
     const missing = fakeRuntime({ authAvailable: false });
     const unsupported = fakeRuntime({
       credentials: [{ providerId: "kimi-coding", type: "oauth" }],
@@ -335,9 +403,9 @@ describe("Pi Kimi credential broker", () => {
         loadRuntime: async () => unsupported,
       }).inspect(),
     ).resolves.toBe("unsupported");
-    expect(available.getAuth).not.toHaveBeenCalled();
-    expect(available.checkAuth).toHaveBeenCalledExactlyOnceWith("kimi-coding");
-    expect(unsupported.checkAuth).not.toHaveBeenCalled();
+    expect(available.getAuth).toHaveBeenCalledExactlyOnceWith("kimi-coding");
+    expect(available.checkAuth).not.toHaveBeenCalled();
+    expect(unsupported.getAuth).not.toHaveBeenCalled();
     expectNoModelActivity(available);
   });
 });

--- a/test/providers/pi-kimi-credential.test.ts
+++ b/test/providers/pi-kimi-credential.test.ts
@@ -16,6 +16,7 @@ import { createPiKimiCredentialBroker } from "../../src/providers/pi-kimi-creden
 const originalHome = process.env.HOME;
 const originalPiAgentDir = process.env.PI_CODING_AGENT_DIR;
 const originalKimiApiKey = process.env.KIMI_API_KEY;
+const originalMissingKimiKey = process.env.MISSING_KIMI_KEY_FIXTURE_983;
 let temporaryDirectories: string[] = [];
 
 afterEach(() => {
@@ -25,6 +26,9 @@ afterEach(() => {
   else process.env.PI_CODING_AGENT_DIR = originalPiAgentDir;
   if (originalKimiApiKey === undefined) delete process.env.KIMI_API_KEY;
   else process.env.KIMI_API_KEY = originalKimiApiKey;
+  if (originalMissingKimiKey === undefined)
+    delete process.env.MISSING_KIMI_KEY_FIXTURE_983;
+  else process.env.MISSING_KIMI_KEY_FIXTURE_983 = originalMissingKimiKey;
   for (const directory of temporaryDirectories) {
     rmSync(directory, { recursive: true, force: true });
   }
@@ -87,6 +91,57 @@ describe("Pi Kimi credential broker", () => {
     expect(statSync(authPath).mode & 0o777).toBe(0o600);
     expect(readdirSync(home)).toEqual([".pi"]);
     expect(readdirSync(dirname(authPath))).toEqual(["auth.json"]);
+  });
+
+  it("resolves a stored environment reference through Pi without exposing the reference", async () => {
+    const fixture = piAuthFixture("$KIMI_API_KEY");
+    process.env.KIMI_API_KEY = "environment-reference-fixture-key-742";
+    const broker = createPiKimiCredentialBroker();
+
+    const resolution = await broker.resolve();
+
+    expect(resolution).toEqual({
+      status: "available",
+      apiKey: "environment-reference-fixture-key-742",
+    });
+    expect(JSON.stringify(resolution)).not.toContain("$KIMI_API_KEY");
+    expectPiAuthUnchanged(fixture);
+  });
+
+  it("reports a missing stored environment reference without transmitting it", async () => {
+    const fixture = piAuthFixture("${MISSING_KIMI_KEY_FIXTURE_983}");
+    delete process.env.MISSING_KIMI_KEY_FIXTURE_983;
+    delete process.env.KIMI_API_KEY;
+    const broker = createPiKimiCredentialBroker();
+
+    const resolution = await broker.resolve();
+
+    expect(resolution).toEqual({ status: "missing" });
+    expect(JSON.stringify(resolution)).not.toContain(
+      "MISSING_KIMI_KEY_FIXTURE_983",
+    );
+    expectPiAuthUnchanged(fixture);
+  });
+
+  it("resolves a supported stored command reference through Pi", async () => {
+    const home = temporaryDirectory();
+    const scriptPath = join(home, "credential-command.mjs");
+    writeFileSync(
+      scriptPath,
+      'process.stdout.write("command-reference-fixture-key-419");\n',
+      { mode: 0o600 },
+    );
+    const fixture = piAuthFixture(
+      `!${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
+      home,
+    );
+    const broker = createPiKimiCredentialBroker();
+
+    await expect(broker.resolve()).resolves.toEqual({
+      status: "available",
+      apiKey: "command-reference-fixture-key-419",
+    });
+    expectPiAuthUnchanged(fixture, ["auth.json"]);
   });
 
   it("resolves a managed API key through the real network-disabled Pi runtime", async () => {
@@ -183,6 +238,7 @@ describe("Pi Kimi credential broker", () => {
 
     expect(implementation).toContain("readStoredCredential(PI_PROVIDER_ID)");
     expect(implementation).toContain("new InMemoryCredentialStore()");
+    expect(implementation).toContain("AuthStorage.inMemory");
     expect(implementation).not.toMatch(
       /node:fs|auth\.json|readFile|JSON\.parse|writeFile|mkdir|rename|unlink/,
     );
@@ -290,6 +346,34 @@ function temporaryDirectory(): string {
   const directory = mkdtempSync(join(tmpdir(), "quota-axi-pi-kimi-"));
   temporaryDirectories.push(directory);
   return directory;
+}
+
+function piAuthFixture(
+  key: string,
+  existingHome?: string,
+): { authPath: string; before: string } {
+  const home = existingHome ?? temporaryDirectory();
+  const authPath = join(home, ".pi", "agent", "auth.json");
+  mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      "kimi-coding": { type: "api_key", key },
+    }),
+    { mode: 0o600 },
+  );
+  process.env.HOME = home;
+  process.env.PI_CODING_AGENT_DIR = dirname(authPath);
+  return { authPath, before: readFileSync(authPath, "utf8") };
+}
+
+function expectPiAuthUnchanged(
+  fixture: { authPath: string; before: string },
+  expectedFiles: string[] = ["auth.json"],
+): void {
+  expect(readFileSync(fixture.authPath, "utf8")).toBe(fixture.before);
+  expect(statSync(fixture.authPath).mode & 0o777).toBe(0o600);
+  expect(readdirSync(dirname(fixture.authPath))).toEqual(expectedFiles);
 }
 
 function fakeRuntime(options: {


### PR DESCRIPTION
## Intent

Fix the published quota-axi 0.1.10 Kimi credential-inspection side effect before any global upgrade, then ship the correction. Both `quota-axi auth --provider kimi` and quota inspection in a fresh isolated HOME must not create `.pi/agent/auth.json` or any Pi provider state. Preserve Pi-first exact `kimi-coding` credential resolution and official `KIMI_API_KEY` handling through Pi supported APIs, followed by the official Kimi Code CLI fallback, without directly parsing Pi auth, launching Pi or Kimi, refreshing credentials, making model requests, contacting custom origins, importing browser state, exposing values, or modifying the global installation or release 0.1.10. Use Pi supported one-off credential access with injectable non-persisting storage, and add deterministic synthetic-home coverage for empty auth/quota inspection, CLI-only fallback state at request time, Pi-managed credentials, environment-backed credentials, provider suite behavior, built CLI output, formatting, lint, and generated surfaces. Keep the correction narrowly scoped to restoring the promised read-only contract.

## What Changed

- Resolve Pi-managed `kimi-coding` credentials through Pi’s supported APIs using non-persisting in-memory storage, preventing Kimi auth and quota inspection from creating Pi state.
- Preserve environment-backed credential references, command output normalization, Windows tilde paths, and the official Kimi Code CLI fallback.
- Add deterministic provider and built-CLI coverage verifying fresh-home inspections remain read-only, and document the guarantee.

## Risk Assessment

✅ Low: The final implementation is bounded, fail-closed, non-persisting, redacts credentials, preserves the required fallback order, and now matches Pi command-output and Windows path semantics for the covered contract.

## Testing

The prior build failure is resolved: focused Kimi coverage, the complete provider suite, production build, generated skill surface check, and direct compiled-CLI auth/quota inspection all passed; the captured transcript demonstrates that an isolated HOME remains free of Pi state.

- Evidence: [Built CLI empty-HOME read-only transcript](https://github.com/kunchenguid/quota-axi/blob/47b6b6880f689f603e200ec97fd896f6ac5beec3/.no-mistakes/evidence/fm/quota-axi-kimi-pi-auth-readonly-f1/built-cli-empty-home.txt)
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (12m28s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- 🚨 `src/providers/pi-kimi-credential.ts:89` - The required intent says to “Preserve Pi-first exact `kimi-coding` credential resolution and official `KIMI_API_KEY` handling through Pi supported APIs,” but this hunk copies `readStoredCredential()` directly into `InMemoryCredentialStore`. That API deliberately returns API-key configuration values unresolved. A Pi credential such as `key: &#34;$KIMI_API_KEY&#34;` or a command-backed key therefore becomes the literal bearer token instead of being resolved as Pi normally resolves it. This can break authentication and expose the stored reference to Kimi&#39;s endpoint. Please confirm whether reference-backed Pi credentials are intentionally unsupported; otherwise preserve Pi&#39;s supported resolution semantics while retaining non-persisting storage.

🔧 Fix: Resolve Pi-backed Kimi credential references read-only
1 error still open:
- 🚨 `src/providers/pi-kimi-credential.ts:126` - The intent requires “Pi supported APIs,” and the follow-up explicitly says to escalate if Pi has no safe supported resolver. This code instead constructs a file URL for `dist/core/auth-storage.js` and imports `AuthStorage`, which Pi deliberately does not export in its package export map or public entrypoint. The pinned package currently contains that private file, but this bypass is unsupported and can break with packaging changes. Please escalate for a public Pi resolver or explicitly approve reliance on the private module.

🔧 Fix: Resolve Kimi references without Pi private APIs
2 issues (1 error, 1 warning) still open:
- 🚨 `src/providers/pi-kimi-credential.ts:206` - The required exact Pi command-reference behavior is not preserved for normal commands that end stdout with a newline. Pi trims command output, but this passes raw `execSync` output to `usableApiKey`, which rejects the trailing control character. Common references such as `!echo &#34;$KIMI_API_KEY&#34;` therefore resolve as missing and fall back instead of using the Pi credential. Trim command stdout before validating it, while keeping the value redacted.
- ⚠️ `src/providers/pi-kimi-credential.ts:254` - Pi expands both `~/...` and Windows `~\...` values in `PI_CODING_AGENT_DIR`, but this replacement only handles the slash form. On Windows, a standard tilde-configured agent directory is treated as a relative path, so the wrong auth file is inspected and Pi-managed Kimi credentials are missed. Mirror Pi&#39;s Windows tilde expansion.

🔧 Fix: Support Windows tilde Pi credential paths
1 error still open:
- 🚨 `src/providers/pi-kimi-credential.ts:206` - The required exact Pi command-reference behavior remains broken for commands that end stdout with a newline. Pi trims command output, but raw `execSync` output is passed to `usableApiKey`, which rejects the trailing control character. Common references such as `!echo &#34;$KIMI_API_KEY&#34;` therefore resolve as missing. Trim command stdout before validation while keeping it redacted.

🔧 Fix: Trim Pi command credential output before validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/providers/pi-kimi-credential.ts:176` - The target does not build. TypeScript rejects passing the allocated `Buffer` to `readSync`, so the built CLI acceptance criterion cannot be validated.
- 🚨 `src/providers/pi-kimi-credential.ts:106` - The implementation directly reads and parses Pi&#39;s `auth.json`, then manually resolves environment and command-backed credentials. This violates the authoritative requirement forbidding direct Pi auth parsing and requiring credential resolution through Pi&#39;s supported APIs.
- <code>`pnpm run build` (failed at `src/providers/pi-kimi-credential.ts:176`)</code>
- `pnpm exec vitest run test/kimi-cli-readonly.test.ts test/providers/pi-kimi-credential.test.ts test/providers/kimi.test.ts test/providers/kimi-code-cli-credential.test.ts`
- `pnpm test`
- `pnpm run build:skill -- --check`
- <code>Manual fresh-HOME source CLI execution of `auth --provider kimi --json --full` and `--provider kimi --json --full`, followed by filesystem inspection confirming `.pi` remained absent</code>
- `Inspected the target implementation against the authoritative forbidden-behavior constraints`

🔧 Fix: Fix read-only Pi credential resolution
✅ Re-checked - no issues remain.
- `pnpm exec vitest run test/kimi-cli-readonly.test.ts test/providers/pi-kimi-credential.test.ts test/providers/kimi.test.ts test/providers/kimi-code-cli-credential.test.ts`
- `pnpm run build`
- `pnpm test`
- <code>Ran `node dist/bin/quota-axi.js auth --provider kimi --json --full` with isolated `HOME`, `XDG_CACHE_HOME`, and `KIMI_CODE_HOME`; verified exit 0 and no `.pi` state.</code>
- <code>Ran `node dist/bin/quota-axi.js --provider kimi --json --full` in the same isolated HOME; verified expected exit 1, `auth_required`, Pi-first source ordering, and no `.pi` state.</code>
- `pnpm run build:skill -- --check`
- <code>Removed generated `dist/` build output after evidence capture and verified only the dedicated evidence directory remained untracked.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
