### PR TITLE
fix(providers): clean up unread Kimi responses

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/built-cli-synthetic-503.txt
+++ b/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/built-cli-synthetic-503.txt
@@ -1,0 +1,48 @@
+$ node --import <synthetic-503-fetch> dist/bin/quota-axi.js --provider kimi --json --full
+exitCode: 1
+stderr: <empty>
+stdout:
+{
+  "generatedAt": "2026-07-21T02:29:27.198Z",
+  "schemaVersion": 2,
+  "providers": [
+    {
+      "provider": "kimi",
+      "label": "Kimi",
+      "source": "unavailable",
+      "windows": [],
+      "state": {
+        "status": "error",
+        "stale": false,
+        "error": "provider_unavailable",
+        "sourcesTried": [
+          "pi:kimi-coding"
+        ]
+      },
+      "attempts": [
+        {
+          "source": "pi:kimi-coding",
+          "status": "failed",
+          "error": "provider_unavailable"
+        }
+      ]
+    }
+  ]
+}
+responseCleanup:
+{
+  "cancelCount": 1,
+  "request": {
+    "url": "https://api.kimi.com/coding/v1/usages",
+    "method": "GET",
+    "redirect": "manual",
+    "credentials": "omit",
+    "authorizationMatches": true
+  },
+  "cleanupCompleted": true
+}
+credentialStateUnchanged: true
+cacheEntries: []
+syntheticSecretRedacted: true
+externalNetworkContact: false (global fetch was replaced before CLI startup)
+result: PASS

--- a/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/loopback-socket-close.txt
+++ b/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/loopback-socket-close.txt
@@ -1,0 +1,33 @@
+$ node reproduce-loopback-socket-close.mjs
+[
+  {
+    "status": 503,
+    "contentType": "application/json",
+    "mappedError": "provider_unavailable",
+    "requestContract": {
+      "url": "https://api.kimi.com/coding/v1/usages",
+      "method": "GET",
+      "redirect": "manual",
+      "credentials": "omit"
+    },
+    "streamingResponseClosed": true,
+    "requestSocketClosed": true,
+    "closeBoundMs": 2000
+  },
+  {
+    "status": 200,
+    "contentType": "text/plain",
+    "mappedError": "unexpected_content_type",
+    "requestContract": {
+      "url": "https://api.kimi.com/coding/v1/usages",
+      "method": "GET",
+      "redirect": "manual",
+      "credentials": "omit"
+    },
+    "streamingResponseClosed": true,
+    "requestSocketClosed": true,
+    "closeBoundMs": 2000
+  }
+]
+externalNetworkContact: false (the injected transport rewrote the fixed Kimi URL to 127.0.0.1)
+result: PASS

--- a/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-built-cli-503.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-built-cli-503.mjs
@@ -1,0 +1,163 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const syntheticSecret = "synthetic-cleanup-key-731";
+const root = mkdtempSync(join(tmpdir(), "quota-axi-kimi-evidence-"));
+const home = join(root, "home");
+const cacheHome = join(root, "cache");
+const kimiCodeHome = join(root, "kimi-code");
+const authPath = join(home, ".pi", "agent", "auth.json");
+const preloadPath = join(root, "synthetic-503-fetch.mjs");
+const markerPath = join(root, "response-cleanup.json");
+const transcriptPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "built-cli-synthetic-503.txt",
+);
+
+try {
+  for (const directory of [home, cacheHome, kimiCodeHome, dirname(authPath)]) {
+    mkdirSync(directory, { recursive: true, mode: 0o700 });
+  }
+  chmodSync(root, 0o700);
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      "kimi-coding": { type: "api_key", key: syntheticSecret },
+    }),
+    { mode: 0o600 },
+  );
+  const authBefore = snapshot(authPath);
+
+  writeFileSync(
+    preloadPath,
+    `import { writeFileSync } from "node:fs";
+
+let cancelCount = 0;
+globalThis.fetch = async (input, init) => {
+  const headers = new Headers(init?.headers);
+  const request = {
+    url: String(input),
+    method: init?.method,
+    redirect: init?.redirect,
+    credentials: init?.credentials,
+    authorizationMatches:
+      headers.get("authorization") === "Bearer ${syntheticSecret}",
+  };
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("synthetic error body"));
+    },
+    async cancel() {
+      cancelCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(
+        process.env.KIMI_CLEANUP_MARKER,
+        JSON.stringify({ cancelCount, request, cleanupCompleted: true }),
+        { mode: 0o600 },
+      );
+    },
+  });
+  return new Response(body, {
+    status: 503,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+    { mode: 0o600 },
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      "--import",
+      pathToFileURL(preloadPath).href,
+      resolve("dist/bin/quota-axi.js"),
+      "--provider",
+      "kimi",
+      "--json",
+      "--full",
+    ],
+    {
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        HOME: home,
+        XDG_CACHE_HOME: cacheHome,
+        KIMI_CODE_HOME: kimiCodeHome,
+        KIMI_CLEANUP_MARKER: markerPath,
+        PATH: process.env.PATH ?? "",
+      },
+    },
+  );
+  if (result.error) throw result.error;
+
+  const marker = JSON.parse(readFileSync(markerPath, "utf8"));
+  const authUnchanged = JSON.stringify(snapshot(authPath)) === JSON.stringify(authBefore);
+  const cacheEntries = readdirSync(cacheHome);
+  const secretRedacted = !result.stdout.includes(syntheticSecret);
+
+  assert(result.status === 1, `expected CLI exit 1, received ${result.status}`);
+  assert(result.stderr === "", `expected empty stderr, received ${result.stderr}`);
+  assert(marker.cancelCount === 1, "response cancellation count was not exactly one");
+  assert(marker.cleanupCompleted === true, "response cleanup did not complete before CLI exit");
+  assert(
+    JSON.stringify(marker.request) ===
+      JSON.stringify({
+        url: "https://api.kimi.com/coding/v1/usages",
+        method: "GET",
+        redirect: "manual",
+        credentials: "omit",
+        authorizationMatches: true,
+      }),
+    "request contract changed",
+  );
+  assert(authUnchanged, "synthetic Pi credential state changed");
+  assert(cacheEntries.length === 0, "cache state changed");
+  assert(secretRedacted, "synthetic secret appeared in CLI output");
+
+  const transcript = [
+    "$ node --import <synthetic-503-fetch> dist/bin/quota-axi.js --provider kimi --json --full",
+    `exitCode: ${result.status}`,
+    "stderr: <empty>",
+    "stdout:",
+    JSON.stringify(JSON.parse(result.stdout), null, 2),
+    "responseCleanup:",
+    JSON.stringify(marker, null, 2),
+    `credentialStateUnchanged: ${authUnchanged}`,
+    `cacheEntries: ${JSON.stringify(cacheEntries)}`,
+    `syntheticSecretRedacted: ${secretRedacted}`,
+    "externalNetworkContact: false (global fetch was replaced before CLI startup)",
+    "result: PASS",
+    "",
+  ].join("\n");
+  writeFileSync(transcriptPath, transcript, { mode: 0o600 });
+  process.stdout.write(transcript);
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+function snapshot(path) {
+  const stats = statSync(path);
+  return {
+    bytes: readFileSync(path, "utf8"),
+    mode: stats.mode & 0o777,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+  };
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-loopback-socket-close.mjs
+++ b/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-loopback-socket-close.mjs
@@ -1,0 +1,133 @@
+import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createKimiAdapter } from "../../../../dist/src/providers/kimi.js";
+
+const cases = [
+  { status: 503, contentType: "application/json", expected: "provider_unavailable" },
+  { status: 200, contentType: "text/plain", expected: "unexpected_content_type" },
+];
+const results = [];
+
+for (const testCase of cases) {
+  results.push(await exercise(testCase));
+}
+
+const transcript = [
+  "$ node reproduce-loopback-socket-close.mjs",
+  JSON.stringify(results, null, 2),
+  "externalNetworkContact: false (the injected transport rewrote the fixed Kimi URL to 127.0.0.1)",
+  "result: PASS",
+  "",
+].join("\n");
+writeFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "loopback-socket-close.txt"),
+  transcript,
+  { mode: 0o600 },
+);
+process.stdout.write(transcript);
+
+async function exercise({ status, contentType, expected }) {
+  const responseClosed = deferred();
+  const socketClosed = deferred();
+  const sockets = new Set();
+  const server = createServer((_request, response) => {
+    response.once("close", responseClosed.resolve);
+    response.socket?.once("close", socketClosed.resolve);
+    response.writeHead(status, { "content-type": contentType });
+    response.write("synthetic streaming response");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+    const address = server.address();
+    const loopbackUrl = `http://127.0.0.1:${address.port}/usage`;
+    let requestContract;
+    const adapter = createKimiAdapter({
+      broker: {
+        resolve: async () => ({ status: "available", apiKey: "synthetic-loopback-key" }),
+        inspect: async () => "available",
+      },
+      cliCredentialSource: {
+        resolve: async () => ({ status: "missing" }),
+        inspect: async () => "missing",
+      },
+      fetch: async (input, init) => {
+        requestContract = {
+          url: String(input),
+          method: init?.method,
+          redirect: init?.redirect,
+          credentials: init?.credentials,
+        };
+        assert(
+          requestContract.url === "https://api.kimi.com/coding/v1/usages",
+          "fixed Kimi request URL changed",
+        );
+        return globalThis.fetch(loopbackUrl, init);
+      },
+      readCachedProvider: () => undefined,
+      deleteCachedProvider: () => undefined,
+      now: () => Date.parse("2027-02-03T04:05:06.000Z"),
+      deadlineMs: 1_000,
+    });
+
+    const report = await adapter.fetchQuota({ allowKeychainPrompt: false });
+    assert(report.state.error === expected, `expected ${expected}, received ${report.state.error}`);
+    await settlesWithin(responseClosed.promise, "streaming response close");
+    await settlesWithin(socketClosed.promise, "request socket close");
+
+    return {
+      status,
+      contentType,
+      mappedError: report.state.error,
+      requestContract,
+      streamingResponseClosed: true,
+      requestSocketClosed: true,
+      closeBoundMs: 2_000,
+    };
+  } finally {
+    server.closeAllConnections();
+    if (server.listening) {
+      await new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+}
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function settlesWithin(promise, description) {
+  let timer;
+  try {
+    await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${description} did not settle`)), 2_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/src/providers/kimi.ts
+++ b/src/providers/kimi.ts
@@ -71,6 +71,11 @@ type NormalizedDetail = {
   resetsAt?: string;
 };
 
+type ResponseBodyLifetime = {
+  markConsumed(): void;
+  cancel(action?: () => Promise<unknown> | undefined): Promise<void>;
+};
+
 export function createKimiAdapter(
   overrides: Partial<KimiDependencies> = {},
 ): ProviderAdapter {
@@ -468,40 +473,46 @@ async function requestKimiQuota(
     });
   }
 
-  const receivedAt = now();
-  rejectHttpFailure(response, receivedAt);
-  const mediaType = response.headers
-    .get("content-type")
-    ?.split(";", 1)[0]
-    ?.trim()
-    .toLowerCase();
-  if (mediaType !== "application/json") {
-    throw new KimiFailure("unexpected_content_type", {
-      staleEligible: true,
-    });
-  }
-
-  let bytes: Uint8Array;
+  const lifetime = createResponseBodyLifetime(response);
   try {
-    bytes = await readBoundedBody(response, signal);
-  } catch (error) {
-    if (error instanceof KimiFailure) throw error;
-    if (signal.aborted || isAbortError(error)) {
-      throw new KimiFailure("request_timeout", { staleEligible: true });
+    const receivedAt = now();
+    rejectHttpFailure(response, receivedAt);
+    const mediaType = response.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (mediaType !== "application/json") {
+      throw new KimiFailure("unexpected_content_type", {
+        staleEligible: true,
+      });
     }
-    throw new KimiFailure("network_unavailable", { staleEligible: true });
-  }
 
-  let text: string;
-  try {
-    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  } catch {
-    throw new KimiFailure("response_invalid_utf8", { staleEligible: true });
-  }
-  try {
-    return JSON.parse(text) as unknown;
-  } catch {
-    throw new KimiFailure("malformed_json", { staleEligible: true });
+    let bytes: Uint8Array;
+    try {
+      bytes = await readBoundedBody(response, signal, lifetime);
+      lifetime.markConsumed();
+    } catch (error) {
+      if (error instanceof KimiFailure) throw error;
+      if (signal.aborted || isAbortError(error)) {
+        throw new KimiFailure("request_timeout", { staleEligible: true });
+      }
+      throw new KimiFailure("network_unavailable", { staleEligible: true });
+    }
+
+    let text: string;
+    try {
+      text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    } catch {
+      throw new KimiFailure("response_invalid_utf8", { staleEligible: true });
+    }
+    try {
+      return JSON.parse(text) as unknown;
+    } catch {
+      throw new KimiFailure("malformed_json", { staleEligible: true });
+    }
+  } finally {
+    await lifetime.cancel();
   }
 }
 
@@ -539,11 +550,11 @@ function rejectHttpFailure(response: Response, receivedAt: number): void {
 async function readBoundedBody(
   response: Response,
   signal: AbortSignal,
+  lifetime: ResponseBodyLifetime,
 ): Promise<Uint8Array> {
   const declaredLength = response.headers.get("content-length")?.trim();
   if (declaredLength && /^\d+$/.test(declaredLength)) {
     if (BigInt(declaredLength) > BigInt(RESPONSE_LIMIT_BYTES)) {
-      void response.body?.cancel().catch(() => undefined);
       throw new KimiFailure("response_too_large", { staleEligible: true });
     }
   }
@@ -554,11 +565,10 @@ async function readBoundedBody(
   let length = 0;
   try {
     while (true) {
-      const { done, value } = await readBodyChunk(reader, signal);
+      const { done, value } = await readBodyChunk(reader, signal, lifetime);
       if (done) break;
       length += value.length;
       if (length > RESPONSE_LIMIT_BYTES) {
-        void reader.cancel().catch(() => undefined);
         throw new KimiFailure("response_too_large", { staleEligible: true });
       }
       chunks.push(value);
@@ -576,33 +586,57 @@ async function readBoundedBody(
   return bytes;
 }
 
-function readBodyChunk(
+async function readBodyChunk(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   signal: AbortSignal,
+  lifetime: ResponseBodyLifetime,
 ): Promise<ReadableStreamReadResult<Uint8Array>> {
+  const cancelReader = () => lifetime.cancel(() => reader.cancel());
   if (signal.aborted) {
-    void reader.cancel().catch(() => undefined);
-    return Promise.reject(
-      new KimiFailure("request_timeout", { staleEligible: true }),
-    );
+    await cancelReader();
+    throw new KimiFailure("request_timeout", { staleEligible: true });
   }
   return new Promise((resolve, reject) => {
+    let aborted = false;
     const abort = () => {
-      void reader.cancel().catch(() => undefined);
-      reject(new KimiFailure("request_timeout", { staleEligible: true }));
+      aborted = true;
+      cancelReader().then(() => {
+        reject(new KimiFailure("request_timeout", { staleEligible: true }));
+      });
     };
     signal.addEventListener("abort", abort, { once: true });
     reader.read().then(
       (result) => {
+        if (aborted) return;
         signal.removeEventListener("abort", abort);
         resolve(result);
       },
       (error: unknown) => {
+        if (aborted) return;
         signal.removeEventListener("abort", abort);
         reject(error);
       },
     );
   });
+}
+
+function createResponseBodyLifetime(response: Response): ResponseBodyLifetime {
+  let consumed = false;
+  let cancellation: Promise<void> | undefined;
+
+  return {
+    markConsumed() {
+      if (!cancellation) consumed = true;
+    },
+    async cancel(action = () => response.body?.cancel()) {
+      if (consumed) return;
+      cancellation ??= Promise.resolve()
+        .then(action)
+        .then(() => undefined)
+        .catch(() => undefined);
+      await cancellation;
+    },
+  };
 }
 
 export function normalizeKimiPayload(payload: unknown): NormalizedKimiPayload {

--- a/test/kimi-built-cli-response-cleanup.test.ts
+++ b/test/kimi-built-cli-response-cleanup.test.ts
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const BUILT_CLI_ENTRYPOINT = resolve("dist/bin/quota-axi.js");
+const TSC_ENTRYPOINT = resolve("node_modules/typescript/bin/tsc");
+let temporaryDirectories: string[] = [];
+
+beforeAll(() => {
+  const result = spawnSync(
+    process.execPath,
+    [TSC_ENTRYPOINT, "--pretty", "false"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      timeout: 30_000,
+    },
+  );
+  if (result.error) throw result.error;
+  expect(result.status, `${result.stdout}${result.stderr}`).toBe(0);
+  expect(existsSync(BUILT_CLI_ENTRYPOINT)).toBe(true);
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  temporaryDirectories = [];
+});
+
+describe("built Kimi CLI response cleanup", () => {
+  it("awaits cancellation of an unread streaming 503 response", () => {
+    const fixture = isolatedFixture();
+    const authPath = join(fixture.home, ".pi", "agent", "auth.json");
+    mkdirSync(dirname(authPath), { recursive: true, mode: 0o700 });
+    writeFileSync(
+      authPath,
+      JSON.stringify({
+        "kimi-coding": {
+          type: "api_key",
+          key: "synthetic-cleanup-key-731",
+        },
+      }),
+      { mode: 0o600 },
+    );
+    const authBefore = snapshot(authPath);
+    const preload = join(fixture.root, "synthetic-503-fetch.mjs");
+    const cleanupMarker = join(fixture.root, "response-cleanup.json");
+    writeFileSync(
+      preload,
+      `import { writeFileSync } from "node:fs";
+
+let cancelCount = 0;
+globalThis.fetch = async (input, init) => {
+  const headers = new Headers(init?.headers);
+  const request = {
+    url: String(input),
+    method: init?.method,
+    redirect: init?.redirect,
+    credentials: init?.credentials,
+    authorizationMatches:
+      headers.get("authorization") === "Bearer synthetic-cleanup-key-731",
+  };
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("synthetic error body"));
+    },
+    async cancel() {
+      cancelCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      writeFileSync(
+        process.env.KIMI_CLEANUP_MARKER,
+        JSON.stringify({ cancelCount, request, cleanupCompleted: true }),
+        { mode: 0o600 },
+      );
+    },
+  });
+  return new Response(body, {
+    status: 503,
+    headers: { "content-type": "application/json" },
+  });
+};
+`,
+      { mode: 0o600 },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        pathToFileURL(preload).href,
+        BUILT_CLI_ENTRYPOINT,
+        "--provider",
+        "kimi",
+        "--json",
+        "--full",
+      ],
+      {
+        encoding: "utf8",
+        timeout: 10_000,
+        env: {
+          HOME: fixture.home,
+          XDG_CACHE_HOME: fixture.cacheHome,
+          KIMI_CODE_HOME: fixture.kimiCodeHome,
+          KIMI_CLEANUP_MARKER: cleanupMarker,
+          PATH: process.env.PATH ?? "",
+        },
+      },
+    );
+    if (result.error) throw result.error;
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      providers: [
+        {
+          provider: "kimi",
+          source: "unavailable",
+          state: {
+            status: "error",
+            error: "provider_unavailable",
+            sourcesTried: ["pi:kimi-coding"],
+          },
+        },
+      ],
+    });
+    expect(JSON.parse(readFileSync(cleanupMarker, "utf8"))).toEqual({
+      cancelCount: 1,
+      request: {
+        url: "https://api.kimi.com/coding/v1/usages",
+        method: "GET",
+        redirect: "manual",
+        credentials: "omit",
+        authorizationMatches: true,
+      },
+      cleanupCompleted: true,
+    });
+    expect(snapshot(authPath)).toEqual(authBefore);
+    expect(readdirSync(fixture.cacheHome)).toEqual([]);
+    expect(result.stdout).not.toContain("synthetic-cleanup-key-731");
+  });
+});
+
+type IsolatedFixture = {
+  root: string;
+  home: string;
+  cacheHome: string;
+  kimiCodeHome: string;
+};
+
+function isolatedFixture(): IsolatedFixture {
+  const root = mkdtempSync(join(tmpdir(), "quota-axi-kimi-cleanup-"));
+  temporaryDirectories.push(root);
+  chmodSync(root, 0o700);
+  const fixture = {
+    root,
+    home: join(root, "home"),
+    cacheHome: join(root, "cache"),
+    kimiCodeHome: join(root, "kimi-code"),
+  };
+  for (const directory of [
+    fixture.home,
+    fixture.cacheHome,
+    fixture.kimiCodeHome,
+  ]) {
+    mkdirSync(directory, { mode: 0o700 });
+  }
+  return fixture;
+}
+
+type FileSnapshot = {
+  bytes: string;
+  mode: number;
+  mtimeMs: number;
+  size: number;
+};
+
+function snapshot(path: string): FileSnapshot {
+  const stats = statSync(path);
+  return {
+    bytes: readFileSync(path, "utf8"),
+    mode: stats.mode & 0o777,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+  };
+}

--- a/test/providers/kimi.test.ts
+++ b/test/providers/kimi.test.ts
@@ -1,3 +1,5 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
 import { describe, expect, it, vi } from "vitest";
 import {
   createKimiAdapter,
@@ -226,6 +228,69 @@ describe("Kimi request transport", () => {
     }
   });
 
+  it.each([
+    [503, "application/json", "provider_unavailable"],
+    [200, "text/plain", "unexpected_content_type"],
+  ] as const)(
+    "awaits exactly one response cleanup for HTTP %i with %s",
+    async (status, contentType, expectedError) => {
+      let finishCleanup: (() => void) | undefined;
+      const cancel = vi.fn(
+        async () =>
+          new Promise<void>((resolve) => {
+            finishCleanup = resolve;
+          }),
+      );
+      const response = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("synthetic body"));
+          },
+          cancel,
+        }),
+        { status, headers: { "content-type": contentType } },
+      );
+      const reportPromise = testAdapter({
+        fetch: vi.fn(async () => response),
+      }).fetchQuota(OPTIONS);
+
+      await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+      let settled = false;
+      void reportPromise.then(() => {
+        settled = true;
+      });
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      finishCleanup?.();
+      const report = await reportPromise;
+
+      expect(report.state.error).toBe(expectedError);
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    [503, "application/json", "provider_unavailable"],
+    [200, "text/plain", "unexpected_content_type"],
+  ] as const)(
+    "closes a loopback streaming response and socket for HTTP %i with %s",
+    async (status, contentType, expectedError) => {
+      const fixture = await streamingServer(status, contentType);
+      try {
+        const report = await testAdapter({
+          fetch: fixture.transport,
+        }).fetchQuota(OPTIONS);
+
+        expect(report.state.error).toBe(expectedError);
+        await settlesWithin(fixture.responseClosed, "response close");
+        await settlesWithin(fixture.socketClosed, "request socket close");
+      } finally {
+        await fixture.close();
+      }
+    },
+  );
+
   it("enforces the total deadline while credential resolution is pending", async () => {
     const request = vi.fn();
     const broker: KimiCredentialBroker = {
@@ -254,6 +319,29 @@ describe("Kimi request transport", () => {
       deadlineMs: 5,
     }).fetchQuota(OPTIONS);
 
+    expect(report.state.error).toBe("request_timeout");
+  });
+
+  it("propagates deadline cancellation to the transport signal", async () => {
+    let transportAborted = false;
+    const report = await testAdapter({
+      fetch: vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) =>
+          new Promise<Response>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => {
+                transportAborted = true;
+                reject(new DOMException("aborted", "AbortError"));
+              },
+              { once: true },
+            );
+          }),
+      ),
+      deadlineMs: 5,
+    }).fetchQuota(OPTIONS);
+
+    expect(transportAborted).toBe(true);
     expect(report.state.error).toBe("request_timeout");
   });
 
@@ -1041,4 +1129,97 @@ async function transientWithCache(
     fetch: vi.fn(async () => new Response(null, { status: 503 })),
     readCachedProvider: () => cached,
   }).fetchQuota(OPTIONS);
+}
+
+type StreamingServerFixture = {
+  transport: typeof globalThis.fetch;
+  responseClosed: Promise<void>;
+  socketClosed: Promise<void>;
+  close(): Promise<void>;
+};
+
+async function streamingServer(
+  status: number,
+  contentType: string,
+): Promise<StreamingServerFixture> {
+  const responseClose = deferred();
+  const socketClose = deferred();
+  const sockets = new Set<Socket>();
+  const server = createServer((_request, response) => {
+    response.once("close", responseClose.resolve);
+    response.socket?.once("close", socketClose.resolve);
+    response.writeHead(status, { "content-type": contentType });
+    response.write("synthetic streaming response");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => {
+      sockets.delete(socket);
+    });
+  });
+  await listen(server);
+  const address = server.address() as AddressInfo;
+  const loopbackUrl = `http://127.0.0.1:${address.port}/usage`;
+
+  return {
+    transport: async (input, init) => {
+      expect(String(input)).toBe("https://api.kimi.com/coding/v1/usages");
+      expect(init).toMatchObject({
+        method: "GET",
+        redirect: "manual",
+        credentials: "omit",
+      });
+      return globalThis.fetch(loopbackUrl, init);
+    },
+    responseClosed: responseClose.promise,
+    socketClosed: socketClose.promise,
+    async close() {
+      server.closeAllConnections();
+      if (!server.listening) return;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+async function settlesWithin(
+  promise: Promise<void>,
+  description: string,
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${description} did not settle`)),
+          2_000,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }


### PR DESCRIPTION
## Intent

Fix the independently reproduced release blocker in corrected quota-axi Kimi quota transport before release PR #34 can proceed. Centralize response-body lifetime handling so every terminal path that does not consume a Kimi response, including all non-200 mappings and wrong content type, cancels cleanup exactly once and awaits completion, while preserving the 15-second deadline, streamed and declared size limits, timeout cancellation, fixed GET https://api.kimi.com/coding/v1/usages, Pi-first and official Kimi CLI source switching, secret redaction, no state mutation, and successful full-body behavior. Retain the exact built-CLI synthetic 503 reproduction as a regression and add bounded loopback transport tests proving streaming response and request-socket closure. Use only synthetic credentials and loopback transport, do not change the direct Pi auth parser, do not contact Kimi or read real credentials, do not touch release PR #34, and do not globally install or release.

## What Changed

- Centralize Kimi response-body lifetime handling so unread error and wrong-content-type responses are cancelled exactly once and cleanup completes before returning.
- Preserve deadline cancellation and bounded successful-body reads while closing streaming responses and request sockets on terminal failures.
- Add built-CLI synthetic 503 regression coverage and bounded loopback transport tests for response and socket cleanup.

## Risk Assessment

✅ Low: The response-lifetime change is well-bounded, preserves the required Kimi transport and credential behavior, and consistently awaits one memoized cleanup operation on every unconsumed-response path.

## Testing

Focused and full automated tests passed. Built-CLI and loopback evidence demonstrated awaited single cleanup, bounded streaming response and socket closure, fixed read-only GET transport, Pi-first credential behavior, redaction, successful body handling, deadlines and size limits, and no credential or cache mutation without contacting Kimi. Generated build and dependency directories were removed afterward.

- Evidence: [Built CLI synthetic 503 reproduction](https://github.com/kunchenguid/quota-axi/blob/9435fd38fd06bae86d8f5cb20e9c65e8d69603d3/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/built-cli-synthetic-503.txt)
- Evidence: [Loopback streaming response and socket closure](https://github.com/kunchenguid/quota-axi/blob/9435fd38fd06bae86d8f5cb20e9c65e8d69603d3/.no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/loopback-socket-close.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm exec vitest run test/providers/kimi.test.ts test/kimi-built-cli-response-cleanup.test.ts test/kimi-cli-readonly.test.ts --reporter=verbose`
- `pnpm test`
- `node .no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-built-cli-503.mjs`
- `node .no-mistakes/evidence/fm/quota-axi-kimi-readonly-release-r3/reproduce-loopback-socket-close.mjs`
- `git diff --quiet 272a7bc1e6c5edce2f689e51e337762b46160b36..443e4feb598632452e61dc898a23aabed24cffbb -- src/providers/pi-kimi-credential.ts`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
