### PR TITLE
feat: add cycle-average quota pace signals

### DIFF
--- a/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-evidence.ts
+++ b/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-evidence.ts
@@ -1,0 +1,79 @@
+import { main } from "../../../../src/cli.js";
+import { PROVIDERS } from "../../../../src/providers/index.js";
+import type { ProviderQuota } from "../../../../src/types.js";
+
+process.env.XDG_CACHE_HOME = new URL("./.transient-cache", import.meta.url)
+  .pathname;
+
+function acceptanceQuota(): ProviderQuota {
+  const now = Date.now();
+  return {
+    provider: "claude",
+    label: "Claude",
+    source: "oauth",
+    windows: [
+      {
+        id: "five_hour",
+        label: "session",
+        kind: "session",
+        percentUsed: 80,
+        percentRemaining: 20,
+        startsAt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        resetsAt: new Date(now + 3 * 60 * 60 * 1000).toISOString(),
+      },
+      {
+        id: "seven_day",
+        label: "week",
+        kind: "weekly",
+        percentUsed: 20,
+        percentRemaining: 80,
+        startsAt: new Date(now - 3 * 24 * 60 * 60 * 1000).toISOString(),
+        resetsAt: new Date(now + 4 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+      {
+        id: "extra_usage",
+        label: "extra usage",
+        kind: "monthly",
+        percentUsed: 25,
+        percentRemaining: 75,
+        resetsAt: new Date(now + 14 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ],
+    state: {
+      status: "fresh",
+      stale: false,
+      sourcesTried: ["oauth"],
+    },
+  };
+}
+
+PROVIDERS.claude = {
+  id: "claude",
+  label: "Claude",
+  async fetchQuota() {
+    return acceptanceQuota();
+  },
+  async inspectAuth() {
+    return { provider: "claude", sources: [] };
+  },
+};
+
+async function capture(argv: string[]): Promise<string> {
+  const chunks: string[] = [];
+  await main({
+    argv,
+    binPath: "quota-axi",
+    stdout: {
+      write(chunk) {
+        chunks.push(String(chunk));
+        return true;
+      },
+    },
+  });
+  return chunks.join("");
+}
+
+console.log("=== DEFAULT TOON ===");
+console.log(await capture(["--provider", "claude"]));
+console.log("\n=== JSON ===");
+console.log(await capture(["--provider", "claude", "--json"]));

--- a/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-transcript.txt
+++ b/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-transcript.txt
@@ -1,0 +1,123 @@
+=== DEFAULT TOON ===
+bin: quota-axi
+description: Report local agent-provider quota windows for routing-aware agents
+generatedAt: "2026-07-28T06:39:29.121Z"
+providers[1]{provider,plan,source,status,refreshedAt}:
+  claude,unknown,oauth,fresh,none
+windows[3]{provider,id,label,percentRemaining,resetsAt,pace,reserve,state}:
+  claude,five_hour,session,20,"2026-07-28T09:39:29.122Z",ahead,-40,fresh
+  claude,seven_day,week,80,"2026-08-01T06:39:29.122Z",behind,22.8571,fresh
+  claude,extra_usage,extra usage,75,"2026-08-11T06:39:29.122Z",unknown,unknown,fresh
+effective[1]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,pace,aheadWindows,unknownPace,worstReserve,unresolvedWindowIds,relationshipStatus}:
+  claude,all_models,20,five_hour + seven_day,five_hour,mixed,five_hour,none,-40,none,known
+help[3]:
+  Run `quota-axi --provider claude --json` for JSON output
+  Run `quota-axi --full` to include account and source-attempt details
+  Run `quota-axi auth` to inspect local auth source availability without printing secrets
+
+
+=== JSON ===
+{
+  "generatedAt": "2026-07-28T06:39:29.124Z",
+  "schemaVersion": 3,
+  "providers": [
+    {
+      "provider": "claude",
+      "label": "Claude",
+      "source": "oauth",
+      "windows": [
+        {
+          "id": "five_hour",
+          "label": "session",
+          "kind": "session",
+          "percentUsed": 80,
+          "percentRemaining": 20,
+          "startsAt": "2026-07-28T04:39:29.124Z",
+          "resetsAt": "2026-07-28T09:39:29.124Z",
+          "pace": {
+            "status": "ahead",
+            "timeRemainingPercent": 60,
+            "elapsedPercent": 40,
+            "reservePercentPoints": -40,
+            "cycleBasis": "starts_at_resets_at",
+            "cycleSeconds": 18000,
+            "burnMultiple": 2,
+            "projectedExhaustedAt": "2026-07-28T07:09:29.124Z",
+            "projectionConfidence": "established",
+            "projectionBasis": "cycle_average"
+          }
+        },
+        {
+          "id": "seven_day",
+          "label": "week",
+          "kind": "weekly",
+          "percentUsed": 20,
+          "percentRemaining": 80,
+          "startsAt": "2026-07-25T06:39:29.124Z",
+          "resetsAt": "2026-08-01T06:39:29.124Z",
+          "pace": {
+            "status": "behind",
+            "timeRemainingPercent": 57.1429,
+            "elapsedPercent": 42.8571,
+            "reservePercentPoints": 22.8571,
+            "cycleBasis": "starts_at_resets_at",
+            "cycleSeconds": 604800,
+            "burnMultiple": 0.4667,
+            "projectedExhaustedAt": "2026-08-09T06:39:29.124Z",
+            "projectionConfidence": "established",
+            "projectionBasis": "cycle_average"
+          }
+        },
+        {
+          "id": "extra_usage",
+          "label": "extra usage",
+          "kind": "monthly",
+          "percentUsed": 25,
+          "percentRemaining": 75,
+          "resetsAt": "2026-08-11T06:39:29.124Z",
+          "pace": {
+            "status": "unknown",
+            "reason": "missing_cycle"
+          }
+        }
+      ],
+      "state": {
+        "status": "fresh",
+        "stale": false,
+        "sourcesTried": [
+          "oauth"
+        ]
+      },
+      "quotaSemantics": {
+        "status": "known",
+        "description": "Claude account windows bound every model. A model-specific window is an additional bound, so that model's effective remaining percentage is the minimum across the named windows.",
+        "effectiveAvailability": [
+          {
+            "scope": "all_models",
+            "status": "known",
+            "effectivePercentRemaining": 20,
+            "boundedBy": [
+              "five_hour",
+              "seven_day"
+            ],
+            "limitingWindowIds": [
+              "five_hour"
+            ],
+            "pace": {
+              "status": "mixed",
+              "aheadWindowIds": [
+                "five_hour"
+              ],
+              "behindWindowIds": [
+                "seven_day"
+              ],
+              "worstReservePercentPoints": -40,
+              "worstReserveWindowId": "five_hour"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - `quota` is the implicit default command: `runAxiCli` routes on `argv[0]` and rejects a leading flag, so `src/cli.ts` `normalizeArgv` prepends `quota` for a bare call or flag-first call (`quota-axi --json`) while leaving `auth`, `update`, and the single-token `--help`/version through to the SDK. Validation errors throw `AxiError("...", "VALIDATION_ERROR")` (exit 2); the all-providers-failed path sets `process.exitCode = 1` and still renders.
 - Default stdout is compact TOON.
 - `--json` emits the normalized model, and `--full` is required before account identity or per-source attempts are shown.
-- JSON report shape and quota interpretation, including stale effective availability, are documented in [README Output Model](README.md#output-model). `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
+- JSON report shape and quota interpretation, including stale effective availability and per-window cycle-average pace signals (`schemaVersion: 3`), are documented in [README Output Model](README.md#output-model) and [README Pace signals](README.md#pace-signals). Pace is derived in `src/pace.ts` from trusted `startsAt`/`resetsAt` or `windowSeconds` plus `generatedAt`; negative `reservePercentPoints` means usage is ahead of the reset clock. Pace is not cached. `state.retryAfter` can appear for provider rate limits, and `state.reason: keychain_access_required` plus `state.remedyCommand` can appear when a stale or unavailable Claude result is blocked by a skipped macOS Keychain prompt.
 - macOS Claude Keychain presence and value reads mirror Claude Code's validated current-user account selector and never fall back to an ambiguous service-only query. Value reads are skipped on plain calls until a successful value read records the profile-and-account-scoped non-secret access marker under the quota-axi cache directory; after that, plain calls may reuse the existing grant and read live Claude quota.
 - Managed-profile, Claude identity, and Codex executable-override contracts are documented in [README Security Posture](README.md#security-posture).
 - `--allow-keychain-prompt` is the first-time opt-in that permits the Claude Keychain value read which can prompt, and agents should relay the one-time "Always Allow" grant when `keychain_access_required` advice appears.
@@ -33,7 +33,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - The Claude Keychain access marker is stored alongside the cache, is `0600`, is keyed by hashed profile/account identity, and contains no credential material or raw account name. Legacy service-only markers are ignored without being deleted.
 - Quota cache files must be `0600` and contain only normalized non-secret snapshots.
 - Only fresh provider snapshots with windows are cached; fresh provider reports with no windows clear any existing cached snapshot for that provider.
-- Failed providers, stale providers, account identity, and source attempts are not cached.
+- Failed providers, stale providers, account identity, source attempts, and derived `pace` objects are not cached.
 - Do not cache raw provider responses or credential headers.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -44,27 +44,27 @@ providers[6]{provider,plan,source,status,refreshedAt}:
   grok,unknown,web,fresh,"2026-03-15T16:42:00.000Z"
   kimi,unknown,api,fresh,"2026-03-15T16:42:00.000Z"
 windows[15]{provider,id,label,percentRemaining,resetsAt,pace,reserve,state}:
-  claude,five_hour,session,82,"2026-03-15T21:15:00.000Z",behind,12.4,fresh
-  claude,seven_day,week,64,"2026-03-19T15:00:00.000Z",ahead,-8.2,fresh
-  claude,seven_day_opus,opus week,93,"2026-03-20T09:30:00.000Z",behind,21.1,fresh
-  claude,"model:fable",Fable week,71,"2026-03-20T09:30:00.000Z",behind,4.5,fresh
-  codex,five_hour,session,58,"2026-03-15T20:45:00.000Z",on_pace,-0.3,fresh
-  codex,weekly,week,47,"2026-03-19T09:00:00.000Z",ahead,-6.1,fresh
-  codex,"model:gpt-5.1-codex:5h",GPT-5.1-Codex session,100,"2026-03-16T01:41:58.000Z",behind,18.0,fresh
+  claude,five_hour,session,82,"2026-03-15T20:10:48.000Z",behind,12.4,fresh
+  claude,seven_day,week,64,"2026-03-20T17:59:45.600Z",ahead,-8.2,fresh
+  claude,seven_day_opus,opus week,93,"2026-03-20T17:29:31.200Z",behind,21.1,fresh
+  claude,"model:fable",Fable week,71,"2026-03-20T08:25:12.000Z",behind,4.5,fresh
+  codex,five_hour,session,58,"2026-03-15T19:36:54.000Z",on_pace,-0.3,fresh
+  codex,weekly,week,47,"2026-03-19T09:54:28.800Z",ahead,-6.1,fresh
+  codex,"model:gpt-5.1-codex:5h",GPT-5.1-Codex session,100,"2026-03-15T20:48:00.000Z",behind,18.0,fresh
   cursor,included_usage,included usage,72,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
   cursor,auto_usage,auto usage,91,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
   cursor,api_usage,API usage,100,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
   copilot,chat,chat,84,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
   copilot,premium_interactions,premium interactions,53,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
   grok,credits,credits,67,"2026-04-01T00:00:00.000Z",behind,3.6,fresh
-  kimi,weekly,week,74,"2026-03-19T09:00:00.000Z",behind,5.2,fresh
-  kimi,five_hour,session,88,"2026-03-15T21:42:00.000Z",behind,7.0,fresh
+  kimi,weekly,week,74,"2026-03-20T12:17:02.400Z",behind,5.2,fresh
+  kimi,five_hour,session,88,"2026-03-15T20:45:00.000Z",behind,7.0,fresh
 effective[9]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,pace,aheadWindows,unknownPace,worstReserve,unresolvedWindowIds,relationshipStatus}:
-  claude,all_models,64,"five_hour + seven_day",seven_day,ahead,seven_day,none,-8.2,none,known
-  claude,"model:fable",64,"five_hour + seven_day + model:fable",seven_day,ahead,seven_day,none,-8.2,none,known
-  claude,seven_day_opus,64,"five_hour + seven_day + seven_day_opus",seven_day,ahead,seven_day,none,-8.2,none,known
+  claude,all_models,64,"five_hour + seven_day",seven_day,mixed,seven_day,none,-8.2,none,known
+  claude,"model:fable",64,"five_hour + seven_day + model:fable",seven_day,mixed,seven_day,none,-8.2,none,known
+  claude,seven_day_opus,64,"five_hour + seven_day + seven_day_opus",seven_day,mixed,seven_day,none,-8.2,none,known
   codex,all_models,47,"five_hour + weekly",weekly,ahead,weekly,none,-6.1,none,known
-  codex,"model:gpt-5.1-codex",47,"five_hour + weekly + model:gpt-5.1-codex:5h",weekly,ahead,weekly,none,-6.1,none,known
+  codex,"model:gpt-5.1-codex",47,"five_hour + weekly + model:gpt-5.1-codex:5h",weekly,mixed,weekly,none,-6.1,none,known
   cursor,unresolved,unknown,none,unknown,unknown,none,none,unknown,"included_usage + auto_usage + api_usage",unknown
   copilot,unresolved,unknown,none,unknown,unknown,none,none,unknown,"chat + premium_interactions",unknown
   grok,all_products,67,credits,credits,behind,none,none,3.6,none,known
@@ -80,7 +80,7 @@ help[3]:
 ```sh
 $ quota-axi --provider claude --json
 {
-  "generatedAt": "2026-03-15T16:42:03.000Z",
+  "generatedAt": "2026-03-15T16:42:00.000Z",
   "schemaVersion": 3,
   "providers": [
     {
@@ -95,7 +95,7 @@ $ quota-axi --provider claude --json
           "kind": "session",
           "percentUsed": 18,
           "percentRemaining": 82,
-          "resetsAt": "2026-03-15T21:15:00.000Z",
+          "resetsAt": "2026-03-15T20:10:48.000Z",
           "windowSeconds": 18000,
           "pace": {
             "status": "behind",
@@ -103,6 +103,9 @@ $ quota-axi --provider claude --json
             "elapsedPercent": 30.4,
             "reservePercentPoints": 12.4,
             "burnMultiple": 0.5921,
+            "projectedExhaustedAt": "2026-03-15T23:37:28.000Z",
+            "projectionConfidence": "established",
+            "projectionBasis": "cycle_average",
             "cycleBasis": "window_seconds",
             "cycleSeconds": 18000
           }
@@ -113,7 +116,7 @@ $ quota-axi --provider claude --json
           "kind": "weekly",
           "percentUsed": 36,
           "percentRemaining": 64,
-          "resetsAt": "2026-03-19T15:00:00.000Z",
+          "resetsAt": "2026-03-20T17:59:45.600Z",
           "windowSeconds": 604800,
           "pace": {
             "status": "ahead",
@@ -121,7 +124,7 @@ $ quota-axi --provider claude --json
             "elapsedPercent": 27.8,
             "reservePercentPoints": -8.2,
             "burnMultiple": 1.295,
-            "projectedExhaustedAt": "2026-03-18T09:12:00.000Z",
+            "projectedExhaustedAt": "2026-03-19T03:43:45.600Z",
             "projectionConfidence": "established",
             "projectionBasis": "cycle_average",
             "cycleBasis": "window_seconds",
@@ -134,7 +137,7 @@ $ quota-axi --provider claude --json
           "kind": "model",
           "percentUsed": 29,
           "percentRemaining": 71,
-          "resetsAt": "2026-03-20T09:30:00.000Z",
+          "resetsAt": "2026-03-20T08:25:12.000Z",
           "windowSeconds": 604800,
           "pace": {
             "status": "behind",
@@ -142,6 +145,9 @@ $ quota-axi --provider claude --json
             "elapsedPercent": 33.5,
             "reservePercentPoints": 4.5,
             "burnMultiple": 0.8657,
+            "projectedExhaustedAt": "2026-03-21T10:29:20.275Z",
+            "projectionConfidence": "established",
+            "projectionBasis": "cycle_average",
             "cycleBasis": "window_seconds",
             "cycleSeconds": 604800
           }
@@ -158,7 +164,7 @@ $ quota-axi --provider claude --json
             "boundedBy": ["five_hour", "seven_day"],
             "limitingWindowIds": ["seven_day"],
             "pace": {
-              "status": "ahead",
+              "status": "mixed",
               "aheadWindowIds": ["seven_day"],
               "behindWindowIds": ["five_hour"],
               "worstReservePercentPoints": -8.2,
@@ -172,7 +178,7 @@ $ quota-axi --provider claude --json
             "boundedBy": ["five_hour", "seven_day", "model:fable"],
             "limitingWindowIds": ["seven_day"],
             "pace": {
-              "status": "ahead",
+              "status": "mixed",
               "aheadWindowIds": ["seven_day"],
               "behindWindowIds": ["five_hour", "model:fable"],
               "worstReservePercentPoints": -8.2,
@@ -353,7 +359,7 @@ A model-specific `scope` names the model window or the shared model prefix when 
 
 `quotaSemantics.status` is `known` only when quota-axi understands the relationships needed for the reported scopes. A non-definitive availability entry omits `effectivePercentRemaining`. Unfamiliar vendor windows produce `partial` or `unknown` semantics and are named in `unresolvedWindowIds`; an empty provider report is `unknown` without inventing an unresolved window.
 
-For every stale provider report, raw windows remain available for diagnostics but effective availability is always `unknown` and omits `effectivePercentRemaining` and `limitingWindowIds`. Window and effective `pace` are also `unknown` with reason `stale`. Routing agents must not treat a stale raw percentage as current headroom.
+For every stale provider report, raw windows remain available for diagnostics but effective availability is always `unknown` and omits `effectivePercentRemaining` and `limitingWindowIds`. Window pace is `unknown` with reason `stale`, and each effective pace summary is also `unknown`. Routing agents must not treat a stale raw percentage as current headroom.
 
 ### Pace signals
 
@@ -370,18 +376,18 @@ reservePercentPoints = percentRemaining - timeRemainingPercent
 | Positive               | Usage is **behind** the reset clock                                          |
 | Within ±1.0            | `on_pace` deadband for API rounding noise                                    |
 
-| Pace field                                | Meaning                                                                                                                 |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `status`                                  | `ahead`, `on_pace`, `behind`, or `unknown`                                                                              |
-| `reason`                                  | Why pace is unknown (`stale`, `missing_usage`, `missing_cycle`, `invalid_cycle`, `future_cycle_start`, `expired_reset`) |
-| `timeRemainingPercent` / `elapsedPercent` | Cycle progress from `generatedAt`                                                                                       |
-| `reservePercentPoints`                    | Signed residual capacity vs the linear clock                                                                            |
-| `burnMultiple`                            | `percentUsed / elapsedPercent` when elapsed > 0                                                                         |
-| `projectedExhaustedAt`                    | Linear cycle-average exhaustion timestamp when defined                                                                  |
-| `projectionConfidence`                    | `early` when elapsed < 10% of the cycle; otherwise `established`                                                        |
-| `projectionBasis`                         | Always `cycle_average` in v1                                                                                            |
-| `cycleBasis`                              | `starts_at_resets_at` when both boundaries are trusted; otherwise `window_seconds` with `resetsAt`                      |
-| `cycleSeconds`                            | Trusted cycle duration used for the math                                                                                |
+| Pace field                                | Meaning                                                                                                                                       |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`                                  | `ahead`, `on_pace`, `behind`, or `unknown`                                                                                                    |
+| `reason`                                  | Why pace is unknown (`stale`, `missing_usage`, `missing_cycle`, `invalid_cycle`, `future_cycle_start`, `expired_reset`, `unsupported_period`) |
+| `timeRemainingPercent` / `elapsedPercent` | Cycle progress from `generatedAt`                                                                                                             |
+| `reservePercentPoints`                    | Signed residual capacity vs the linear clock                                                                                                  |
+| `burnMultiple`                            | `percentUsed / elapsedPercent` when elapsed > 0                                                                                               |
+| `projectedExhaustedAt`                    | Linear cycle-average exhaustion timestamp when defined                                                                                        |
+| `projectionConfidence`                    | `early` when elapsed < 10% of the cycle; otherwise `established`                                                                              |
+| `projectionBasis`                         | Currently always `cycle_average`                                                                                                              |
+| `cycleBasis`                              | `starts_at_resets_at` when both boundaries are trusted; otherwise `window_seconds` with `resetsAt`                                            |
+| `cycleSeconds`                            | Trusted cycle duration used for the math                                                                                                      |
 
 Pace is calculated only from trusted cycle evidence:
 
@@ -391,7 +397,7 @@ Pace is calculated only from trusted cycle evidence:
 
 Default TOON keeps token cost low: window rows expose `pace` status and signed `reserve` only. Full projection evidence is in `--json`. Pace is recomputed on every report from `generatedAt` and is not written to the quota cache.
 
-Each `effectiveAvailability` entry also carries a compact `pace` summary over **every** bounding window for that scope (not only the current lowest-remaining limiter): `aheadWindowIds`, `unknownWindowIds`, and `worstReservePercentPoints` / `worstReserveWindowId` (most negative signed reserve among known-pace windows). Different windows keep their own reset horizons; quota-axi does not invent one synthetic reset for a scope. This is factual inspectable data, never a provider/model routing recommendation.
+Each `effectiveAvailability` entry also carries a compact `pace` summary over **every** bounding window for that scope (not only the current lowest-remaining limiter): per-status window lists, including `aheadWindowIds` and `unknownWindowIds`, plus `worstReservePercentPoints` / `worstReserveWindowId` (most negative signed reserve among known-pace windows). Different windows keep their own reset horizons; quota-axi does not invent one synthetic reset for a scope. This is factual inspectable data, never a provider/model routing recommendation.
 
 ### Quota enums
 

--- a/README.md
+++ b/README.md
@@ -43,32 +43,32 @@ providers[6]{provider,plan,source,status,refreshedAt}:
   copilot,individual,api,fresh,"2026-03-15T16:42:00.000Z"
   grok,unknown,web,fresh,"2026-03-15T16:42:00.000Z"
   kimi,unknown,api,fresh,"2026-03-15T16:42:00.000Z"
-windows[15]{provider,id,label,percentRemaining,resetsAt,state}:
-  claude,five_hour,session,82,"2026-03-15T21:15:00.000Z",fresh
-  claude,seven_day,week,64,"2026-03-19T15:00:00.000Z",fresh
-  claude,seven_day_opus,opus week,93,"2026-03-20T09:30:00.000Z",fresh
-  claude,"model:fable",Fable week,71,"2026-03-20T09:30:00.000Z",fresh
-  codex,five_hour,session,58,"2026-03-15T20:45:00.000Z",fresh
-  codex,weekly,week,47,"2026-03-19T09:00:00.000Z",fresh
-  codex,"model:gpt-5.1-codex:5h",GPT-5.1-Codex session,100,"2026-03-16T01:41:58.000Z",fresh
-  cursor,included_usage,included usage,72,"2026-04-01T00:00:00.000Z",fresh
-  cursor,auto_usage,auto usage,91,"2026-04-01T00:00:00.000Z",fresh
-  cursor,api_usage,API usage,100,"2026-04-01T00:00:00.000Z",fresh
-  copilot,chat,chat,84,"2026-04-01T00:00:00.000Z",fresh
-  copilot,premium_interactions,premium interactions,53,"2026-04-01T00:00:00.000Z",fresh
-  grok,credits,credits,67,"2026-04-01T00:00:00.000Z",fresh
-  kimi,weekly,week,74,"2026-03-19T09:00:00.000Z",fresh
-  kimi,five_hour,session,88,"2026-03-15T21:42:00.000Z",fresh
-effective[9]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,unresolvedWindowIds,relationshipStatus}:
-  claude,all_models,64,"five_hour + seven_day",seven_day,none,known
-  claude,"model:fable",64,"five_hour + seven_day + model:fable",seven_day,none,known
-  claude,seven_day_opus,64,"five_hour + seven_day + seven_day_opus",seven_day,none,known
-  codex,all_models,47,"five_hour + weekly",weekly,none,known
-  codex,"model:gpt-5.1-codex",47,"five_hour + weekly + model:gpt-5.1-codex:5h",weekly,none,known
-  cursor,unresolved,unknown,none,unknown,"included_usage + auto_usage + api_usage",unknown
-  copilot,unresolved,unknown,none,unknown,"chat + premium_interactions",unknown
-  grok,all_products,67,credits,credits,none,known
-  kimi,all_models,74,"weekly + five_hour",weekly,none,known
+windows[15]{provider,id,label,percentRemaining,resetsAt,pace,reserve,state}:
+  claude,five_hour,session,82,"2026-03-15T21:15:00.000Z",behind,12.4,fresh
+  claude,seven_day,week,64,"2026-03-19T15:00:00.000Z",ahead,-8.2,fresh
+  claude,seven_day_opus,opus week,93,"2026-03-20T09:30:00.000Z",behind,21.1,fresh
+  claude,"model:fable",Fable week,71,"2026-03-20T09:30:00.000Z",behind,4.5,fresh
+  codex,five_hour,session,58,"2026-03-15T20:45:00.000Z",on_pace,-0.3,fresh
+  codex,weekly,week,47,"2026-03-19T09:00:00.000Z",ahead,-6.1,fresh
+  codex,"model:gpt-5.1-codex:5h",GPT-5.1-Codex session,100,"2026-03-16T01:41:58.000Z",behind,18.0,fresh
+  cursor,included_usage,included usage,72,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
+  cursor,auto_usage,auto usage,91,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
+  cursor,api_usage,API usage,100,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
+  copilot,chat,chat,84,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
+  copilot,premium_interactions,premium interactions,53,"2026-04-01T00:00:00.000Z",unknown,unknown,fresh
+  grok,credits,credits,67,"2026-04-01T00:00:00.000Z",behind,3.6,fresh
+  kimi,weekly,week,74,"2026-03-19T09:00:00.000Z",behind,5.2,fresh
+  kimi,five_hour,session,88,"2026-03-15T21:42:00.000Z",behind,7.0,fresh
+effective[9]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,pace,aheadWindows,unknownPace,worstReserve,unresolvedWindowIds,relationshipStatus}:
+  claude,all_models,64,"five_hour + seven_day",seven_day,ahead,seven_day,none,-8.2,none,known
+  claude,"model:fable",64,"five_hour + seven_day + model:fable",seven_day,ahead,seven_day,none,-8.2,none,known
+  claude,seven_day_opus,64,"five_hour + seven_day + seven_day_opus",seven_day,ahead,seven_day,none,-8.2,none,known
+  codex,all_models,47,"five_hour + weekly",weekly,ahead,weekly,none,-6.1,none,known
+  codex,"model:gpt-5.1-codex",47,"five_hour + weekly + model:gpt-5.1-codex:5h",weekly,ahead,weekly,none,-6.1,none,known
+  cursor,unresolved,unknown,none,unknown,unknown,none,none,unknown,"included_usage + auto_usage + api_usage",unknown
+  copilot,unresolved,unknown,none,unknown,unknown,none,none,unknown,"chat + premium_interactions",unknown
+  grok,all_products,67,credits,credits,behind,none,none,3.6,none,known
+  kimi,all_models,74,"weekly + five_hour",weekly,behind,none,none,5.2,none,known
 help[3]:
   Run `quota-axi --provider claude --json` for JSON output
   Run `quota-axi --full` to include account and source-attempt details
@@ -81,7 +81,7 @@ help[3]:
 $ quota-axi --provider claude --json
 {
   "generatedAt": "2026-03-15T16:42:03.000Z",
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "providers": [
     {
       "provider": "claude",
@@ -95,7 +95,17 @@ $ quota-axi --provider claude --json
           "kind": "session",
           "percentUsed": 18,
           "percentRemaining": 82,
-          "resetsAt": "2026-03-15T21:15:00.000Z"
+          "resetsAt": "2026-03-15T21:15:00.000Z",
+          "windowSeconds": 18000,
+          "pace": {
+            "status": "behind",
+            "timeRemainingPercent": 69.6,
+            "elapsedPercent": 30.4,
+            "reservePercentPoints": 12.4,
+            "burnMultiple": 0.5921,
+            "cycleBasis": "window_seconds",
+            "cycleSeconds": 18000
+          }
         },
         {
           "id": "seven_day",
@@ -103,7 +113,20 @@ $ quota-axi --provider claude --json
           "kind": "weekly",
           "percentUsed": 36,
           "percentRemaining": 64,
-          "resetsAt": "2026-03-19T15:00:00.000Z"
+          "resetsAt": "2026-03-19T15:00:00.000Z",
+          "windowSeconds": 604800,
+          "pace": {
+            "status": "ahead",
+            "timeRemainingPercent": 72.2,
+            "elapsedPercent": 27.8,
+            "reservePercentPoints": -8.2,
+            "burnMultiple": 1.295,
+            "projectedExhaustedAt": "2026-03-18T09:12:00.000Z",
+            "projectionConfidence": "established",
+            "projectionBasis": "cycle_average",
+            "cycleBasis": "window_seconds",
+            "cycleSeconds": 604800
+          }
         },
         {
           "id": "model:fable",
@@ -111,7 +134,17 @@ $ quota-axi --provider claude --json
           "kind": "model",
           "percentUsed": 29,
           "percentRemaining": 71,
-          "resetsAt": "2026-03-20T09:30:00.000Z"
+          "resetsAt": "2026-03-20T09:30:00.000Z",
+          "windowSeconds": 604800,
+          "pace": {
+            "status": "behind",
+            "timeRemainingPercent": 66.5,
+            "elapsedPercent": 33.5,
+            "reservePercentPoints": 4.5,
+            "burnMultiple": 0.8657,
+            "cycleBasis": "window_seconds",
+            "cycleSeconds": 604800
+          }
         }
       ],
       "quotaSemantics": {
@@ -123,14 +156,28 @@ $ quota-axi --provider claude --json
             "status": "known",
             "effectivePercentRemaining": 64,
             "boundedBy": ["five_hour", "seven_day"],
-            "limitingWindowIds": ["seven_day"]
+            "limitingWindowIds": ["seven_day"],
+            "pace": {
+              "status": "ahead",
+              "aheadWindowIds": ["seven_day"],
+              "behindWindowIds": ["five_hour"],
+              "worstReservePercentPoints": -8.2,
+              "worstReserveWindowId": "seven_day"
+            }
           },
           {
             "scope": "model:fable",
             "status": "known",
             "effectivePercentRemaining": 64,
             "boundedBy": ["five_hour", "seven_day", "model:fable"],
-            "limitingWindowIds": ["seven_day"]
+            "limitingWindowIds": ["seven_day"],
+            "pace": {
+              "status": "ahead",
+              "aheadWindowIds": ["seven_day"],
+              "behindWindowIds": ["five_hour", "model:fable"],
+              "worstReservePercentPoints": -8.2,
+              "worstReserveWindowId": "seven_day"
+            }
           }
         ]
       },
@@ -259,7 +306,7 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ## Output Model
 
-`--json` emits `schemaVersion: 2`.
+`--json` emits `schemaVersion: 3`.
 
 ### Quota report shape
 
@@ -295,10 +342,10 @@ Claude credential failures without a usable access token preserve the precise `c
 
 ### Quota windows
 
-| Field set | Fields                                                              |
-| --------- | ------------------------------------------------------------------- |
-| Required  | `id`, `label`, `kind`                                               |
-| Optional  | Percentages, reset fields, `windowSeconds`, and credit-spend fields |
+| Field set | Fields                                                                                          |
+| --------- | ----------------------------------------------------------------------------------------------- |
+| Required  | `id`, `label`, `kind`                                                                           |
+| Optional  | Percentages, `startsAt`, reset fields, `windowSeconds`, credit-spend fields, and derived `pace` |
 
 Do not interpret a model window's percentage in isolation. `quotaSemantics.effectiveAvailability` reports the effective percentage for each understood scope, the complete `boundedBy` window set used to compute it, and the currently limiting window IDs. `all_models` applies to any model without a more specific scope; a matching `model:*` scope includes both account and model-specific bounds. Grok uses the analogous `all_products` and `product:*` scopes.
 
@@ -306,7 +353,45 @@ A model-specific `scope` names the model window or the shared model prefix when 
 
 `quotaSemantics.status` is `known` only when quota-axi understands the relationships needed for the reported scopes. A non-definitive availability entry omits `effectivePercentRemaining`. Unfamiliar vendor windows produce `partial` or `unknown` semantics and are named in `unresolvedWindowIds`; an empty provider report is `unknown` without inventing an unresolved window.
 
-For every stale provider report, raw windows remain available for diagnostics but effective availability is always `unknown` and omits `effectivePercentRemaining` and `limitingWindowIds`. Routing agents must not treat a stale raw percentage as current headroom.
+For every stale provider report, raw windows remain available for diagnostics but effective availability is always `unknown` and omits `effectivePercentRemaining` and `limitingWindowIds`. Window and effective `pace` are also `unknown` with reason `stale`. Routing agents must not treat a stale raw percentage as current headroom.
+
+### Pace signals
+
+Each window may include a derived `pace` object that compares cumulative usage to elapsed cycle time using the response `generatedAt` clock:
+
+```text
+timeRemainingPercent = 100 * (resetsAt - generatedAt) / cycleDuration
+reservePercentPoints = percentRemaining - timeRemainingPercent
+```
+
+| `reservePercentPoints` | Meaning                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| Negative               | Usage is **ahead** of the reset clock (burning faster than linear); conserve |
+| Positive               | Usage is **behind** the reset clock                                          |
+| Within ±1.0            | `on_pace` deadband for API rounding noise                                    |
+
+| Pace field                                | Meaning                                                                                                                 |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `status`                                  | `ahead`, `on_pace`, `behind`, or `unknown`                                                                              |
+| `reason`                                  | Why pace is unknown (`stale`, `missing_usage`, `missing_cycle`, `invalid_cycle`, `future_cycle_start`, `expired_reset`) |
+| `timeRemainingPercent` / `elapsedPercent` | Cycle progress from `generatedAt`                                                                                       |
+| `reservePercentPoints`                    | Signed residual capacity vs the linear clock                                                                            |
+| `burnMultiple`                            | `percentUsed / elapsedPercent` when elapsed > 0                                                                         |
+| `projectedExhaustedAt`                    | Linear cycle-average exhaustion timestamp when defined                                                                  |
+| `projectionConfidence`                    | `early` when elapsed < 10% of the cycle; otherwise `established`                                                        |
+| `projectionBasis`                         | Always `cycle_average` in v1                                                                                            |
+| `cycleBasis`                              | `starts_at_resets_at` when both boundaries are trusted; otherwise `window_seconds` with `resetsAt`                      |
+| `cycleSeconds`                            | Trusted cycle duration used for the math                                                                                |
+
+Pace is calculated only from trusted cycle evidence:
+
+- Prefer provider-reported `startsAt` + `resetsAt` (Grok current period).
+- Otherwise use provider-owned `windowSeconds` with `resetsAt` (Codex durations; Claude fixed 5h/7d; Kimi fixed 5h/weekly).
+- Do not infer monthly, rolling, or unlabeled periods.
+
+Default TOON keeps token cost low: window rows expose `pace` status and signed `reserve` only. Full projection evidence is in `--json`. Pace is recomputed on every report from `generatedAt` and is not written to the quota cache.
+
+Each `effectiveAvailability` entry also carries a compact `pace` summary over **every** bounding window for that scope (not only the current lowest-remaining limiter): `aheadWindowIds`, `unknownWindowIds`, and `worstReservePercentPoints` / `worstReserveWindowId` (most negative signed reserve among known-pace windows). Different windows keep their own reset horizons; quota-axi does not invent one synthetic reset for a scope. This is factual inspectable data, never a provider/model routing recommendation.
 
 ### Quota enums
 
@@ -316,6 +401,10 @@ For every stale provider report, raw windows remain available for diagnostics bu
 | Provider sources                 | `oauth`, `cli-rpc`, `api`, `web`, `cache`, or `unavailable`                  |
 | Current provider adapter sources | `oauth`, `cli-rpc`, `api`, `web`, `cache`, and `unavailable`                 |
 | Window kinds                     | `session`, `weekly`, `monthly`, `model`, `credits`, or `unknown`             |
+| Window pace statuses             | `ahead`, `on_pace`, `behind`, or `unknown`                                   |
+| Effective pace statuses          | `ahead`, `on_pace`, `behind`, `mixed`, or `unknown`                          |
+| Pace projection confidence       | `early` or `established`                                                     |
+| Pace cycle basis                 | `starts_at_resets_at` or `window_seconds`                                    |
 | Quota relationship statuses      | `known`, `partial`, or `unknown`                                             |
 | Source attempt statuses          | `success`, `failed`, or `skipped`                                            |
 
@@ -325,14 +414,14 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 
 | Provider               | Windows and capabilities                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Claude                 | Can report `five_hour`, `seven_day`, optional `seven_day_opus`, and optional `extra_usage` windows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| Claude scoped `limits` | When the account's usage response includes a scoped `limits` list, quota-axi surfaces every active window it describes instead, including model-scoped ones (e.g. Fable) as a `model:<slug>` window.                                                                                                                                                                                                                                                                                                                                                                   |
+| Claude                 | Can report `five_hour`, `seven_day`, optional `seven_day_opus`, and optional `extra_usage` windows. Trusted session/weekly/model windows emit fixed `windowSeconds` (18,000 or 604,800) for pace; `extra_usage` does not invent a monthly duration.                                                                                                                                                                                                                                                                                                                    |
+| Claude scoped `limits` | When the account's usage response includes a scoped `limits` list, quota-axi surfaces every active window it describes instead, including model-scoped ones (e.g. Fable) as a `model:<slug>` window with the same trusted weekly duration.                                                                                                                                                                                                                                                                                                                             |
 | Codex                  | Identifies exact 18,000-second and 604,800-second periods as `five_hour` and `weekly`, regardless of source slot; periods without a duration retain their positional identity. Additional model- or feature-scoped limits use `model:<id>:5h` / `model:<id>:7d`, and code-review limits use `code_review_five_hour` / `code_review_weekly`. Unfamiliar durations remain honest `<hours>h` windows instead of being classified as known periods. Duplicate derived IDs are preserved with `_2`, `_3`, and later suffixes. Optional credit balance data can also appear. |
-| Cursor                 | Can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows.                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| GitHub Copilot         | Can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions`; when the first-party endpoint exposes entitlement but no numeric quota windows, quota-axi reports a fresh provider state with an empty `windows` list rather than inventing percentages.                                                                                                                                                                                                                                                                                  |
-| Grok                   | Reports the shared `credits` window, optional product-scoped `product:<slug>` windows, the current-period reset, and optional prepaid credit balance from the consumer Usage-page operation. Top-level `credits.remaining` is prepaid/on-demand balance, distinct from the shared period `windows` credits percentage used for effective availability.                                                                                                                                                                                                                 |
+| Cursor                 | Can report `included_usage`, `auto_usage`, `api_usage`, and optional `spend_limit` windows. Monthly labels alone are not trusted cycle evidence, so pace stays `unknown` unless a future provider duration appears.                                                                                                                                                                                                                                                                                                                                                    |
+| GitHub Copilot         | Can report quota snapshot windows such as `chat`, `completions`, and `premium_interactions`; when the first-party endpoint exposes entitlement but no numeric quota windows, quota-axi reports a fresh provider state with an empty `windows` list rather than inventing percentages. Pace stays `unknown` without trusted cycle boundaries.                                                                                                                                                                                                                           |
+| Grok                   | Reports the shared `credits` window, optional product-scoped `product:<slug>` windows, the current-period `startsAt` and reset, and optional prepaid credit balance from the consumer Usage-page operation. Top-level `credits.remaining` is prepaid/on-demand balance, distinct from the shared period `windows` credits percentage used for effective availability. Pace prefers the startsAt/resetsAt pair.                                                                                                                                                         |
 | Grok proto3 zero       | For the exact consumer operation only, an omitted usage float is the official proto3 zero when a valid weekly or monthly current period proves the config is present; quota-axi reports `0` used and `100` remaining rather than deriving usage from money.                                                                                                                                                                                                                                                                                                            |
-| Kimi                   | Reports the principal `weekly` subscription window plus every valid self-described limit in wire order. Only a limit whose normalized duration is exactly 18,000 seconds is identified as `five_hour`; future limits remain `limit:<index>` unknown windows.                                                                                                                                                                                                                                                                                                           |
+| Kimi                   | Reports the principal `weekly` subscription window (with trusted 604,800s duration) plus every valid self-described limit in wire order. Only a limit whose normalized duration is exactly 18,000 seconds is identified as `five_hour`; future limits remain `limit:<index>` unknown windows.                                                                                                                                                                                                                                                                          |
 
 ### `auth --json` shape
 

--- a/scripts/build-skill.ts
+++ b/scripts/build-skill.ts
@@ -5,11 +5,15 @@
 //   pnpm run build:skill -- --check # fail (exit 1) if the committed file is stale
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import { format } from "prettier";
 
 import { createSkillMarkdown } from "../src/skill.js";
 
 const target = new URL("../skills/quota-axi/SKILL.md", import.meta.url);
-const expected = createSkillMarkdown();
+const targetPath = fileURLToPath(target);
+const expected = await format(createSkillMarkdown(), {
+  filepath: targetPath,
+});
 const check = process.argv.includes("--check");
 
 if (check) {
@@ -31,5 +35,5 @@ if (check) {
     recursive: true,
   });
   await writeFile(target, expected);
-  console.log(`Wrote ${fileURLToPath(target)}`);
+  console.log(`Wrote ${targetPath}`);
 }

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,11 +1,23 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining percentages, reset times, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
   hermes:
-    tags: [quota, rate-limits, claude, codex, cursor, copilot, grok, kimi, cli]
+    tags:
+      [
+        quota,
+        rate-limits,
+        pace,
+        claude,
+        codex,
+        cursor,
+        copilot,
+        grok,
+        kimi,
+        cli,
+      ]
     category: observability
 ---
 
@@ -33,9 +45,13 @@ or when comparing supported local provider headroom side by side.
 3. Pass `--json` for the normalized machine-readable model instead of TOON. Read
    `quotaSemantics.effectiveAvailability` rather than treating a model window in isolation:
    account windows can bound every model, and `boundedBy` names every window included in the
-   effective percentage. If relationship status is `partial` or `unknown`, do not infer one.
-   Stale reports keep raw windows for diagnostics, but effective availability is always unknown;
-   never route from a stale raw percentage as though it were current headroom.
+   effective percentage. Read each window's `pace` (and the effective scope's pace summary) to
+   distinguish raw remaining capacity from whether usage is ahead of or behind the reset clock:
+   negative `reservePercentPoints` means ahead/conserve. Default TOON already shows `pace` and
+   signed `reserve` on window rows. If relationship status is `partial` or `unknown`, do not
+   infer one. Stale reports keep raw windows for diagnostics, but effective availability and pace
+   are always unknown; never route from a stale raw percentage as though it were current headroom.
+   quota-axi never recommends a provider, model, or route.
 4. Pass `--full` to include account identity and per-source attempt details.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
    secret values.

--- a/src/advice.ts
+++ b/src/advice.ts
@@ -23,7 +23,7 @@ export function annotateQuotaAdvice(
   const help = providers.flatMap(providerHelpLines);
   return {
     generatedAt: response.generatedAt,
-    schemaVersion: 2,
+    schemaVersion: 3,
     providers,
     ...(help.length > 0 ? { help } : {}),
   };

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -319,6 +319,7 @@ function normalizeCachedWindow(raw: unknown): QuotaWindow | undefined {
   const result: QuotaWindow = { id, label, kind };
   assignNumber(result, "percentUsed", data.percentUsed);
   assignNumber(result, "percentRemaining", data.percentRemaining);
+  assignString(result, "startsAt", data.startsAt);
   assignString(result, "resetsAt", data.resetsAt);
   assignString(result, "resetText", data.resetText);
   assignNumber(result, "windowSeconds", data.windowSeconds);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -64,13 +64,14 @@ async function fetchQuota(
   providers: ProviderId[],
   options: ProviderOptions,
 ): Promise<QuotaAxiResponse> {
+  const generatedAt = nowIso();
   const results = (
     await Promise.all(
       providers.map((provider) => PROVIDERS[provider].fetchQuota(options)),
     )
-  ).map(withQuotaSemantics);
+  ).map((provider) => withQuotaSemantics(provider, generatedAt));
   return annotateQuotaAdvice({
-    generatedAt: nowIso(),
+    generatedAt,
     providers: results,
   });
 }

--- a/src/interpretation.ts
+++ b/src/interpretation.ts
@@ -1,3 +1,4 @@
+import { computeWindowPace, summarizeEffectivePace } from "./pace.js";
 import type {
   EffectiveAvailability,
   ProviderQuota,
@@ -5,10 +6,20 @@ import type {
   QuotaWindow,
 } from "./types.js";
 
-export function withQuotaSemantics(provider: ProviderQuota): ProviderQuota {
-  const semantics = semanticsFor(provider);
+export function withQuotaSemantics(
+  provider: ProviderQuota,
+  generatedAt: string,
+): ProviderQuota {
+  const windows = provider.windows.map((window) => ({
+    ...window,
+    pace: computeWindowPace(window, generatedAt, {
+      stale: provider.state.stale,
+    }),
+  }));
+  const withWindows = { ...provider, windows };
+  const semantics = semanticsFor(withWindows);
   return {
-    ...provider,
+    ...withWindows,
     quotaSemantics: provider.state.stale
       ? staleSemantics(semantics)
       : semantics,
@@ -21,10 +32,29 @@ function staleSemantics(semantics: QuotaSemantics): QuotaSemantics {
     description:
       "The raw quota windows are stale diagnostic data, so effective remaining is unknown until the provider refreshes successfully.",
     effectiveAvailability: semantics.effectiveAvailability.map(
-      ({ scope, boundedBy }) => ({
+      ({ scope, boundedBy, pace }) => ({
         scope,
         status: "unknown",
         boundedBy,
+        ...(pace
+          ? {
+              pace: {
+                status: "unknown" as const,
+                ...(pace.unknownWindowIds
+                  ? { unknownWindowIds: pace.unknownWindowIds }
+                  : boundedBy.length > 0
+                    ? { unknownWindowIds: boundedBy }
+                    : {}),
+              },
+            }
+          : boundedBy.length > 0
+            ? {
+                pace: {
+                  status: "unknown" as const,
+                  unknownWindowIds: boundedBy,
+                },
+              }
+            : {}),
       }),
     ),
     ...(semantics.unresolvedWindowIds
@@ -179,6 +209,7 @@ function kimiSemantics(
                 scope: "all_models",
                 status: "unknown",
                 boundedBy: recognized.map(({ id }) => id),
+                pace: summarizeEffectivePace(recognized),
               },
             ]
           : [],
@@ -199,11 +230,12 @@ function availability(
 ): EffectiveAvailability {
   const boundedBy = windows.map(({ id }) => id);
   const remaining = windows.map(({ percentRemaining }) => percentRemaining);
+  const pace = summarizeEffectivePace(windows);
   if (
     remaining.length === 0 ||
     remaining.some((value) => value === undefined)
   ) {
-    return { scope, status: "unknown", boundedBy };
+    return { scope, status: "unknown", boundedBy, pace };
   }
   const effectivePercentRemaining = Math.min(...(remaining as number[]));
   return {
@@ -217,6 +249,7 @@ function availability(
           percentRemaining === effectivePercentRemaining,
       )
       .map(({ id }) => id),
+    pace,
   };
 }
 

--- a/src/pace.ts
+++ b/src/pace.ts
@@ -1,0 +1,245 @@
+import type {
+  EffectivePaceSummary,
+  QuotaPace,
+  QuotaPaceReason,
+  QuotaWindow,
+} from "./types.js";
+
+/** Reserve within this many percentage points of zero is treated as on_pace. */
+export const PACE_ON_PACE_DEADBAND_PERCENT_POINTS = 1;
+
+/**
+ * Linear exhaustion projections before this much of the cycle has elapsed are
+ * labeled `early` rather than `established`.
+ */
+export const PACE_EARLY_ELAPSED_PERCENT = 10;
+
+type PaceOptions = {
+  stale?: boolean;
+};
+
+type ResolvedCycle = {
+  cycleSeconds: number;
+  startsAtMs: number;
+  resetsAtMs: number;
+  cycleBasis: NonNullable<QuotaPace["cycleBasis"]>;
+};
+
+export function computeWindowPace(
+  window: QuotaWindow,
+  generatedAt: string,
+  options: PaceOptions = {},
+): QuotaPace {
+  if (options.stale) return unknownPace("stale");
+
+  const generatedAtMs = Date.parse(generatedAt);
+  if (!Number.isFinite(generatedAtMs)) return unknownPace("invalid_cycle");
+
+  const percentRemaining = finiteNumber(window.percentRemaining);
+  const percentUsed = resolvePercentUsed(window, percentRemaining);
+  if (percentRemaining === undefined || percentUsed === undefined) {
+    return unknownPace("missing_usage");
+  }
+
+  const cycle = resolveCycle(window, generatedAtMs);
+  if (!cycle.ok) return unknownPace(cycle.reason);
+
+  const { cycleSeconds, startsAtMs, resetsAtMs, cycleBasis } = cycle.value;
+  const remainingMs = resetsAtMs - generatedAtMs;
+  const elapsedMs = generatedAtMs - startsAtMs;
+  const timeRemainingPercent = (100 * remainingMs) / (cycleSeconds * 1000);
+  const elapsedPercent = (100 * elapsedMs) / (cycleSeconds * 1000);
+  const reservePercentPoints = percentRemaining - timeRemainingPercent;
+  const status = classifyPace(reservePercentPoints);
+
+  const pace: QuotaPace = {
+    status,
+    timeRemainingPercent: roundPace(timeRemainingPercent),
+    elapsedPercent: roundPace(elapsedPercent),
+    reservePercentPoints: roundPace(reservePercentPoints),
+    cycleBasis,
+    cycleSeconds,
+  };
+
+  if (elapsedPercent > 0) {
+    pace.burnMultiple = roundPace(percentUsed / elapsedPercent);
+  }
+
+  if (percentUsed > 0 && elapsedMs > 0) {
+    const remainingBudget = percentRemaining;
+    const burnPerMs = percentUsed / elapsedMs;
+    if (burnPerMs > 0 && remainingBudget >= 0) {
+      const msToExhaust = remainingBudget / burnPerMs;
+      pace.projectedExhaustedAt = new Date(
+        generatedAtMs + msToExhaust,
+      ).toISOString();
+      pace.projectionConfidence =
+        elapsedPercent < PACE_EARLY_ELAPSED_PERCENT ? "early" : "established";
+      pace.projectionBasis = "cycle_average";
+    }
+  }
+
+  return pace;
+}
+
+export function summarizeEffectivePace(
+  windows: QuotaWindow[],
+): EffectivePaceSummary {
+  const aheadWindowIds: string[] = [];
+  const behindWindowIds: string[] = [];
+  const onPaceWindowIds: string[] = [];
+  const unknownWindowIds: string[] = [];
+  let worstReservePercentPoints: number | undefined;
+  let worstReserveWindowId: string | undefined;
+
+  for (const window of windows) {
+    const pace = window.pace;
+    switch (pace?.status) {
+      case "ahead":
+        aheadWindowIds.push(window.id);
+        break;
+      case "behind":
+        behindWindowIds.push(window.id);
+        break;
+      case "on_pace":
+        onPaceWindowIds.push(window.id);
+        break;
+      default:
+        unknownWindowIds.push(window.id);
+        break;
+    }
+
+    const reserve = pace?.reservePercentPoints;
+    if (reserve === undefined) continue;
+    if (
+      worstReservePercentPoints === undefined ||
+      reserve < worstReservePercentPoints
+    ) {
+      worstReservePercentPoints = reserve;
+      worstReserveWindowId = window.id;
+    }
+  }
+
+  const summary: EffectivePaceSummary = {
+    status: aggregatePaceStatus({
+      ahead: aheadWindowIds.length,
+      behind: behindWindowIds.length,
+      onPace: onPaceWindowIds.length,
+      unknown: unknownWindowIds.length,
+    }),
+  };
+  if (aheadWindowIds.length > 0) summary.aheadWindowIds = aheadWindowIds;
+  if (behindWindowIds.length > 0) summary.behindWindowIds = behindWindowIds;
+  if (onPaceWindowIds.length > 0) summary.onPaceWindowIds = onPaceWindowIds;
+  if (unknownWindowIds.length > 0) summary.unknownWindowIds = unknownWindowIds;
+  if (
+    worstReservePercentPoints !== undefined &&
+    worstReserveWindowId !== undefined
+  ) {
+    summary.worstReservePercentPoints = worstReservePercentPoints;
+    summary.worstReserveWindowId = worstReserveWindowId;
+  }
+  return summary;
+}
+
+function resolveCycle(
+  window: QuotaWindow,
+  generatedAtMs: number,
+): { ok: true; value: ResolvedCycle } | { ok: false; reason: QuotaPaceReason } {
+  const resetsAtMs = parseTimestamp(window.resetsAt);
+  if (resetsAtMs === undefined) return { ok: false, reason: "missing_cycle" };
+  if (resetsAtMs <= generatedAtMs)
+    return { ok: false, reason: "expired_reset" };
+
+  const startsAtMs = parseTimestamp(window.startsAt);
+  if (startsAtMs !== undefined) {
+    if (startsAtMs >= resetsAtMs) return { ok: false, reason: "invalid_cycle" };
+    if (startsAtMs > generatedAtMs)
+      return { ok: false, reason: "future_cycle_start" };
+    const cycleSeconds = (resetsAtMs - startsAtMs) / 1000;
+    if (!(cycleSeconds > 0) || !Number.isFinite(cycleSeconds)) {
+      return { ok: false, reason: "invalid_cycle" };
+    }
+    return {
+      ok: true,
+      value: {
+        cycleSeconds,
+        startsAtMs,
+        resetsAtMs,
+        cycleBasis: "starts_at_resets_at",
+      },
+    };
+  }
+
+  const windowSeconds = finiteNumber(window.windowSeconds);
+  if (windowSeconds === undefined)
+    return { ok: false, reason: "missing_cycle" };
+  if (!(windowSeconds > 0)) return { ok: false, reason: "invalid_cycle" };
+
+  const impliedStartsAtMs = resetsAtMs - windowSeconds * 1000;
+  if (impliedStartsAtMs > generatedAtMs) {
+    return { ok: false, reason: "future_cycle_start" };
+  }
+  return {
+    ok: true,
+    value: {
+      cycleSeconds: windowSeconds,
+      startsAtMs: impliedStartsAtMs,
+      resetsAtMs,
+      cycleBasis: "window_seconds",
+    },
+  };
+}
+
+function classifyPace(
+  reservePercentPoints: number,
+): Exclude<QuotaPace["status"], "unknown"> {
+  if (Math.abs(reservePercentPoints) <= PACE_ON_PACE_DEADBAND_PERCENT_POINTS) {
+    return "on_pace";
+  }
+  return reservePercentPoints < 0 ? "ahead" : "behind";
+}
+
+function aggregatePaceStatus(counts: {
+  ahead: number;
+  behind: number;
+  onPace: number;
+  unknown: number;
+}): EffectivePaceSummary["status"] {
+  const known = counts.ahead + counts.behind + counts.onPace;
+  if (known === 0) return "unknown";
+  if (counts.ahead > 0 && counts.behind > 0) return "mixed";
+  if (counts.ahead > 0) return "ahead";
+  if (counts.behind > 0) return "behind";
+  return "on_pace";
+}
+
+function resolvePercentUsed(
+  window: QuotaWindow,
+  percentRemaining: number | undefined,
+): number | undefined {
+  const explicit = finiteNumber(window.percentUsed);
+  if (explicit !== undefined) return explicit;
+  if (percentRemaining === undefined) return undefined;
+  return 100 - percentRemaining;
+}
+
+function unknownPace(reason: QuotaPaceReason): QuotaPace {
+  return { status: "unknown", reason };
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function finiteNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function roundPace(value: number): number {
+  return Number(value.toFixed(4));
+}

--- a/src/pace.ts
+++ b/src/pace.ts
@@ -70,12 +70,15 @@ export function computeWindowPace(
     const burnPerMs = percentUsed / elapsedMs;
     if (burnPerMs > 0 && remainingBudget >= 0) {
       const msToExhaust = remainingBudget / burnPerMs;
-      pace.projectedExhaustedAt = new Date(
-        generatedAtMs + msToExhaust,
-      ).toISOString();
-      pace.projectionConfidence =
-        elapsedPercent < PACE_EARLY_ELAPSED_PERCENT ? "early" : "established";
-      pace.projectionBasis = "cycle_average";
+      const projectedExhaustedAtMs = generatedAtMs + msToExhaust;
+      if (isRepresentableDateMs(projectedExhaustedAtMs)) {
+        pace.projectedExhaustedAt = new Date(
+          projectedExhaustedAtMs,
+        ).toISOString();
+        pace.projectionConfidence =
+          elapsedPercent < PACE_EARLY_ELAPSED_PERCENT ? "early" : "established";
+        pace.projectionBasis = "cycle_average";
+      }
     }
   }
 
@@ -176,7 +179,14 @@ function resolveCycle(
     return { ok: false, reason: "missing_cycle" };
   if (!(windowSeconds > 0)) return { ok: false, reason: "invalid_cycle" };
 
-  const impliedStartsAtMs = resetsAtMs - windowSeconds * 1000;
+  const cycleDurationMs = windowSeconds * 1000;
+  if (!Number.isFinite(cycleDurationMs)) {
+    return { ok: false, reason: "invalid_cycle" };
+  }
+  const impliedStartsAtMs = resetsAtMs - cycleDurationMs;
+  if (!isRepresentableDateMs(impliedStartsAtMs)) {
+    return { ok: false, reason: "invalid_cycle" };
+  }
   if (impliedStartsAtMs > generatedAtMs) {
     return { ok: false, reason: "future_cycle_start" };
   }
@@ -238,6 +248,10 @@ function finiteNumber(value: number | undefined): number | undefined {
   return typeof value === "number" && Number.isFinite(value)
     ? value
     : undefined;
+}
+
+function isRepresentableDateMs(value: number): boolean {
+  return Number.isFinite(value) && !Number.isNaN(new Date(value).getTime());
 }
 
 function roundPace(value: number): number {

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -42,6 +42,8 @@ const DEFAULT_KEYCHAIN_ACCOUNT = "claude-code-user";
 const SAFE_KEYCHAIN_ACCOUNT = /^[a-zA-Z0-9._-]+$/;
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1_000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1_000;
+const FIVE_HOURS_SECONDS = 18_000;
+const SEVEN_DAYS_SECONDS = 604_800;
 
 type ClaudeCredentials = {
   source: "oauth-file" | "keychain";
@@ -443,6 +445,7 @@ function normalizeScopedLimitEntry(raw: unknown): QuotaWindow | undefined {
       kind: "model",
       percentUsed: clampPercent(percent),
       resetsAt,
+      windowSeconds: SEVEN_DAYS_SECONDS,
     });
   }
 
@@ -454,6 +457,7 @@ function normalizeScopedLimitEntry(raw: unknown): QuotaWindow | undefined {
       kind: "session",
       percentUsed: clampPercent(percent),
       resetsAt,
+      windowSeconds: FIVE_HOURS_SECONDS,
     });
   }
   if (group === "weekly") {
@@ -463,6 +467,7 @@ function normalizeScopedLimitEntry(raw: unknown): QuotaWindow | undefined {
       kind: "weekly",
       percentUsed: clampPercent(percent),
       resetsAt,
+      windowSeconds: SEVEN_DAYS_SECONDS,
     });
   }
 
@@ -862,13 +867,31 @@ function normalizeWindow(
   const used =
     typeof data.utilization === "number" ? data.utilization : undefined;
   if (used === undefined) return undefined;
+  const windowSeconds = trustedClaudeWindowSeconds(id, kind);
   return withRemaining({
     id,
     label,
     kind,
     percentUsed: clampPercent(used),
     resetsAt: stringValue(data.resets_at) ?? stringValue(data.reset_at),
+    ...(windowSeconds !== undefined ? { windowSeconds } : {}),
   });
+}
+
+function trustedClaudeWindowSeconds(
+  id: string,
+  kind: QuotaWindow["kind"],
+): number | undefined {
+  if (id === "five_hour" || kind === "session") return FIVE_HOURS_SECONDS;
+  if (
+    id === "seven_day" ||
+    id === "seven_day_opus" ||
+    kind === "weekly" ||
+    kind === "model"
+  ) {
+    return SEVEN_DAYS_SECONDS;
+  }
+  return undefined;
 }
 
 function normalizeExtraUsage(raw: unknown): QuotaWindow | undefined {

--- a/src/providers/grok.ts
+++ b/src/providers/grok.ts
@@ -185,6 +185,7 @@ export function normalizeGrokConsumerPayload(
       kind: "credits",
       percentUsed,
       percentRemaining: 100 - percentUsed,
+      ...(periodStart ? { startsAt: periodStart } : {}),
       resetsAt,
     });
   }
@@ -206,6 +207,7 @@ export function normalizeGrokConsumerPayload(
       kind: "credits",
       percentUsed,
       percentRemaining: 100 - percentUsed,
+      ...(periodStart ? { startsAt: periodStart } : {}),
       resetsAt,
     });
   }

--- a/src/providers/kimi.ts
+++ b/src/providers/kimi.ts
@@ -663,6 +663,7 @@ export function normalizeKimiPayload(payload: unknown): NormalizedKimiPayload {
       kind: "weekly",
       percentUsed: principal.percentUsed,
       percentRemaining: principal.percentRemaining,
+      windowSeconds: WEEK_SECONDS,
       ...(principal.resetsAt ? { resetsAt: principal.resetsAt } : {}),
     },
   ];

--- a/src/render.ts
+++ b/src/render.ts
@@ -31,33 +31,43 @@ export function renderQuotaToon(
       label: window.label,
       percentRemaining: window.percentRemaining ?? "unknown",
       resetsAt: window.resetsAt ?? window.resetText ?? "unknown",
+      pace: window.pace?.status ?? "unknown",
+      reserve: window.pace?.reservePercentPoints ?? "unknown",
       state: provider.state.status,
     })),
   );
   const effective = response.providers.flatMap((provider) => {
     const semantics = provider.quotaSemantics;
     if (!semantics || semantics.effectiveAvailability.length === 0) {
-      return [
-        {
-          provider: provider.provider,
-          scope: "unresolved",
-          effectivePercentRemaining: "unknown",
-          boundedBy: "none",
-          limitingWindowIds: "unknown",
-          unresolvedWindowIds:
-            semantics?.unresolvedWindowIds?.join(" + ") ?? "none",
-          relationshipStatus: semantics?.status ?? "unknown",
-        },
-      ];
+      const row = {
+        provider: provider.provider,
+        scope: "unresolved",
+        effectivePercentRemaining: "unknown" as string | number,
+        boundedBy: "none",
+        limitingWindowIds: "unknown",
+        pace: "unknown",
+        aheadWindows: "none",
+        unknownPace: "none",
+        worstReserve: "unknown" as string | number,
+        unresolvedWindowIds:
+          semantics?.unresolvedWindowIds?.join(" + ") ?? "none",
+        relationshipStatus: semantics?.status ?? ("unknown" as const),
+      };
+      return [row];
     }
     return semantics.effectiveAvailability.map((availability) => ({
       provider: provider.provider,
       scope: availability.scope,
       effectivePercentRemaining:
-        availability.effectivePercentRemaining ?? "unknown",
+        availability.effectivePercentRemaining ?? ("unknown" as const),
       boundedBy: availability.boundedBy.join(" + ") || "none",
       limitingWindowIds:
         availability.limitingWindowIds?.join(" + ") ?? "unknown",
+      pace: availability.pace?.status ?? "unknown",
+      aheadWindows: availability.pace?.aheadWindowIds?.join(" + ") ?? "none",
+      unknownPace: availability.pace?.unknownWindowIds?.join(" + ") ?? "none",
+      worstReserve:
+        availability.pace?.worstReservePercentPoints ?? ("unknown" as const),
       unresolvedWindowIds: semantics.unresolvedWindowIds?.join(" + ") ?? "none",
       relationshipStatus: semantics.status,
     }));

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -4,9 +4,9 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
   "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining " +
-  "percentages, reset times, and provider status read from local auth sources, with no " +
-  "routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
-  "to keep spending a provider's quota, when the user asks about usage, rate limits, or " +
+  "percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, " +
+  "with no routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
+  "to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or " +
   "remaining quota, or when comparing local provider headroom.";
 
 export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
@@ -17,6 +17,7 @@ export const SKILL_AUTHOR = "Kun Chen (kunchenguid)";
 export const HERMES_TAGS = [
   "quota",
   "rate-limits",
+  "pace",
   "claude",
   "codex",
   "cursor",
@@ -75,9 +76,13 @@ or when comparing supported local provider headroom side by side.
 3. Pass \`--json\` for the normalized machine-readable model instead of TOON. Read
    \`quotaSemantics.effectiveAvailability\` rather than treating a model window in isolation:
    account windows can bound every model, and \`boundedBy\` names every window included in the
-   effective percentage. If relationship status is \`partial\` or \`unknown\`, do not infer one.
-   Stale reports keep raw windows for diagnostics, but effective availability is always unknown;
-   never route from a stale raw percentage as though it were current headroom.
+   effective percentage. Read each window's \`pace\` (and the effective scope's pace summary) to
+   distinguish raw remaining capacity from whether usage is ahead of or behind the reset clock:
+   negative \`reservePercentPoints\` means ahead/conserve. Default TOON already shows \`pace\` and
+   signed \`reserve\` on window rows. If relationship status is \`partial\` or \`unknown\`, do not
+   infer one. Stale reports keep raw windows for diagnostics, but effective availability and pace
+   are always unknown; never route from a stale raw percentage as though it were current headroom.
+   quota-axi never recommends a provider, model, or route.
 4. Pass \`--full\` to include account identity and per-source attempt details.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing
    secret values.

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,17 +35,71 @@ export type ProviderStateReason =
   | "keychain_access_required"
   | "credentials_expired";
 
+export type QuotaPaceStatus = "ahead" | "on_pace" | "behind" | "unknown";
+
+export type QuotaPaceReason =
+  | "stale"
+  | "missing_usage"
+  | "missing_cycle"
+  | "invalid_cycle"
+  | "future_cycle_start"
+  | "expired_reset"
+  | "unsupported_period";
+
+export type QuotaPace = {
+  status: QuotaPaceStatus;
+  /** Present only when status is unknown. */
+  reason?: QuotaPaceReason;
+  /** 100 * (resetsAt - generatedAt) / cycleDuration. */
+  timeRemainingPercent?: number;
+  /** 100 * (generatedAt - cycleStart) / cycleDuration. */
+  elapsedPercent?: number;
+  /**
+   * percentRemaining - timeRemainingPercent.
+   * Negative means usage is ahead of the reset clock (burning faster than linear).
+   * Positive means usage is behind the reset clock.
+   */
+  reservePercentPoints?: number;
+  /** percentUsed / elapsedPercent when elapsedPercent > 0. */
+  burnMultiple?: number;
+  /** Linear cycle-average exhaustion timestamp when defined. */
+  projectedExhaustedAt?: string;
+  projectionConfidence?: "early" | "established";
+  /** Always cycle-average in v1; reserved for future bases. */
+  projectionBasis?: "cycle_average";
+  cycleBasis?: "starts_at_resets_at" | "window_seconds";
+  cycleSeconds?: number;
+};
+
+export type EffectivePaceSummary = {
+  /**
+   * Aggregate across every bounding window for this scope.
+   * `worstReservePercentPoints` is the most negative (most ahead) signed reserve
+   * among windows with known pace; it is not a routing score.
+   */
+  status: "ahead" | "on_pace" | "behind" | "mixed" | "unknown";
+  aheadWindowIds?: string[];
+  behindWindowIds?: string[];
+  onPaceWindowIds?: string[];
+  unknownWindowIds?: string[];
+  worstReservePercentPoints?: number;
+  worstReserveWindowId?: string;
+};
+
 export type QuotaWindow = {
   id: string;
   label: string;
   kind: "session" | "weekly" | "monthly" | "model" | "credits" | "unknown";
   percentUsed?: number;
   percentRemaining?: number;
+  startsAt?: string;
   resetsAt?: string;
   resetText?: string;
   windowSeconds?: number;
   spentUsd?: number;
   limitUsd?: number;
+  /** Cycle-average pace relative to generatedAt. Not cached. */
+  pace?: QuotaPace;
 };
 
 export type EffectiveAvailability = {
@@ -54,6 +108,8 @@ export type EffectiveAvailability = {
   effectivePercentRemaining?: number;
   boundedBy: string[];
   limitingWindowIds?: string[];
+  /** Compact pace over every bounding window, not only the current limiter. */
+  pace?: EffectivePaceSummary;
 };
 
 export type QuotaSemantics = {
@@ -104,7 +160,7 @@ export type ProviderQuota = {
 
 export type QuotaAxiResponse = {
   generatedAt: string;
-  schemaVersion: 2;
+  schemaVersion: 3;
   providers: ProviderQuota[];
   help?: string[];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,7 +65,7 @@ export type QuotaPace = {
   /** Linear cycle-average exhaustion timestamp when defined. */
   projectedExhaustedAt?: string;
   projectionConfidence?: "early" | "established";
-  /** Always cycle-average in v1; reserved for future bases. */
+  /** Currently cycle-average; reserved for future bases. */
   projectionBasis?: "cycle_average";
   cycleBasis?: "starts_at_resets_at" | "window_seconds";
   cycleSeconds?: number;

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -185,6 +185,35 @@ describe("quota cache", () => {
     ]);
   });
 
+  it("retains trusted cycle evidence but never caches derived pace", () => {
+    useTempCache();
+    const claude = quota("claude", 40);
+    claude.windows[0] = {
+      ...claude.windows[0],
+      percentRemaining: 60,
+      startsAt: "2026-07-06T15:00:00Z",
+      resetsAt: "2026-07-06T20:00:00Z",
+      windowSeconds: 18_000,
+      pace: {
+        status: "ahead",
+        reservePercentPoints: -20,
+        projectionBasis: "cycle_average",
+      },
+    };
+
+    writeCachedProviders([claude]);
+
+    const bytes = readFileSync(cacheFilePath(), "utf8");
+    const cachedWindow = readCachedProvider("claude")?.windows[0];
+    expect(bytes).not.toContain('"pace"');
+    expect(cachedWindow).toMatchObject({
+      startsAt: "2026-07-06T15:00:00Z",
+      resetsAt: "2026-07-06T20:00:00Z",
+      windowSeconds: 18_000,
+    });
+    expect(cachedWindow?.pace).toBeUndefined();
+  });
+
   it("deletes a definitive-auth provider while retaining other snapshots", () => {
     useTempCache();
     writeCachedProviders([quota("claude", 10), quota("kimi", 20)]);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -231,7 +231,7 @@ describe("CLI quota rendering", () => {
     const codex = output.providers.find(
       (provider) => provider.provider === "codex",
     );
-    expect(output.schemaVersion).toBe(2);
+    expect(output.schemaVersion).toBe(3);
     expect(claude?.state.reason).toBe("keychain_access_required");
     expect(claude?.state.remedyCommand).toBe(
       "quota-axi --allow-keychain-prompt",
@@ -243,8 +243,16 @@ describe("CLI quota rendering", () => {
           scope: "all_models",
           status: "unknown",
           boundedBy: ["five_hour"],
+          pace: {
+            status: "unknown",
+            unknownWindowIds: ["five_hour"],
+          },
         },
       ],
+    });
+    expect(claude?.windows[0]?.pace).toEqual({
+      status: "unknown",
+      reason: "stale",
     });
     expect(
       claude?.quotaSemantics?.effectiveAvailability[0]
@@ -408,6 +416,10 @@ describe("CLI quota rendering", () => {
       effectivePercentRemaining: 3,
       boundedBy: ["five_hour", "seven_day", "model:fable"],
       limitingWindowIds: ["seven_day"],
+      pace: {
+        status: "unknown",
+        unknownWindowIds: ["five_hour", "seven_day", "model:fable"],
+      },
     });
   });
 
@@ -418,27 +430,67 @@ describe("CLI quota rendering", () => {
     const toon = await capture(["--provider", "kimi"]);
     expect(toon).toContain("kimi,unknown,api,fresh");
     expect(toon).toContain(
-      'kimi,five_hour,session,81.25,"2027-02-03T09:05:06.000Z",fresh',
+      "windows[2]{provider,id,label,percentRemaining,resetsAt,pace,reserve,state}:",
+    );
+    expect(toon).toMatch(
+      /kimi,five_hour,session,81\.25,"2027-02-03T09:05:06\.000Z",[^,]+,[^,]+,fresh/,
+    );
+    expect(toon).toMatch(
+      /kimi,weekly,week,67\.5,"2027-02-08T04:05:06\.000Z",[^,]+,[^,]+,fresh/,
     );
     expect(toon).toContain(
-      'kimi,weekly,week,67.5,"2027-02-08T04:05:06.000Z",fresh',
+      "effective[1]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,pace,aheadWindows,unknownPace,worstReserve,unresolvedWindowIds,relationshipStatus}:",
     );
     expect(toon).not.toContain("synthetic-kimi-key");
+    expect(toon).not.toMatch(/recommend|prefer provider|switch to/i);
 
     const json = JSON.parse(
       await capture(["--provider", "kimi", "--json"]),
     ) as QuotaAxiResponse;
+    expect(json.schemaVersion).toBe(3);
     expect(json.providers).toEqual([
       expect.objectContaining({
         provider: "kimi",
         label: "Kimi",
         source: "api",
-        windows: freshKimiQuota().windows,
+        windows: [
+          expect.objectContaining({
+            id: "weekly",
+            percentRemaining: 67.5,
+            windowSeconds: 604_800,
+            pace: expect.objectContaining({
+              status: expect.stringMatching(/^(ahead|on_pace|behind|unknown)$/),
+            }),
+          }),
+          expect.objectContaining({
+            id: "five_hour",
+            percentRemaining: 81.25,
+            windowSeconds: 18_000,
+            pace: expect.objectContaining({
+              status: expect.stringMatching(/^(ahead|on_pace|behind|unknown)$/),
+            }),
+          }),
+        ],
+        quotaSemantics: expect.objectContaining({
+          effectiveAvailability: [
+            expect.objectContaining({
+              scope: "all_models",
+              pace: expect.objectContaining({
+                status: expect.stringMatching(
+                  /^(ahead|on_pace|behind|mixed|unknown)$/,
+                ),
+              }),
+            }),
+          ],
+        }),
         state: expect.objectContaining({ status: "fresh", stale: false }),
       }),
     ]);
     expect(json.providers[0].account).toBeUndefined();
     expect(json.providers[0].attempts).toBeUndefined();
+    expect(JSON.stringify(json)).not.toMatch(
+      /recommend|prefer provider|switch to|route to/i,
+    );
   });
 });
 
@@ -497,7 +549,7 @@ describe("response redaction", () => {
   it("hides account identity and attempts unless --full is set", () => {
     const response: QuotaAxiResponse = {
       generatedAt: "2026-07-06T18:10:00Z",
-      schemaVersion: 2,
+      schemaVersion: 3,
       providers: [
         {
           provider: "claude",
@@ -640,6 +692,7 @@ function freshKimiQuota(): ProviderQuota {
         percentUsed: 32.5,
         percentRemaining: 67.5,
         resetsAt: "2027-02-08T04:05:06.000Z",
+        windowSeconds: 604_800,
       },
       {
         id: "five_hour",

--- a/test/interpretation.test.ts
+++ b/test/interpretation.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import { withQuotaSemantics } from "../src/interpretation.js";
 import type { ProviderQuota, QuotaWindow } from "../src/types.js";
 
+const GENERATED_AT = "2026-07-15T12:00:00.000Z";
+const WEEK_SECONDS = 604_800;
+
 function provider(
   provider: ProviderQuota["provider"],
   windows: QuotaWindow[],
@@ -19,6 +22,7 @@ function window(
   id: string,
   kind: QuotaWindow["kind"],
   percentRemaining: number,
+  extra: Partial<QuotaWindow> = {},
 ): QuotaWindow {
   return {
     id,
@@ -26,7 +30,15 @@ function window(
     kind,
     percentUsed: 100 - percentRemaining,
     percentRemaining,
+    ...extra,
   };
+}
+
+function weeklyResetsAt(elapsedFraction: number): string {
+  const remainingSeconds = WEEK_SECONDS * (1 - elapsedFraction);
+  return new Date(
+    Date.parse(GENERATED_AT) + remainingSeconds * 1000,
+  ).toISOString();
 }
 
 describe("quota semantics", () => {
@@ -49,7 +61,7 @@ describe("quota semantics", () => {
         sourcesTried: ["api", "cache"],
       };
 
-      const semantics = withQuotaSemantics(stale).quotaSemantics;
+      const semantics = withQuotaSemantics(stale, GENERATED_AT).quotaSemantics;
       expect(semantics?.status, providerId).not.toBe("known");
       expect(
         semantics?.effectiveAvailability.every(
@@ -59,16 +71,34 @@ describe("quota semantics", () => {
         ),
         providerId,
       ).toBe(true);
+      expect(
+        stale.windows.every(() => true) &&
+          withQuotaSemantics(stale, GENERATED_AT).windows.every(
+            (item) =>
+              item.pace?.status === "unknown" && item.pace.reason === "stale",
+          ),
+        providerId,
+      ).toBe(true);
     }
   });
 
   it("reports a model's effective headroom from its bounding account and model windows", () => {
     const result = withQuotaSemantics(
       provider("claude", [
-        window("five_hour", "session", 91),
-        window("seven_day", "weekly", 3),
-        window("model:fable", "model", 19),
+        window("five_hour", "session", 91, {
+          windowSeconds: 18_000,
+          resetsAt: weeklyResetsAt(0.2),
+        }),
+        window("seven_day", "weekly", 3, {
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: weeklyResetsAt(0.2),
+        }),
+        window("model:fable", "model", 19, {
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: weeklyResetsAt(0.2),
+        }),
       ]),
+      GENERATED_AT,
     );
 
     expect(result.quotaSemantics).toMatchObject({
@@ -90,6 +120,47 @@ describe("quota semantics", () => {
         },
       ],
     });
+    expect(
+      result.windows.every((item) => item.pace?.status !== undefined),
+    ).toBe(true);
+  });
+
+  it("surfaces pace on a non-currently-limiting bounding window that is ahead", () => {
+    const result = withQuotaSemantics(
+      provider("claude", [
+        window("five_hour", "session", 80, {
+          windowSeconds: 18_000,
+          resetsAt: new Date(
+            Date.parse(GENERATED_AT) + 9_000 * 1000,
+          ).toISOString(),
+        }),
+        window("seven_day", "weekly", 40, {
+          windowSeconds: WEEK_SECONDS,
+          // 20% of the week elapsed, 60% used -> ahead, but not the lowest remaining
+          resetsAt: weeklyResetsAt(0.2),
+        }),
+      ]),
+      GENERATED_AT,
+    );
+
+    const allModels = result.quotaSemantics?.effectiveAvailability.find(
+      (availability) => availability.scope === "all_models",
+    );
+    expect(allModels).toMatchObject({
+      status: "known",
+      effectivePercentRemaining: 40,
+      limitingWindowIds: ["seven_day"],
+      pace: {
+        status: "mixed",
+        aheadWindowIds: ["seven_day"],
+        worstReserveWindowId: "seven_day",
+      },
+    });
+    expect(allModels?.pace?.aheadWindowIds).toContain("seven_day");
+    expect(allModels?.pace?.worstReservePercentPoints ?? 0).toBeLessThan(0);
+    expect(
+      result.windows.find((item) => item.id === "seven_day")?.pace?.status,
+    ).toBe("ahead");
   });
 
   it("applies Codex base windows to named model windows", () => {
@@ -100,22 +171,27 @@ describe("quota semantics", () => {
         window("code_review_weekly", "weekly", 70),
         window("model:codex_bengalfox:7d", "model", 99),
       ]),
+      GENERATED_AT,
     );
 
-    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual({
-      scope: "code_review",
-      status: "known",
-      effectivePercentRemaining: 70,
-      boundedBy: ["code_review_five_hour", "code_review_weekly"],
-      limitingWindowIds: ["code_review_weekly"],
-    });
-    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual({
-      scope: "model:codex_bengalfox",
-      status: "known",
-      effectivePercentRemaining: 38,
-      boundedBy: ["weekly", "model:codex_bengalfox:7d"],
-      limitingWindowIds: ["weekly"],
-    });
+    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual(
+      expect.objectContaining({
+        scope: "code_review",
+        status: "known",
+        effectivePercentRemaining: 70,
+        boundedBy: ["code_review_five_hour", "code_review_weekly"],
+        limitingWindowIds: ["code_review_weekly"],
+      }),
+    );
+    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual(
+      expect.objectContaining({
+        scope: "model:codex_bengalfox",
+        status: "known",
+        effectivePercentRemaining: 38,
+        boundedBy: ["weekly", "model:codex_bengalfox:7d"],
+        limitingWindowIds: ["weekly"],
+      }),
+    );
   });
 
   it("marks unfamiliar Codex windows partial instead of ignoring them", () => {
@@ -124,6 +200,7 @@ describe("quota semantics", () => {
         window("weekly", "weekly", 38),
         window("future_monthly", "monthly", 10),
       ]),
+      GENERATED_AT,
     );
 
     expect(result.quotaSemantics).toMatchObject({
@@ -139,16 +216,18 @@ describe("quota semantics", () => {
         window("weekly", "weekly", 59),
         window("five_hour", "session", 50),
       ]),
+      GENERATED_AT,
     );
 
     expect(result.quotaSemantics?.effectiveAvailability).toEqual([
-      {
+      expect.objectContaining({
         scope: "all_models",
         status: "known",
         effectivePercentRemaining: 50,
         boundedBy: ["weekly", "five_hour"],
         limitingWindowIds: ["five_hour"],
-      },
+        pace: expect.objectContaining({ status: "unknown" }),
+      }),
     ]);
   });
 
@@ -156,7 +235,7 @@ describe("quota semantics", () => {
     const kimi = provider("kimi", [window("weekly", "weekly", 59)]);
     kimi.state.untrustedWindowIds = ["limit:2"];
 
-    const result = withQuotaSemantics(kimi);
+    const result = withQuotaSemantics(kimi, GENERATED_AT);
 
     expect(result.quotaSemantics).toEqual({
       status: "partial",
@@ -167,6 +246,10 @@ describe("quota semantics", () => {
           scope: "all_models",
           status: "unknown",
           boundedBy: ["weekly"],
+          pace: {
+            status: "unknown",
+            unknownWindowIds: ["weekly"],
+          },
         },
       ],
       unresolvedWindowIds: ["limit:2"],
@@ -179,20 +262,24 @@ describe("quota semantics", () => {
         window("credits", "credits", 1),
         window("product:grok_build", "credits", 88),
       ]),
+      GENERATED_AT,
     );
 
-    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual({
-      scope: "product:grok_build",
-      status: "known",
-      effectivePercentRemaining: 1,
-      boundedBy: ["credits", "product:grok_build"],
-      limitingWindowIds: ["credits"],
-    });
+    expect(result.quotaSemantics?.effectiveAvailability).toContainEqual(
+      expect.objectContaining({
+        scope: "product:grok_build",
+        status: "known",
+        effectivePercentRemaining: 1,
+        boundedBy: ["credits", "product:grok_build"],
+        limitingWindowIds: ["credits"],
+      }),
+    );
   });
 
   it("labels unknown and unfamiliar relationships instead of inventing an answer", () => {
     const cursor = withQuotaSemantics(
       provider("cursor", [window("included_usage", "monthly", 100)]),
+      GENERATED_AT,
     );
     expect(cursor.quotaSemantics).toMatchObject({
       status: "unknown",
@@ -205,6 +292,7 @@ describe("quota semantics", () => {
         window("weekly", "weekly", 59),
         window("limit:2", "unknown", 80),
       ]),
+      GENERATED_AT,
     );
     expect(kimi.quotaSemantics).toMatchObject({
       status: "partial",
@@ -217,5 +305,29 @@ describe("quota semantics", () => {
       ],
       unresolvedWindowIds: ["limit:2"],
     });
+  });
+
+  it("does not invent provider or model routing recommendations", () => {
+    const result = withQuotaSemantics(
+      provider("claude", [
+        window("five_hour", "session", 10, {
+          windowSeconds: 18_000,
+          resetsAt: new Date(
+            Date.parse(GENERATED_AT) + 3_600_000,
+          ).toISOString(),
+        }),
+        window("seven_day", "weekly", 90, {
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: weeklyResetsAt(0.1),
+        }),
+      ]),
+      GENERATED_AT,
+    );
+
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toMatch(/recommend|prefer|switch to|route to/i);
+    expect(result.quotaSemantics?.description).not.toMatch(
+      /recommend|prefer|switch|route/i,
+    );
   });
 });

--- a/test/pace.test.ts
+++ b/test/pace.test.ts
@@ -157,6 +157,26 @@ describe("computeWindowPace", () => {
     expect(usedAtStart.projectedExhaustedAt).toBeUndefined();
   });
 
+  it("omits projections outside the representable timestamp range", () => {
+    const pace = computeWindowPace(
+      window({
+        id: "credits",
+        kind: "credits",
+        percentUsed: 0.000001,
+        percentRemaining: 99.999999,
+        startsAt: startsBefore(1 / 7),
+        resetsAt: resetsAfter(1 / 7),
+      }),
+      GENERATED_AT,
+    );
+
+    expect(pace.status).toBe("behind");
+    expect(pace.burnMultiple).toBeDefined();
+    expect(pace.projectedExhaustedAt).toBeUndefined();
+    expect(pace.projectionConfidence).toBeUndefined();
+    expect(pace.projectionBasis).toBeUndefined();
+  });
+
   it("returns unknown for stale, missing, expired, rolling, and invalid cycles", () => {
     expect(
       computeWindowPace(
@@ -228,6 +248,19 @@ describe("computeWindowPace", () => {
           percentUsed: 10,
           percentRemaining: 90,
           windowSeconds: 0,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "invalid_cycle" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          windowSeconds: Number.MAX_VALUE,
           resetsAt: resetsAfter(0.2),
         }),
         GENERATED_AT,

--- a/test/pace.test.ts
+++ b/test/pace.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeWindowPace,
+  PACE_EARLY_ELAPSED_PERCENT,
+  PACE_ON_PACE_DEADBAND_PERCENT_POINTS,
+  summarizeEffectivePace,
+} from "../src/pace.js";
+import type { QuotaWindow } from "../src/types.js";
+
+const GENERATED_AT = "2026-07-15T12:00:00.000Z";
+const WEEK_SECONDS = 604_800;
+const FIVE_HOURS_SECONDS = 18_000;
+
+function window(
+  partial: Partial<QuotaWindow> & Pick<QuotaWindow, "id">,
+): QuotaWindow {
+  return {
+    label: partial.label ?? partial.id,
+    kind: partial.kind ?? "weekly",
+    ...partial,
+  };
+}
+
+function resetsAfter(
+  elapsedFraction: number,
+  cycleSeconds = WEEK_SECONDS,
+): string {
+  const generatedAtMs = Date.parse(GENERATED_AT);
+  const remainingSeconds = cycleSeconds * (1 - elapsedFraction);
+  return new Date(generatedAtMs + remainingSeconds * 1000).toISOString();
+}
+
+function startsBefore(
+  elapsedFraction: number,
+  cycleSeconds = WEEK_SECONDS,
+): string {
+  const generatedAtMs = Date.parse(GENERATED_AT);
+  return new Date(
+    generatedAtMs - cycleSeconds * elapsedFraction * 1000,
+  ).toISOString();
+}
+
+describe("computeWindowPace", () => {
+  it("classifies ahead, behind, and on_pace with signed reserve", () => {
+    const ahead = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 50,
+        percentRemaining: 50,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0.25),
+      }),
+      GENERATED_AT,
+    );
+    expect(ahead.status).toBe("ahead");
+    expect(ahead.reservePercentPoints).toBeCloseTo(50 - 75, 4);
+    expect(ahead.burnMultiple).toBeCloseTo(2, 4);
+    expect(ahead.cycleBasis).toBe("window_seconds");
+
+    const behind = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 10,
+        percentRemaining: 90,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0.5),
+      }),
+      GENERATED_AT,
+    );
+    expect(behind.status).toBe("behind");
+    expect(behind.reservePercentPoints).toBeCloseTo(40, 4);
+    expect(behind.burnMultiple).toBeCloseTo(0.2, 4);
+
+    const onPace = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 50,
+        percentRemaining: 50,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0.5),
+      }),
+      GENERATED_AT,
+    );
+    expect(onPace.status).toBe("on_pace");
+    expect(onPace.reservePercentPoints).toBeCloseTo(0, 4);
+    expect(Math.abs(onPace.reservePercentPoints ?? 99)).toBeLessThanOrEqual(
+      PACE_ON_PACE_DEADBAND_PERCENT_POINTS,
+    );
+  });
+
+  it("uses startsAt + resetsAt when both boundaries are present", () => {
+    const elapsed = 0.4;
+    const pace = computeWindowPace(
+      window({
+        id: "credits",
+        kind: "credits",
+        percentUsed: 20,
+        percentRemaining: 80,
+        startsAt: startsBefore(elapsed),
+        resetsAt: resetsAfter(elapsed),
+      }),
+      GENERATED_AT,
+    );
+
+    expect(pace).toMatchObject({
+      status: "behind",
+      cycleBasis: "starts_at_resets_at",
+      cycleSeconds: WEEK_SECONDS,
+    });
+    expect(pace.elapsedPercent).toBeCloseTo(40, 4);
+    expect(pace.reservePercentPoints).toBeCloseTo(20, 4);
+  });
+
+  it("labels early-cycle projections and omits burn multiple at zero elapsed", () => {
+    const earlyElapsed = (PACE_EARLY_ELAPSED_PERCENT - 1) / 100;
+    const early = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 20,
+        percentRemaining: 80,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(earlyElapsed),
+      }),
+      GENERATED_AT,
+    );
+    expect(early.status).toBe("ahead");
+    expect(early.projectionConfidence).toBe("early");
+    expect(early.projectionBasis).toBe("cycle_average");
+    expect(early.projectedExhaustedAt).toEqual(expect.any(String));
+
+    const zeroElapsed = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 0,
+        percentRemaining: 100,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0),
+      }),
+      GENERATED_AT,
+    );
+    expect(zeroElapsed.status).toBe("on_pace");
+    expect(zeroElapsed.burnMultiple).toBeUndefined();
+    expect(zeroElapsed.projectedExhaustedAt).toBeUndefined();
+
+    const usedAtStart = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 5,
+        percentRemaining: 95,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0),
+      }),
+      GENERATED_AT,
+    );
+    expect(usedAtStart.status).toBe("ahead");
+    expect(usedAtStart.burnMultiple).toBeUndefined();
+    expect(usedAtStart.projectedExhaustedAt).toBeUndefined();
+  });
+
+  it("returns unknown for stale, missing, expired, rolling, and invalid cycles", () => {
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+        { stale: true },
+      ),
+    ).toEqual({ status: "unknown", reason: "stale" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "missing_usage" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "missing_cycle" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: "2026-07-15T11:00:00.000Z",
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "expired_reset" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          startsAt: "2026-07-16T12:00:00.000Z",
+          resetsAt: "2026-07-23T12:00:00.000Z",
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "future_cycle_start" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "weekly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          windowSeconds: 0,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "invalid_cycle" });
+
+    expect(
+      computeWindowPace(
+        window({
+          id: "monthly",
+          kind: "monthly",
+          percentUsed: 10,
+          percentRemaining: 90,
+          resetsAt: resetsAfter(0.2),
+        }),
+        GENERATED_AT,
+      ),
+    ).toEqual({ status: "unknown", reason: "missing_cycle" });
+  });
+
+  it("matches the deterministic live acceptance fixtures", () => {
+    // Codex weekly: 6% used, ~1.16% elapsed, ahead ~4.84 points, early projection.
+    const codexElapsed = 0.0116;
+    const codex = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 6,
+        percentRemaining: 94,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(codexElapsed),
+      }),
+      GENERATED_AT,
+    );
+    expect(codex.status).toBe("ahead");
+    expect(codex.elapsedPercent).toBeCloseTo(1.16, 2);
+    expect(codex.reservePercentPoints).toBeCloseTo(-4.84, 2);
+    expect(codex.projectionConfidence).toBe("early");
+    expect(codex.burnMultiple).toBeCloseTo(6 / 1.16, 2);
+
+    // Kimi weekly: 57% used, ~50.09% elapsed, ahead ~6.91, projection ~20h before reset.
+    const kimiElapsed = 0.5009;
+    const kimiResetsAt = resetsAfter(kimiElapsed);
+    const kimi = computeWindowPace(
+      window({
+        id: "weekly",
+        percentUsed: 57,
+        percentRemaining: 43,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: kimiResetsAt,
+      }),
+      GENERATED_AT,
+    );
+    expect(kimi.status).toBe("ahead");
+    expect(kimi.elapsedPercent).toBeCloseTo(50.09, 2);
+    expect(kimi.reservePercentPoints).toBeCloseTo(-6.91, 2);
+    expect(kimi.projectionConfidence).toBe("established");
+    expect(kimi.projectedExhaustedAt).toEqual(expect.any(String));
+    const kimiExhaustLeadHours =
+      (Date.parse(kimiResetsAt) - Date.parse(kimi.projectedExhaustedAt!)) /
+      3_600_000;
+    expect(kimiExhaustLeadHours).toBeCloseTo(20, 0);
+
+    // Claude Fable weekly: ~59% used, ~37% elapsed, materially ahead.
+    const fable = computeWindowPace(
+      window({
+        id: "model:fable",
+        kind: "model",
+        percentUsed: 59,
+        percentRemaining: 41,
+        windowSeconds: WEEK_SECONDS,
+        resetsAt: resetsAfter(0.37),
+      }),
+      GENERATED_AT,
+    );
+    expect(fable.status).toBe("ahead");
+    expect(fable.reservePercentPoints).toBeCloseTo(41 - 63, 2);
+    expect(fable.reservePercentPoints ?? 0).toBeLessThan(-15);
+
+    // Grok weekly credits: 2% used, ~5.55% elapsed, behind ~3.55 points.
+    const grokElapsed = 0.0555;
+    const grok = computeWindowPace(
+      window({
+        id: "credits",
+        kind: "credits",
+        percentUsed: 2,
+        percentRemaining: 98,
+        startsAt: startsBefore(grokElapsed),
+        resetsAt: resetsAfter(grokElapsed),
+      }),
+      GENERATED_AT,
+    );
+    expect(grok.status).toBe("behind");
+    expect(grok.elapsedPercent).toBeCloseTo(5.55, 2);
+    expect(grok.reservePercentPoints).toBeCloseTo(3.55, 2);
+    expect(grok.cycleBasis).toBe("starts_at_resets_at");
+  });
+
+  it("supports five-hour duration-based cycles", () => {
+    const pace = computeWindowPace(
+      window({
+        id: "five_hour",
+        kind: "session",
+        percentUsed: 50,
+        percentRemaining: 50,
+        windowSeconds: FIVE_HOURS_SECONDS,
+        resetsAt: resetsAfter(0.5, FIVE_HOURS_SECONDS),
+      }),
+      GENERATED_AT,
+    );
+    expect(pace.status).toBe("on_pace");
+    expect(pace.cycleSeconds).toBe(FIVE_HOURS_SECONDS);
+  });
+});
+
+describe("summarizeEffectivePace", () => {
+  it("flags a non-limiting bounding window that is ahead", () => {
+    const fiveHour = window({
+      id: "five_hour",
+      kind: "session",
+      percentUsed: 10,
+      percentRemaining: 90,
+      pace: {
+        status: "behind",
+        reservePercentPoints: 20,
+      },
+    });
+    const weekly = window({
+      id: "weekly",
+      percentUsed: 60,
+      percentRemaining: 40,
+      pace: {
+        status: "ahead",
+        reservePercentPoints: -15,
+      },
+    });
+
+    expect(summarizeEffectivePace([fiveHour, weekly])).toEqual({
+      status: "mixed",
+      aheadWindowIds: ["weekly"],
+      behindWindowIds: ["five_hour"],
+      worstReservePercentPoints: -15,
+      worstReserveWindowId: "weekly",
+    });
+  });
+
+  it("reports mixed and unknown aggregates", () => {
+    expect(
+      summarizeEffectivePace([
+        window({
+          id: "a",
+          pace: { status: "ahead", reservePercentPoints: -2 },
+        }),
+        window({
+          id: "b",
+          pace: { status: "behind", reservePercentPoints: 4 },
+        }),
+      ]),
+    ).toMatchObject({
+      status: "mixed",
+      aheadWindowIds: ["a"],
+      behindWindowIds: ["b"],
+      worstReservePercentPoints: -2,
+      worstReserveWindowId: "a",
+    });
+
+    expect(
+      summarizeEffectivePace([
+        window({
+          id: "x",
+          pace: { status: "unknown", reason: "missing_cycle" },
+        }),
+      ]),
+    ).toEqual({
+      status: "unknown",
+      unknownWindowIds: ["x"],
+    });
+  });
+});

--- a/test/providers/claude.test.ts
+++ b/test/providers/claude.test.ts
@@ -23,6 +23,7 @@ describe("Claude quota parsing", () => {
         percentUsed: 18,
         percentRemaining: 82,
         resetsAt: "2026-07-06T22:15:00Z",
+        windowSeconds: 18_000,
       },
       {
         id: "seven_day",
@@ -30,12 +31,14 @@ describe("Claude quota parsing", () => {
         percentUsed: 36,
         percentRemaining: 64,
         resetsAt: "2026-07-10T16:00:00Z",
+        windowSeconds: 604_800,
       },
       {
         id: "seven_day_opus",
         kind: "model",
         percentUsed: 7,
         percentRemaining: 93,
+        windowSeconds: 604_800,
       },
       {
         id: "extra_usage",
@@ -46,6 +49,10 @@ describe("Claude quota parsing", () => {
         limitUsd: 20,
       },
     ]);
+    expect(
+      result?.windows.find((window) => window.id === "extra_usage")
+        ?.windowSeconds,
+    ).toBeUndefined();
   });
 
   it("prefers the scoped `limits` array and surfaces model-scoped windows like Fable", () => {
@@ -62,6 +69,7 @@ describe("Claude quota parsing", () => {
         percentUsed: 22,
         percentRemaining: 78,
         resetsAt: "2026-07-06T22:15:00.317709+00:00",
+        windowSeconds: 18_000,
       },
       {
         id: "seven_day",
@@ -69,6 +77,7 @@ describe("Claude quota parsing", () => {
         percentUsed: 41,
         percentRemaining: 59,
         resetsAt: "2026-07-10T16:00:00.317732+00:00",
+        windowSeconds: 604_800,
       },
       {
         id: "model:fable",
@@ -77,6 +86,7 @@ describe("Claude quota parsing", () => {
         percentUsed: 63,
         percentRemaining: 37,
         resetsAt: "2026-07-11T09:30:00.318030+00:00",
+        windowSeconds: 604_800,
       },
       {
         id: "extra_usage",

--- a/test/providers/grok.test.ts
+++ b/test/providers/grok.test.ts
@@ -270,6 +270,7 @@ describe("Grok consumer quota parsing", () => {
         kind: "credits",
         percentUsed: 18.25,
         percentRemaining: 81.75,
+        startsAt: "2026-07-20T20:00:00.000Z",
         resetsAt: "2026-07-27T20:00:00.000Z",
       },
       {
@@ -278,6 +279,7 @@ describe("Grok consumer quota parsing", () => {
         kind: "credits",
         percentUsed: 33.25,
         percentRemaining: 66.75,
+        startsAt: "2026-07-20T20:00:00.000Z",
         resetsAt: "2026-07-27T20:00:00.000Z",
       },
       {
@@ -286,6 +288,7 @@ describe("Grok consumer quota parsing", () => {
         kind: "credits",
         percentUsed: 100,
         percentRemaining: 0,
+        startsAt: "2026-07-20T20:00:00.000Z",
         resetsAt: "2026-07-27T20:00:00.000Z",
       },
     ]);

--- a/test/providers/kimi.test.ts
+++ b/test/providers/kimi.test.ts
@@ -550,6 +550,7 @@ describe("Kimi payload normalization", () => {
           kind: "weekly",
           percentUsed: 22,
           percentRemaining: 78,
+          windowSeconds: 604_800,
         },
       ],
       diagnostics: [{ code: "limits_missing" }],


### PR DESCRIPTION
## Intent

Implement first-class quota-window pace signals in quota-axi (producer only) so routing agents can distinguish raw remaining capacity from whether usage is running ahead of or behind the reset clock. quota-axi must remain data-only and must never recommend a provider, model, or route. For each window, compute cycle-average pace from generatedAt: timeRemainingPercent = 100*(resetsAt-generatedAt)/cycleDuration and reservePercentPoints = percentRemaining - timeRemainingPercent (negative = ahead/conserve, positive = behind), with a small on_pace deadband and status ahead|on_pace|behind|unknown. Include inspectable facts: elapsed/time remaining, signed reserve, burn multiple, linear projected exhaustion when defined, projectionConfidence early vs established (early when elapsed < 10%), and cycle-average projection basis. Calculate pace only from trusted cycle evidence (prefer startsAt+resetsAt; else provider-owned windowSeconds+resetsAt); do not invent monthly/rolling durations. Claude/Kimi emit trusted fixed durations; Grok preserves startsAt; Codex already had durations. Stale/missing/invalid/expired/unsupported cycles yield unknown pace. Extend effectiveAvailability with a compact pace summary over every bounding window (ahead/unknown lists and worst signed reserve), not only the current limiter. Keep default TOON token-efficient with pace status and signed reserve on window rows; full projection evidence in JSON. Bump schemaVersion deliberately to 3. Update README, skill, cache (no pace caching), fixtures/tests for ahead/behind/on_pace/unknown, live acceptance-shaped deterministic examples, and absence of routing recommendations. Firstmate consumer is a separate dependent task - do not edit Firstmate.

## What Changed

- Add schema v3 cycle-average pace data for quota windows, including ahead/on-pace/behind status, signed reserve, burn rate, projection evidence, and explicit unknown reasons.
- Aggregate pace across every window bounding effective availability, and expose compact pace fields in default TOON output while retaining full evidence in JSON.
- Supply trusted cycle metadata for Claude, Kimi, and Grok, keep derived pace out of cached snapshots, and update documentation, generated skill content, fixtures, and coverage.

## Risk Assessment

✅ Low: The follow-up commit durably fixes both prior numeric boundary failures, and the cumulative pace-signal change now satisfies the reviewed source-level intent without additional material issues.

## Testing

Focused pace math, trusted-cycle handling, effective summaries, cache behavior, provider normalization, and CLI rendering all passed; the captured end-user transcript demonstrates compact TOON pace/reserve fields plus schema v3 JSON projection evidence for ahead, behind, mixed, and unknown cases.

- Evidence: [End-user CLI pace transcript](https://github.com/kunchenguid/quota-axi/blob/6bba07011223a5255ec381869f04118b121bf879/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-transcript.txt)
- Evidence: [Reproducible CLI evidence driver](https://github.com/kunchenguid/quota-axi/blob/6bba07011223a5255ec381869f04118b121bf879/.no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-evidence.ts)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `src/pace.ts:73` - A valid, very small nonzero utilization can make `generatedAtMs + msToExhaust` exceed JavaScript&#39;s representable Date range, causing `toISOString()` to throw and abort the entire quota report. This is reachable through Grok&#39;s unrounded usage floats, for example roughly 0.000001% used after one day of a weekly cycle. Validate the projected timestamp before formatting it and omit projection fields when it is not representable.
- 🚨 `src/pace.ts:169` - The required criterion says &#34;invalid ... cycles yield unknown pace,&#34; but this branch accepts any finite positive `windowSeconds`. A sufficiently large value overflows `windowSeconds * 1000`, makes the implied start `-Infinity`, and produces known pace with `NaN` elapsed evidence rather than `{status: &#34;unknown&#34;, reason: &#34;invalid_cycle&#34;}`. Validate the duration in milliseconds and implied start before accepting the cycle.

🔧 Fix: Harden pace timestamp boundary validation
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Inspected the target diff and pace-related acceptance coverage.`
- `pnpm exec vitest run test/pace.test.ts test/interpretation.test.ts test/cli.test.ts test/providers/claude.test.ts test/providers/grok.test.ts test/providers/kimi.test.ts`
- `pnpm exec tsx .no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-evidence.ts | tee .no-mistakes/evidence/fm/quota-pace-signals-p1/pace-cli-transcript.txt`
- `pnpm exec vitest run test/cache.test.ts test/pace.test.ts test/interpretation.test.ts test/cli.test.ts test/providers/claude.test.ts test/providers/grok.test.ts test/providers/kimi.test.ts`
- `Checked the CLI transcript for forbidden provider/model/route recommendations and found none.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
