### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-quota-axi-r1/workflow-validation.md
+++ b/.no-mistakes/evidence/fm/nm-body-events-quota-axi-r1/workflow-validation.md
@@ -1,0 +1,76 @@
+# PR body compliance workflow validation
+
+Validated target commit `b4ca4b61aba2c7b6def255ddd4ae521d60457c0b`
+against base `f0cce7f2499b152d0bc1272e8c69b242308ce261`.
+
+## End-user signature check
+
+The workflow's actual embedded shell step was parsed from
+`.github/workflows/no-mistakes-required.yml` and executed with representative
+PR event data.
+
+```text
+=== signed opened/edited body ===
+Found no-mistakes signature in PR #42 body.
+exit_status=0
+=== unsigned opened/edited body ===
+::error::This PR was not raised through no-mistakes.
+
+Contributions to this repository must be submitted via 'git push no-mistakes'.
+That pipeline runs the required review/test/lint/CI steps and writes a
+deterministic '## Pipeline' section into the PR body containing:
+
+    Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)
+
+See CONTRIBUTING.md for setup and the full workflow.
+
+PR author: test-user
+exit_status=1
+```
+
+## Event concurrency matrix
+
+The configured group expression was checked across successive events for the
+same PR:
+
+```text
+event | run_id | concurrency group
+opened | 101 | no-mistakes-required-42-101
+opened | 102 | no-mistakes-required-42-102
+edited | 103 | no-mistakes-required-42-103
+edited | 104 | no-mistakes-required-42-104
+synchronize | 105 | no-mistakes-required-42-head-change
+reopened | 106 | no-mistakes-required-42-head-change
+
+Workflow contract: PASS
+```
+
+This demonstrates immutable per-run groups for every body-bearing event and
+preserved coalescing for head-change events.
+
+## Preserved workflow contract
+
+Focused structural assertions confirmed:
+
+- `pull_request` remains the trigger boundary, targeting `main`.
+- Event types remain `opened`, `edited`, `synchronize`, and `reopened`.
+- Permissions remain exactly `contents: read`.
+- `cancel-in-progress` remains `true`.
+- The stable check name remains `PR must be raised via no-mistakes`.
+- All three existing bot exemptions remain present.
+- No step uses an action or checks out or executes fork code.
+- The canonical run name includes PR number, action, run number, and run ID.
+
+## Minimal rollout scope
+
+```text
+commit=b4ca4b61aba2c7b6def255ddd4ae521d60457c0b
+subject=fix: execute every PR body compliance event
+parents=f0cce7f2499b152d0bc1272e8c69b242308ce261
+.github/workflows/no-mistakes-required.yml
+6       1       .github/workflows/no-mistakes-required.yml
+```
+
+The diff contains exactly two hunks: the canonical `run-name` addition and the
+concurrency policy update with its rationale comment. No documentation or
+unrelated project files changed.


### PR DESCRIPTION
## Intent

Implement the captain-authorized repository-specific rollout of the merged no-mistakes PR-body compliance-event policy from kunchenguid/no-mistakes#558. Every opened or edited pull-request body event, including independently approved first-time-fork events on an unchanged head, must execute the signature check to terminal success or failure using immutable run-id concurrency groups. Preserve synchronize/reopened coalescing under head-change, cancel-in-progress true, pull_request fork boundary, read-only permissions, no secrets or fork-code execution, the signature marker and bot exemptions, and the stable check name. Add the canonical run-name exposing PR number, action, monotonic run number, and immutable run ID. Keep the rollout minimal to the exact two-hunk workflow change, with no documentation or unrelated changes. Deliver one green PR titled 'fix: execute every PR body compliance event' and do not merge.

## What Changed

- Give every opened or edited PR body event an immutable run-ID concurrency group while preserving coalescing for synchronize and reopened events.
- Add a canonical workflow run name and validation evidence covering signature checks, concurrency behavior, and preserved security constraints.

## Risk Assessment

✅ Low: The minimal workflow-only change exactly matches the canonical policy, uniquely executes opened and edited events while preserving head-change coalescing, and retains all security and check-name invariants.

## Testing

No baseline test command was supplied. Focused workflow parsing, event-concurrency simulation, real signature-script execution, commit-scope inspection, and live PR lookup all completed; local behavior passed and reviewer evidence was captured, but no PR exists yet to demonstrate the required green, correctly titled, unmerged GitHub state.

- Evidence: [Workflow validation report](https://github.com/kunchenguid/quota-axi/blob/dec0a17cdfe09dd6c9cad6615eac2d21fbbe916f/.no-mistakes/evidence/fm/nm-body-events-quota-axi-r1/workflow-validation.md)
- Outcome: ⚠️ 1 warning across 1 run (2m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No pull request currently exists for head branch `fm/nm-body-events-quota-axi-r1`, so the required live green status, exact PR title, and unmerged state cannot yet be demonstrated. Create/push the intended PR and rerun the live check.
- <code>`git diff --unified=80 f0cce7f2499b152d0bc1272e8c69b242308ce261..b4ca4b61aba2c7b6def255ddd4ae521d60457c0b` - verified one workflow file and exactly two change hunks.</code>
- <code>Ruby YAML contract harness against `.github/workflows/no-mistakes-required.yml` - asserted triggers, read-only permissions, `pull_request` fork boundary, bot exemptions, stable check name, canonical run name, concurrency behavior, and absence of action/fork-code execution.</code>
- <code>Ruby `Open3.capture3` harness executing the workflow&#39;s actual embedded Bash step - signed body exited 0; unsigned body emitted the GitHub error annotation and exited 1.</code>
- <code>`git show -s --format=&#39;commit=%H%nsubject=%s%nparents=%P&#39; b4ca4b61aba2c7b6def255ddd4ae521d60457c0b` - verified the required commit title and single base parent.</code>
- <code>`gh-axi pr list --state all --head fm/nm-body-events-quota-axi-r1 --limit 10` - found no live PR.</code>
- <code>`git status --short --untracked-files=all` - confirmed only the intentional evidence report was added.</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `CONTRIBUTING.md:32` - CONTRIBUTING.md says Node 20+ is supported, but package.json requires Node &gt;=22.19.0. Left unchanged because the authoritative intent requires an exact workflow-only two-hunk change; update in a separate follow-up.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
