### PR TITLE
feat(providers): add sub2API balance reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
 - quota-axi is data only.
-- It reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
+- It reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows plus an optional sub2API balance, and it must never route, recommend, proxy, intercept, log in, import browser cookies, or mutate provider state.
 - Claude quota windows can include `five_hour`, `seven_day`, `seven_day_opus`, and `extra_usage`. When the OAuth usage response includes a `limits` array, that array is the authoritative, self-describing source and is preferred over the fixed top-level fields: it surfaces every active limit, including ones scoped to a specific model (e.g. Fable) via `scope.model.display_name`, with a `model:<slug>` window id.
 - Claude credential-validity and cache-fallback contracts are documented in [README Security Posture](README.md#security-posture).
 - Codex window identity and cache-validation contracts are documented in [README Provider windows](README.md#provider-windows) and [README Cache](README.md#cache).
@@ -18,6 +18,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 - Grok cache fallback accepts only current `web` source snapshots, not legacy `api` billing-proxy entries. Never send cookies, launch Grok or Pi, refresh credentials, or retain raw responses.
 - Codex OAuth credential availability is access-token authoritative: expired `id_token` alone must not mark `auth-json` expired or skip the bearer quota probe.
 - Kimi's credential, fallback, and transport contracts are documented in [README Security Posture](README.md#security-posture).
+- sub2API reads explicit `SUB2API_BASE_URL` / `SUB2API_API_KEY` or an active Codex `sub2api` provider plus its `OPENAI_API_KEY`, then performs one redirect-disabled same-origin `/v1/usage` read. It reports a top-level balance without inventing percentage windows or reset cycles and never sends that key to OpenAI quota endpoints.
 - Provider adapter behavior (retry-after handling, snake/camel field tolerance, window parsing) is an original, clean-room implementation derived only from the vendors' own OAuth/HTTP behavior; quota-axi carries no vendored or attributed third-party adapter code.
 - CLI plumbing (routing, `--help`, `-v/--version`, error framing, exit codes, and the built-in `update` self-updater) comes from `axi-sdk-js` `runAxiCli`, matching sibling tasks-axi; product TOON/JSON rendering stays in `src/render.ts` and the command bodies live in `src/commands.ts`.
 - `quota` is the implicit default command: `runAxiCli` routes on `argv[0]` and rejects a leading flag, so `src/cli.ts` `normalizeArgv` prepends `quota` for a bare call or flag-first call (`quota-axi --json`) while leaving `auth`, `update`, and the single-token `--help`/version through to the SDK. Validation errors throw `AxiError("...", "VALIDATION_ERROR")` (exit 2); the all-providers-failed path sets `process.exitCode = 1` and still renders.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Quota CLI for agents - designed with [AXI](https://axi.md) (Agent eXperience Int
 Agents need quota state before they choose where work can safely run.
 Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth sources.
 
-quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows in one [AXI](https://axi.md)-shaped call.
+quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows plus an optional sub2API balance in one [AXI](https://axi.md)-shaped call.
 It is data only: it never routes, recommends, proxies, intercepts, logs in, imports browser cookies, or mutates provider state.
 
-- **Official sources** - quota-axi reads local provider auth sources and calls the first-party quota, usage, billing, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
-- **Local first** - quota and auth reports run on the machine that holds the credentials; their network calls go to first-party provider endpoints, never a third-party relay.
+- **Explicit sources** - quota-axi reads local provider auth sources and calls first-party quota, usage, billing, or entitlement endpoints, with a read-only Codex app-server probe as fallback. The optional sub2API provider calls only the base URL explicitly configured by the user.
+- **Local first** - quota and auth reports run on the machine that holds the credentials; official-provider calls go to first-party endpoints, while sub2API calls its configured relay directly.
   The separate `update` command contacts npm only when the user runs it.
 - **Token efficient** - default stdout is compact TOON so agents spend fewer tokens parsing quota state, with `--json` available when a caller needs the normalized model.
 
@@ -318,14 +318,14 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ### Flags
 
-| Flag                                               | Description                                            |
-| -------------------------------------------------- | ------------------------------------------------------ |
-| `--provider claude,codex,cursor,copilot,grok,kimi` | Scope providers                                        |
-| `--json`                                           | Emit normalized JSON instead of TOON for quota or auth |
-| `--full`                                           | Include account, source attempts, and reserve details  |
-| `--allow-keychain-prompt`                          | Permit macOS Claude Keychain access that could prompt  |
-| `-h`, `--help`                                     | Print terse [AXI](https://axi.md) help                 |
-| `-v`, `-V`, `--version`                            | Print version                                          |
+| Flag                                                       | Description                                            |
+| ---------------------------------------------------------- | ------------------------------------------------------ |
+| `--provider claude,codex,cursor,copilot,grok,kimi,sub2api` | Scope providers                                        |
+| `--json`                                                   | Emit normalized JSON instead of TOON for quota or auth |
+| `--full`                                                   | Include account, source attempts, and reserve details  |
+| `--allow-keychain-prompt`                                  | Permit macOS Claude Keychain access that could prompt  |
+| `-h`, `--help`                                             | Print terse [AXI](https://axi.md) help                 |
+| `-v`, `-V`, `--version`                                    | Print version                                          |
 
 ## Output Model
 
@@ -461,6 +461,7 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 | Grok                   | With a usable Grok CLI session bearer, can report the shared `credits` window, optional product-scoped `product:<slug>` windows, the current-period `startsAt` and reset, and optional prepaid credit balance from the consumer Usage-page operation. Pi `xai` auth alone establishes usability but cannot provide these consumer windows. Top-level `credits.remaining` is prepaid/on-demand balance, distinct from the shared period `windows` credits percentage used for effective availability. Pace prefers the startsAt/resetsAt pair.                          |
 | Grok proto3 zero       | For the exact consumer operation only, an omitted usage float is the official proto3 zero when a valid weekly or monthly current period proves the config is present; quota-axi reports `0` used and `100` remaining rather than deriving usage from money.                                                                                                                                                                                                                                                                                                            |
 | Kimi                   | Reports the principal `weekly` subscription window (with trusted 604,800s duration) plus every valid self-described limit in wire order. Only a limit whose normalized duration is exactly 18,000 seconds is identified as `five_hour`; future limits remain `limit:<index>` unknown windows.                                                                                                                                                                                                                                                                          |
+| sub2API                | Reports `remaining`, `quota.remaining`, or `balance` from the configured `/v1/usage` endpoint as top-level `credits`. It does not invent a percentage window, reset, effective availability, or pace from a monetary balance.                                                                                                                                                                                                                                                                                                                                          |
 
 ### `auth --json` shape
 
@@ -472,10 +473,10 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 
 Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 
-| Name                 | Values                                                                                                                                    |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Auth source statuses | `available`, `missing`, `invalid`, `expired`, `skipped`, or `error`                                                                       |
-| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, `cli-rpc`, `pi:kimi-coding`, `pi:xai`, and `kimi-code-cli` |
+| Name                 | Values                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Auth source statuses | `available`, `missing`, `invalid`, `expired`, `skipped`, or `error`                                                                                                      |
+| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, `cli-rpc`, `pi:kimi-coding`, `pi:xai`, `kimi-code-cli`, `sub2api-env`, and `codex-config` |
 
 ## Security Posture
 
@@ -489,6 +490,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 | GitHub Copilot | `$GITHUB_COPILOT_APPS_JSON` when set or the local Copilot apps auth file                                                                                                                                                                                                                                                             |
 | Grok           | Grok CLI session auth from `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`, plus Pi's independent `$PI_CODING_AGENT_DIR/auth.json` `xai` entry (default `~/.pi/agent/auth.json`) for OAuth or literal API-key model auth                                                  |
 | Kimi           | Pi's `$PI_CODING_AGENT_DIR/auth.json` (default `~/.pi/agent/auth.json`) for a literal `kimi-coding` API key first, then a fresh official Kimi Code CLI access token from `$KIMI_CODE_HOME/credentials/kimi-code.json` (default `$HOME/.kimi-code/credentials/kimi-code.json`)                                                        |
+| sub2API        | `SUB2API_BASE_URL` plus `SUB2API_API_KEY`; otherwise an active `model_provider = "sub2api"` in `$CODEX_HOME/config.toml` and `OPENAI_API_KEY` from the matching `$CODEX_HOME/auth.json`                                                                                                                                              |
 
 ### Provider notes
 
@@ -539,11 +541,19 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 - It never uses `refresh_token`, accepts a custom Kimi origin, launches Pi or Kimi, makes a model request, refreshes or writes credentials, creates a device ID, imports cookies, sends device identity, retains raw responses, or exposes account, plan, token, or fingerprint data.
 - Definitive credential absence or rejection retires Kimi cache data. Transient fallback drops reset-expired windows and applies five-hour or seven-day age bounds to windows without resets.
 
+**sub2API**
+
+- Explicit `SUB2API_BASE_URL` and `SUB2API_API_KEY` take precedence. A partial environment configuration fails closed instead of falling back to another credential.
+- Without those variables, quota-axi reads bounded Codex TOML/JSON files only when the active Codex provider is exactly `sub2api`; it does not reuse `OPENAI_API_KEY` for any other configured provider.
+- It sends one redirect-disabled `GET` with bearer authentication to `/v1/usage` on the configured origin. HTTPS is required except for loopback development URLs, response bodies are capped at 64 KiB, and the total request deadline is 15 seconds.
+- It accepts the CCSwitch-compatible `remaining`, `quota.remaining`, and `balance` fields plus `is_active` / `isValid`. USD is reported as `credits.unit: "usd"`; other units are treated as generic credits.
+- Balance-only reports are not cached because they contain no quota windows. Raw responses and credentials are never cached or printed.
+
 ### Safety guarantees
 
-- Quota and auth HTTP requests go only to first-party provider usage, quota, billing, or entitlement endpoints with the user's local credentials.
+- Official-provider quota requests go only to first-party usage, quota, billing, or entitlement endpoints. The optional sub2API request goes only to the user-configured origin.
 - The user-initiated `update` command is the only non-provider network surface, and it is not part of quota measurement.
-- It sends credential values only to the first-party provider request they authenticate.
+- It sends credential values only to the provider origin they authenticate; sub2API credentials are never sent to OpenAI's first-party quota endpoints.
 - It never prints, logs, or caches credential values.
 - It never launches the Claude, Grok, Pi, or Kimi CLIs, so it cannot spend quota or mutate provider credentials while measuring them.
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "toon",
     "claude",
     "codex",
+    "sub2api",
     "kimi"
   ],
   "bin": {
@@ -52,7 +53,8 @@
   },
   "dependencies": {
     "@toon-format/toon": "2.1.0",
-    "axi-sdk-js": "^0.1.7"
+    "axi-sdk-js": "^0.1.7",
+    "smol-toml": "^1.7.1"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       axi-sdk-js:
         specifier: ^0.1.7
         version: 0.1.8
+      smol-toml:
+        specifier: ^1.7.1
+        version: 1.7.1
     devDependencies:
       "@eslint/js":
         specifier: 10.0.1
@@ -1565,6 +1568,13 @@ packages:
         integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
       }
 
+  smol-toml@1.7.1:
+    resolution:
+      {
+        integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==,
+      }
+    engines: { node: ">= 18" }
+
   source-map-js@1.2.1:
     resolution:
       {
@@ -2574,6 +2584,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  smol-toml@1.7.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows plus sub2API balance via the quota-axi CLI - remaining effective usable runway, percentages or balance, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -16,6 +16,7 @@ metadata:
         copilot,
         grok,
         kimi,
+        sub2api,
         cli,
       ]
     category: observability
@@ -29,7 +30,7 @@ You do not need quota-axi installed globally - invoke it with `npx -y quota-axi`
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
 browser cookies, or mutates provider state. It reads local provider auth sources and calls
-first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
+first-party provider quota endpoints or the explicitly configured sub2API usage endpoint; it never launches the
 Claude, Grok, Pi, or Kimi CLIs, so it cannot spend the quota it measures.
 
 ## When to use
@@ -41,7 +42,7 @@ or when comparing supported local provider headroom side by side.
 ## Workflow
 
 1. Run `npx -y quota-axi` for compact TOON output covering supported providers' quota windows.
-2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok,kimi`.
+2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok,kimi,sub2api`.
 3. Pass `--json` for the normalized machine-readable model instead of TOON. Read
    `quotaSemantics.effectiveAvailability` rather than treating a model window in isolation:
    account windows can bound every model, and `boundedBy` names every window included in the
@@ -86,6 +87,10 @@ or when comparing supported local provider headroom side by side.
    Grok also reads that same Pi auth file for an independent `xai` OAuth or literal API-key
    entry and treats Grok as usable when either the Grok CLI session or Pi `xai` credential is
    valid.
+10. For sub2API, quota-axi prefers `SUB2API_BASE_URL` and `SUB2API_API_KEY`, then falls back
+    to an active Codex `model_provider = "sub2api"` and its `OPENAI_API_KEY`. It sends one
+    redirect-disabled `GET /v1/usage` to that configured origin and reports the returned
+    monetary or credit balance without inventing percentage windows or reset times.
 
 ## Usage
 
@@ -96,11 +101,11 @@ commands[2]:
 output:
   Default TOON reports effective headroom and usable-runway evidence; use --full or --json for reserve diagnostics.
 flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,kimi,sub2api>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
-  quota-axi --provider cursor,copilot,grok,kimi
+  quota-axi --provider cursor,copilot,grok,kimi,sub2api
   quota-axi --json
   quota-axi --full
   quota-axi auth
@@ -114,6 +119,8 @@ examples:
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
+- A sub2API balance is an amount, not a percentage, and has no effective availability or pace
+  unless that endpoint later supplies authoritative total-limit and cycle data.
 - Claude `--full` output exposes the authoritative OAuth profile `account.uuid` as
   `account.accountId` when Anthropic returns one; otherwise the account identity is explicitly
   marked unverified rather than inferred.

--- a/src/args.ts
+++ b/src/args.ts
@@ -74,7 +74,9 @@ function parseProviderScope(value: string | undefined): ProviderId[] {
     throw new AxiError(
       error instanceof Error ? error.message : "unsupported provider",
       "VALIDATION_ERROR",
-      ["Supported providers: claude, codex, cursor, copilot, grok, kimi"],
+      [
+        "Supported providers: claude, codex, cursor, copilot, grok, kimi, sub2api",
+      ],
     );
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,11 +11,11 @@ commands[2]:
 output:
   Default TOON reports effective headroom and usable-runway evidence; use --full or --json for reserve diagnostics.
 flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,kimi,sub2api>, --json, --full, --allow-keychain-prompt, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
-  quota-axi --provider cursor,copilot,grok,kimi
+  quota-axi --provider cursor,copilot,grok,kimi,sub2api
   quota-axi --json
   quota-axi --full
   quota-axi auth

--- a/src/interpretation.ts
+++ b/src/interpretation.ts
@@ -90,6 +90,7 @@ function semanticsFor(
       );
     case "cursor":
     case "copilot":
+    case "sub2api":
       return unknownSemantics(
         provider.windows,
         `quota-axi does not know whether ${provider.label}'s reported windows are independent or jointly bounding, so it does not claim an effective remaining percentage.`,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,6 +4,7 @@ import { copilotAdapter } from "./copilot.js";
 import { cursorAdapter } from "./cursor.js";
 import { grokAdapter } from "./grok.js";
 import { kimiAdapter } from "./kimi.js";
+import { sub2apiAdapter } from "./sub2api.js";
 import {
   PROVIDER_IDS,
   type ProviderAdapter,
@@ -17,6 +18,7 @@ export const PROVIDERS: Record<ProviderId, ProviderAdapter> = {
   copilot: copilotAdapter,
   grok: grokAdapter,
   kimi: kimiAdapter,
+  sub2api: sub2apiAdapter,
 };
 
 export function parseProviders(value: string | undefined): ProviderId[] {

--- a/src/providers/sub2api.ts
+++ b/src/providers/sub2api.ts
@@ -1,0 +1,587 @@
+import { open } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parse } from "smol-toml";
+import { retryAfterToIso } from "../lib/time.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  ProviderStatus,
+  SourceAttempt,
+} from "../types.js";
+import { failedProvider, successProvider } from "./common.js";
+
+const ENV_SOURCE = "sub2api-env";
+const CODEX_SOURCE = "codex-config";
+const CONFIG_LIMIT_BYTES = 64 * 1024;
+const RESPONSE_LIMIT_BYTES = 64 * 1024;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+type Sub2apiCredential = {
+  baseUrl: URL;
+  apiKey: string;
+  source: typeof ENV_SOURCE | typeof CODEX_SOURCE;
+  path?: string;
+};
+
+type CredentialResolution =
+  | { status: "available"; credential: Sub2apiCredential }
+  | {
+      status: "missing" | "invalid" | "error";
+      source: typeof ENV_SOURCE | typeof CODEX_SOURCE;
+      path?: string;
+      error: string;
+    };
+
+type Sub2apiDependencies = {
+  environment: Readonly<Record<string, string | undefined>>;
+  homeDirectory: () => string;
+  readFile: (path: string, maxBytes: number) => Promise<Buffer>;
+  fetch: typeof globalThis.fetch;
+  now: () => number;
+  timeoutMs: number;
+};
+
+export type NormalizedSub2apiUsage = {
+  isValid: boolean;
+  remaining: number;
+  unit: "usd" | "credits";
+};
+
+export function createSub2apiAdapter(
+  overrides: Partial<Sub2apiDependencies> = {},
+): ProviderAdapter {
+  const dependencies: Sub2apiDependencies = {
+    environment: process.env,
+    homeDirectory: homedir,
+    readFile: readBoundedFile,
+    fetch: globalThis.fetch,
+    now: Date.now,
+    timeoutMs: REQUEST_TIMEOUT_MS,
+    ...overrides,
+  };
+
+  return {
+    id: "sub2api",
+    label: "sub2API",
+    fetchQuota: (_options: ProviderOptions) => fetchQuota(dependencies),
+    inspectAuth: (_options: ProviderOptions) => inspectAuth(dependencies),
+  };
+}
+
+export const sub2apiAdapter = createSub2apiAdapter();
+
+export function normalizeSub2apiUsage(
+  raw: unknown,
+): NormalizedSub2apiUsage | undefined {
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  const quota = objectValue(data.quota);
+  const remaining =
+    numberValue(data.remaining) ??
+    numberValue(quota?.remaining) ??
+    numberValue(data.balance);
+  if (remaining === undefined) return undefined;
+
+  const isValid =
+    booleanValue(data.is_active) ?? booleanValue(data.isValid) ?? true;
+  const rawUnit = stringValue(data.unit) ?? stringValue(quota?.unit) ?? "USD";
+  return {
+    isValid,
+    remaining,
+    unit: rawUnit.toLowerCase() === "usd" ? "usd" : "credits",
+  };
+}
+
+async function fetchQuota(
+  dependencies: Sub2apiDependencies,
+): Promise<ProviderQuota> {
+  const resolution = await resolveCredential(dependencies);
+  if (resolution.status !== "available") {
+    const attempt: SourceAttempt = {
+      source: resolution.source,
+      status: resolution.status === "error" ? "failed" : "skipped",
+      error: resolution.error,
+    };
+    return failedProvider({
+      provider: "sub2api",
+      label: "sub2API",
+      status: resolution.status === "error" ? "error" : "auth_required",
+      error: "sub2API configuration or API key required",
+      sourcesTried: [resolution.source],
+      attempts: [attempt],
+    });
+  }
+
+  const { credential } = resolution;
+  const attempts: SourceAttempt[] = [
+    { source: credential.source, status: "failed" },
+  ];
+  try {
+    const usage = await requestUsage(credential, dependencies);
+    if (!usage.isValid) {
+      throw new Sub2apiFailure(
+        "sub2api_account_inactive",
+        "sub2API account is inactive",
+        "auth_required",
+      );
+    }
+    attempts[0] = { source: credential.source, status: "success" };
+    return successProvider({
+      provider: "sub2api",
+      label: "sub2API",
+      source: "api",
+      windows: [],
+      credits: { remaining: usage.remaining, unit: usage.unit },
+      refreshedAt: new Date(dependencies.now()).toISOString(),
+      sourcesTried: [credential.source],
+      attempts,
+    });
+  } catch (error) {
+    const failure =
+      error instanceof Sub2apiFailure
+        ? error
+        : new Sub2apiFailure(
+            "sub2api_request_failed",
+            "sub2API quota request failed",
+            "error",
+          );
+    attempts[0] = {
+      source: credential.source,
+      status: "failed",
+      error: failure.code,
+    };
+    return failedProvider({
+      provider: "sub2api",
+      label: "sub2API",
+      status: failure.status,
+      error: failure.message,
+      retryAfter: failure.retryAfter,
+      sourcesTried: [credential.source],
+      attempts,
+    });
+  }
+}
+
+async function inspectAuth(
+  dependencies: Sub2apiDependencies,
+): Promise<AuthProviderReport> {
+  const resolution = await resolveCredential(dependencies);
+  const source: AuthSourceReport =
+    resolution.status === "available"
+      ? {
+          source: resolution.credential.source,
+          path: resolution.credential.path,
+          status: "available",
+          credentialPresent: true,
+        }
+      : {
+          source: resolution.source,
+          path: resolution.path,
+          status:
+            resolution.status === "missing"
+              ? "missing"
+              : resolution.status === "error"
+                ? "error"
+                : "invalid",
+          error: resolution.error,
+        };
+  return { provider: "sub2api", sources: [source] };
+}
+
+async function resolveCredential(
+  dependencies: Sub2apiDependencies,
+): Promise<CredentialResolution> {
+  const envBaseUrl = nonempty(dependencies.environment.SUB2API_BASE_URL);
+  const envApiKey = usableApiKey(dependencies.environment.SUB2API_API_KEY);
+  if (envBaseUrl !== undefined || dependencies.environment.SUB2API_API_KEY) {
+    if (!envBaseUrl || !envApiKey) {
+      return {
+        status: "invalid",
+        source: ENV_SOURCE,
+        error: "sub2api_environment_incomplete",
+      };
+    }
+    const baseUrl = usableBaseUrl(envBaseUrl);
+    return baseUrl
+      ? {
+          status: "available",
+          credential: { baseUrl, apiKey: envApiKey, source: ENV_SOURCE },
+        }
+      : {
+          status: "invalid",
+          source: ENV_SOURCE,
+          error: "sub2api_base_url_invalid",
+        };
+  }
+
+  const codexHome = resolveCodexHome(dependencies);
+  const configPath = join(codexHome, "config.toml");
+  const config = await readToml(configPath, dependencies);
+  if (config.status !== "success") {
+    return {
+      status: config.status,
+      source: CODEX_SOURCE,
+      path: configPath,
+      error: config.error,
+    };
+  }
+  if (stringValue(config.value.model_provider) !== "sub2api") {
+    return {
+      status: "missing",
+      source: CODEX_SOURCE,
+      path: configPath,
+      error: "sub2api_not_active_codex_provider",
+    };
+  }
+  const providerTable = objectValue(
+    objectValue(config.value.model_providers)?.sub2api,
+  );
+  const baseUrl = usableBaseUrl(stringValue(providerTable?.base_url));
+  if (!baseUrl) {
+    return {
+      status: "invalid",
+      source: CODEX_SOURCE,
+      path: configPath,
+      error: "sub2api_base_url_invalid",
+    };
+  }
+
+  const authPath = join(codexHome, "auth.json");
+  const auth = await readJson(authPath, dependencies);
+  if (auth.status !== "success") {
+    return {
+      status: auth.status,
+      source: CODEX_SOURCE,
+      path: authPath,
+      error: auth.error,
+    };
+  }
+  const apiKey = usableApiKey(auth.value.OPENAI_API_KEY);
+  if (!apiKey) {
+    return {
+      status: "invalid",
+      source: CODEX_SOURCE,
+      path: authPath,
+      error: "sub2api_api_key_invalid",
+    };
+  }
+  return {
+    status: "available",
+    credential: {
+      baseUrl,
+      apiKey,
+      source: CODEX_SOURCE,
+      path: configPath,
+    },
+  };
+}
+
+async function requestUsage(
+  credential: Sub2apiCredential,
+  dependencies: Sub2apiDependencies,
+): Promise<NormalizedSub2apiUsage> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), dependencies.timeoutMs);
+  try {
+    const response = await dependencies.fetch(usageUrl(credential.baseUrl), {
+      method: "GET",
+      headers: {
+        authorization: `Bearer ${credential.apiKey}`,
+        accept: "application/json",
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    if (response.status === 401 || response.status === 403) {
+      await cancelResponseBody(response);
+      throw new Sub2apiFailure(
+        "sub2api_credentials_rejected",
+        "sub2API sign-in required",
+        "auth_required",
+      );
+    }
+    if (response.status === 429) {
+      await cancelResponseBody(response);
+      throw new Sub2apiFailure(
+        "sub2api_rate_limited",
+        "sub2API quota endpoint rate limited",
+        "rate_limited",
+        retryAfterToIso(response.headers.get("retry-after")),
+      );
+    }
+    if (!response.ok) {
+      await cancelResponseBody(response);
+      throw new Sub2apiFailure(
+        "sub2api_endpoint_failed",
+        "sub2API quota endpoint failed",
+        "error",
+      );
+    }
+    const usage = normalizeSub2apiUsage(await readJsonBody(response));
+    if (!usage) {
+      throw new Sub2apiFailure(
+        "sub2api_usage_invalid",
+        "sub2API quota response is invalid",
+        "error",
+      );
+    }
+    return usage;
+  } catch (error) {
+    if (error instanceof Sub2apiFailure) throw error;
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Sub2apiFailure(
+        "sub2api_request_timeout",
+        "sub2API quota request timed out",
+        "error",
+      );
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function cancelResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    return;
+  }
+}
+
+function usageUrl(baseUrl: URL): URL {
+  const url = new URL(baseUrl);
+  const basePath = url.pathname.replace(/\/+$/, "");
+  url.pathname = basePath.endsWith("/v1")
+    ? `${basePath}/usage`
+    : `${basePath}/v1/usage`;
+  return url;
+}
+
+function usableBaseUrl(value: string | undefined): URL | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.username || url.password || url.search || url.hash)
+      return undefined;
+    const isLoopback = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+    if (
+      url.protocol !== "https:" &&
+      !(url.protocol === "http:" && isLoopback)
+    ) {
+      return undefined;
+    }
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const declaredLength = response.headers.get("content-length")?.trim();
+  if (/^\d+$/.test(declaredLength ?? "")) {
+    if (BigInt(declaredLength!) > BigInt(RESPONSE_LIMIT_BYTES)) {
+      await response.body?.cancel();
+      throw new Sub2apiFailure(
+        "sub2api_response_too_large",
+        "sub2API quota response is too large",
+        "error",
+      );
+    }
+  }
+  if (!response.body) return undefined;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.byteLength;
+      if (length > RESPONSE_LIMIT_BYTES) {
+        await reader.cancel();
+        throw new Sub2apiFailure(
+          "sub2api_response_too_large",
+          "sub2API quota response is too large",
+          "error",
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const body = Buffer.concat(chunks, length).toString("utf8");
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new Sub2apiFailure(
+      "sub2api_response_invalid_json",
+      "sub2API quota response is invalid JSON",
+      "error",
+    );
+  }
+}
+
+async function readToml(
+  path: string,
+  dependencies: Sub2apiDependencies,
+): Promise<
+  | { status: "success"; value: Record<string, unknown> }
+  | { status: "missing" | "invalid" | "error"; error: string }
+> {
+  const contents = await readConfigFile(path, dependencies);
+  if (contents.status !== "success") return contents;
+  try {
+    return {
+      status: "success",
+      value: parse(contents.value) as Record<string, unknown>,
+    };
+  } catch {
+    return { status: "invalid", error: "codex_config_invalid_toml" };
+  }
+}
+
+async function readJson(
+  path: string,
+  dependencies: Sub2apiDependencies,
+): Promise<
+  | { status: "success"; value: Record<string, unknown> }
+  | { status: "missing" | "invalid" | "error"; error: string }
+> {
+  const contents = await readConfigFile(path, dependencies);
+  if (contents.status !== "success") return contents;
+  try {
+    const parsed = objectValue(JSON.parse(contents.value) as unknown);
+    return parsed
+      ? { status: "success", value: parsed }
+      : { status: "invalid", error: "codex_auth_invalid_json" };
+  } catch {
+    return { status: "invalid", error: "codex_auth_invalid_json" };
+  }
+}
+
+async function readConfigFile(
+  path: string,
+  dependencies: Sub2apiDependencies,
+): Promise<
+  | { status: "success"; value: string }
+  | { status: "missing" | "invalid" | "error"; error: string }
+> {
+  try {
+    const contents = await dependencies.readFile(path, CONFIG_LIMIT_BYTES);
+    if (contents.byteLength > CONFIG_LIMIT_BYTES) {
+      return { status: "invalid", error: "codex_config_too_large" };
+    }
+    return { status: "success", value: contents.toString("utf8") };
+  } catch (error) {
+    return errorCode(error) === "ENOENT"
+      ? { status: "missing", error: "codex_config_missing" }
+      : { status: "error", error: "codex_config_read_failed" };
+  }
+}
+
+async function readBoundedFile(
+  path: string,
+  maxBytes: number,
+): Promise<Buffer> {
+  const file = await open(path, "r");
+  try {
+    const buffer = new Uint8Array(maxBytes + 1);
+    let offset = 0;
+    while (offset < buffer.byteLength) {
+      const { bytesRead } = await file.read(
+        buffer,
+        offset,
+        buffer.byteLength - offset,
+        null,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    return Buffer.from(buffer.buffer, buffer.byteOffset, offset);
+  } finally {
+    await file.close();
+  }
+}
+
+function resolveCodexHome(dependencies: Sub2apiDependencies): string {
+  const configured = nonempty(dependencies.environment.CODEX_HOME);
+  if (!configured) return join(dependencies.homeDirectory(), ".codex");
+  if (configured === "~") return dependencies.homeDirectory();
+  if (configured.startsWith("~/")) {
+    return join(dependencies.homeDirectory(), configured.slice(2));
+  }
+  return configured;
+}
+
+function usableApiKey(value: unknown): string | undefined {
+  if (typeof value !== "string" || value.trim().length === 0) return undefined;
+  if (
+    [...value].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x1f || code === 0x7f;
+    })
+  ) {
+    return undefined;
+  }
+  return value;
+}
+
+function nonempty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && value.trim().length > 0
+        ? Number(value)
+        : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (value === 1) return true;
+  if (value === 0) return false;
+  return undefined;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error !== null &&
+    typeof error === "object" &&
+    "code" in error &&
+    typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+class Sub2apiFailure extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly status: ProviderStatus,
+    readonly retryAfter?: string,
+  ) {
+    super(message);
+  }
+}

--- a/src/render.ts
+++ b/src/render.ts
@@ -36,6 +36,15 @@ export function renderQuotaToon(
       state: provider.state.status,
     })),
   );
+  const credits = response.providers
+    .filter((provider) => provider.credits)
+    .map((provider) => ({
+      provider: provider.provider,
+      remaining: provider.credits?.remaining ?? "unknown",
+      unlimited: provider.credits?.unlimited ?? "unknown",
+      unit: provider.credits?.unit ?? "unknown",
+      state: provider.state.status,
+    }));
   const effective = response.providers.flatMap((provider) => {
     const semantics = provider.quotaSemantics;
     if (!semantics || semantics.effectiveAvailability.length === 0) {
@@ -91,6 +100,7 @@ export function renderQuotaToon(
       generatedAt: response.generatedAt,
     }),
     encode({ providers }),
+    ...(credits.length > 0 ? [encode({ credits })] : []),
     encode({ windows }),
     encode({ effective }),
   ];

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,8 +3,8 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
-  "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining " +
-  "effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, " +
+  "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows plus sub2API balance via the quota-axi CLI - remaining " +
+  "effective usable runway, percentages or balance, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, " +
   "with no routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or " +
   "remaining quota, or when comparing local provider headroom.";
@@ -24,6 +24,7 @@ export const HERMES_TAGS = [
   "copilot",
   "grok",
   "kimi",
+  "sub2api",
   "cli",
 ];
 export const HERMES_CATEGORY = "observability";
@@ -60,7 +61,7 @@ You do not need quota-axi installed globally - invoke it with \`npx -y quota-axi
 
 quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
 browser cookies, or mutates provider state. It reads local provider auth sources and calls
-first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
+first-party provider quota endpoints or the explicitly configured sub2API usage endpoint; it never launches the
 Claude, Grok, Pi, or Kimi CLIs, so it cannot spend the quota it measures.
 
 ## When to use
@@ -72,7 +73,7 @@ or when comparing supported local provider headroom side by side.
 ## Workflow
 
 1. Run \`npx -y quota-axi\` for compact TOON output covering supported providers' quota windows.
-2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok,kimi\`.
+2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok,kimi,sub2api\`.
 3. Pass \`--json\` for the normalized machine-readable model instead of TOON. Read
    \`quotaSemantics.effectiveAvailability\` rather than treating a model window in isolation:
    account windows can bound every model, and \`boundedBy\` names every window included in the
@@ -117,6 +118,10 @@ or when comparing supported local provider headroom side by side.
    Grok also reads that same Pi auth file for an independent \`xai\` OAuth or literal API-key
    entry and treats Grok as usable when either the Grok CLI session or Pi \`xai\` credential is
    valid.
+10. For sub2API, quota-axi prefers \`SUB2API_BASE_URL\` and \`SUB2API_API_KEY\`, then falls back
+    to an active Codex \`model_provider = "sub2api"\` and its \`OPENAI_API_KEY\`. It sends one
+    redirect-disabled \`GET /v1/usage\` to that configured origin and reports the returned
+    monetary or credit balance without inventing percentage windows or reset times.
 
 ## Usage
 
@@ -132,6 +137,8 @@ ${TOP_HELP.trimEnd()}
   every provider failed; exit code 2 means a usage error.
 - Percentages are not comparable across providers - quota-axi never claims one provider's
   percentage equals another's.
+- A sub2API balance is an amount, not a percentage, and has no effective availability or pace
+  unless that endpoint later supplies authoritative total-limit and cycle data.
 - Claude \`--full\` output exposes the authoritative OAuth profile \`account.uuid\` as
   \`account.accountId\` when Anthropic returns one; otherwise the account identity is explicitly
   marked unverified rather than inferred.

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ export type ProviderId =
   | "cursor"
   | "copilot"
   | "grok"
-  | "kimi";
+  | "kimi"
+  | "sub2api";
 
 export const PROVIDER_IDS = [
   "claude",
@@ -13,6 +14,7 @@ export const PROVIDER_IDS = [
   "copilot",
   "grok",
   "kimi",
+  "sub2api",
 ] as const satisfies readonly ProviderId[];
 
 export type ProviderSource =

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -18,6 +18,7 @@ const originalCursorProvider = PROVIDERS.cursor;
 const originalCopilotProvider = PROVIDERS.copilot;
 const originalGrokProvider = PROVIDERS.grok;
 const originalKimiProvider = PROVIDERS.kimi;
+const originalSub2apiProvider = PROVIDERS.sub2api;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
@@ -28,6 +29,7 @@ afterEach(() => {
   PROVIDERS.copilot = originalCopilotProvider;
   PROVIDERS.grok = originalGrokProvider;
   PROVIDERS.kimi = originalKimiProvider;
+  PROVIDERS.sub2api = originalSub2apiProvider;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -45,6 +47,7 @@ describe("CLI flag parsing", () => {
       "copilot",
       "grok",
       "kimi",
+      "sub2api",
     ]);
   });
 
@@ -65,7 +68,15 @@ describe("CLI flag parsing", () => {
   it("collects the boolean flags", () => {
     expect(parseFlags(["--json", "--full", "--allow-keychain-prompt"])).toEqual(
       {
-        providers: ["claude", "codex", "cursor", "copilot", "grok", "kimi"],
+        providers: [
+          "claude",
+          "codex",
+          "cursor",
+          "copilot",
+          "grok",
+          "kimi",
+          "sub2api",
+        ],
         json: true,
         full: true,
         allowKeychainPrompt: true,
@@ -564,6 +575,42 @@ describe("CLI quota rendering", () => {
       /recommend|prefer provider|switch to|route to/i,
     );
   });
+
+  it("renders sub2API monetary balance without inventing a percentage", async () => {
+    useTempCache();
+    PROVIDERS.sub2api = providerWithQuota({
+      provider: "sub2api",
+      label: "sub2API",
+      source: "api",
+      windows: [],
+      credits: { remaining: 27.5, unit: "usd" },
+      state: {
+        status: "fresh",
+        stale: false,
+        refreshedAt: "2026-07-30T00:00:00.000Z",
+        sourcesTried: ["codex-config"],
+      },
+    });
+
+    const toon = await capture(["--provider", "sub2api"]);
+    expect(toon).toContain(
+      "credits[1]{provider,remaining,unlimited,unit,state}:\n  sub2api,27.5,unknown,usd,fresh",
+    );
+    expect(toon).not.toContain("sub2api,credits,credits,27.5");
+
+    const json = JSON.parse(
+      await capture(["--provider", "sub2api", "--json"]),
+    ) as QuotaAxiResponse;
+    expect(json.providers[0]).toMatchObject({
+      provider: "sub2api",
+      credits: { remaining: 27.5, unit: "usd" },
+      windows: [],
+      quotaSemantics: {
+        status: "unknown",
+        effectiveAvailability: [],
+      },
+    });
+  });
 });
 
 describe("CLI plumbing via the axi SDK", () => {
@@ -594,6 +641,7 @@ describe("CLI plumbing via the axi SDK", () => {
     PROVIDERS.copilot = providerWithAuth("copilot", "GitHub Copilot");
     PROVIDERS.grok = providerWithAuth("grok", "Grok");
     PROVIDERS.kimi = providerWithAuth("kimi", "Kimi");
+    PROVIDERS.sub2api = providerWithAuth("sub2api", "sub2API");
 
     const output = await capture(["--allow-keychain-prompt", "auth"]);
     expect(output).toContain(

--- a/test/providers/sub2api.test.ts
+++ b/test/providers/sub2api.test.ts
@@ -1,0 +1,295 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSub2apiAdapter,
+  normalizeSub2apiUsage,
+} from "../../src/providers/sub2api.js";
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+describe("sub2API usage parsing", () => {
+  it("supports remaining, nested quota remaining, and balance payloads", () => {
+    expect(normalizeSub2apiUsage({ remaining: 12.5, unit: "USD" })).toEqual({
+      isValid: true,
+      remaining: 12.5,
+      unit: "usd",
+    });
+    expect(
+      normalizeSub2apiUsage({
+        quota: { remaining: "8.25", unit: "credits" },
+        is_active: 1,
+      }),
+    ).toEqual({ isValid: true, remaining: 8.25, unit: "credits" });
+    expect(normalizeSub2apiUsage({ balance: 3, isValid: false })).toEqual({
+      isValid: false,
+      remaining: 3,
+      unit: "usd",
+    });
+  });
+
+  it("rejects payloads without a finite balance", () => {
+    expect(normalizeSub2apiUsage({})).toBeUndefined();
+    expect(
+      normalizeSub2apiUsage({ remaining: "not-a-number" }),
+    ).toBeUndefined();
+    expect(
+      normalizeSub2apiUsage({ remaining: Number.POSITIVE_INFINITY }),
+    ).toBeUndefined();
+  });
+});
+
+describe("sub2API provider", () => {
+  it("uses explicit environment configuration and reports a USD balance", async () => {
+    const fetchMock = vi.fn(async (url: URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("https://sub2.example.test/v1/usage");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer fixture-key",
+      );
+      expect(init?.redirect).toBe("manual");
+      return Response.json({ remaining: 42, unit: "USD" });
+    });
+    const adapter = createSub2apiAdapter({
+      environment: {
+        SUB2API_BASE_URL: "https://sub2.example.test",
+        SUB2API_API_KEY: "fixture-key",
+      },
+      fetch: fetchMock as typeof fetch,
+      now: () => Date.parse("2026-07-30T00:00:00Z"),
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result).toMatchObject({
+      provider: "sub2api",
+      label: "sub2API",
+      source: "api",
+      windows: [],
+      credits: { remaining: 42, unit: "usd" },
+      state: {
+        status: "fresh",
+        stale: false,
+        refreshedAt: "2026-07-30T00:00:00.000Z",
+        sourcesTried: ["sub2api-env"],
+      },
+      attempts: [{ source: "sub2api-env", status: "success" }],
+    });
+  });
+
+  it("discovers the active sub2api provider and API key from Codex files", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "quota-axi-sub2api-"));
+    writeFileSync(
+      join(tempDir, "config.toml"),
+      [
+        'model_provider = "sub2api"',
+        "",
+        "[model_providers.sub2api]",
+        'base_url = "https://sub2.example.test/v1"',
+        'wire_api = "responses"',
+        "requires_openai_auth = true",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(tempDir, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: "codex-fixture-key" }),
+    );
+    const fetchMock = vi.fn(async (url: URL, init?: RequestInit) => {
+      expect(url.toString()).toBe("https://sub2.example.test/v1/usage");
+      expect(new Headers(init?.headers).get("authorization")).toBe(
+        "Bearer codex-fixture-key",
+      );
+      return Response.json({ quota: { remaining: 9, unit: "USD" } });
+    });
+    const adapter = createSub2apiAdapter({
+      environment: { CODEX_HOME: tempDir },
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const auth = await adapter.inspectAuth({ allowKeychainPrompt: false });
+    const quota = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(auth).toEqual({
+      provider: "sub2api",
+      sources: [
+        {
+          source: "codex-config",
+          path: join(tempDir, "config.toml"),
+          status: "available",
+          credentialPresent: true,
+        },
+      ],
+    });
+    expect(quota.credits).toEqual({ remaining: 9, unit: "usd" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed on partial environment configuration", async () => {
+    const fetchMock = vi.fn();
+    const adapter = createSub2apiAdapter({
+      environment: { SUB2API_BASE_URL: "https://sub2.example.test" },
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state).toMatchObject({
+      status: "auth_required",
+      sourcesTried: ["sub2api-env"],
+    });
+    expect(result.attempts).toEqual([
+      {
+        source: "sub2api-env",
+        status: "skipped",
+        error: "sub2api_environment_incomplete",
+      },
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects insecure non-loopback base URLs before sending credentials", async () => {
+    const fetchMock = vi.fn();
+    const adapter = createSub2apiAdapter({
+      environment: {
+        SUB2API_BASE_URL: "http://sub2.example.test",
+        SUB2API_API_KEY: "fixture-key",
+      },
+      fetch: fetchMock as typeof fetch,
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.attempts?.[0]?.error).toBe("sub2api_base_url_invalid");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats inactive accounts and rejected credentials as auth failures", async () => {
+    const inactive = createSub2apiAdapter({
+      environment: fixtureEnvironment(),
+      fetch: (async () =>
+        Response.json({ balance: 1, is_active: false })) as typeof fetch,
+    });
+    const rejected = createSub2apiAdapter({
+      environment: fixtureEnvironment(),
+      fetch: (async () => new Response("{}", { status: 401 })) as typeof fetch,
+    });
+
+    const inactiveResult = await inactive.fetchQuota({
+      allowKeychainPrompt: false,
+    });
+    const rejectedResult = await rejected.fetchQuota({
+      allowKeychainPrompt: false,
+    });
+
+    expect(inactiveResult.state.status).toBe("auth_required");
+    expect(inactiveResult.attempts?.[0]?.error).toBe(
+      "sub2api_account_inactive",
+    );
+    expect(rejectedResult.state.status).toBe("auth_required");
+    expect(rejectedResult.attempts?.[0]?.error).toBe(
+      "sub2api_credentials_rejected",
+    );
+  });
+
+  it("does not follow redirects that could receive the bearer token", async () => {
+    const cancel = vi.fn();
+    const adapter = createSub2apiAdapter({
+      environment: fixtureEnvironment(),
+      fetch: (async (_url: URL, init?: RequestInit) => {
+        expect(init?.redirect).toBe("manual");
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("redirect"));
+            },
+            cancel,
+          }),
+          {
+            status: 302,
+            headers: { location: "https://other.example.test/v1/usage" },
+          },
+        );
+      }) as typeof fetch,
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("error");
+    expect(result.attempts?.[0]?.error).toBe("sub2api_endpoint_failed");
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+
+  it("rejects oversized response bodies", async () => {
+    const adapter = createSub2apiAdapter({
+      environment: fixtureEnvironment(),
+      fetch: (async () =>
+        new Response("x", {
+          status: 200,
+          headers: { "content-length": "65537" },
+        })) as typeof fetch,
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("error");
+    expect(result.attempts?.[0]?.error).toBe("sub2api_response_too_large");
+  });
+
+  it("reports missing Codex configuration without reading arbitrary auth", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "quota-axi-sub2api-"));
+    mkdirSync(tempDir, { recursive: true });
+    const adapter = createSub2apiAdapter({
+      environment: { CODEX_HOME: tempDir },
+      fetch: vi.fn() as typeof fetch,
+    });
+
+    const auth = await adapter.inspectAuth({ allowKeychainPrompt: false });
+
+    expect(auth).toEqual({
+      provider: "sub2api",
+      sources: [
+        {
+          source: "codex-config",
+          path: join(tempDir, "config.toml"),
+          status: "missing",
+          error: "codex_config_missing",
+        },
+      ],
+    });
+  });
+
+  it("reports configuration read failures as errors rather than sign-in state", async () => {
+    const adapter = createSub2apiAdapter({
+      environment: {},
+      readFile: async () => {
+        throw new Error("fixture read failure");
+      },
+      fetch: vi.fn() as typeof fetch,
+    });
+
+    const result = await adapter.fetchQuota({ allowKeychainPrompt: false });
+
+    expect(result.state.status).toBe("error");
+    expect(result.attempts).toEqual([
+      {
+        source: "codex-config",
+        status: "failed",
+        error: "codex_config_read_failed",
+      },
+    ]);
+  });
+});
+
+function fixtureEnvironment(): Record<string, string> {
+  return {
+    SUB2API_BASE_URL: "https://sub2.example.test",
+    SUB2API_API_KEY: "fixture-key",
+  };
+}


### PR DESCRIPTION
## Intent

Add safe sub2API balance reporting to quota-axi by reading the active Codex sub2api configuration or explicit environment variables, querying GET /v1/usage without exposing credentials, and reporting balances without inventing percentage quota windows. Preserve quota-axi as a read-only reporting tool: do not route traffic, mutate provider state, follow redirects, leak secrets, or send a sub2API key to OpenAI endpoints. Include focused tests and user-facing documentation, then deliver the change as a pull request to the upstream kunchenguid/quota-axi repository through the configured lawlielt fork.

## What Changed

- Add a new read-only `sub2api` provider (`src/providers/sub2api.ts`) that resolves credentials from explicit `SUB2API_BASE_URL`/`SUB2API_API_KEY` or an active Codex `sub2api` provider plus `OPENAI_API_KEY`, then performs a single redirect-disabled, size- and time-bounded `GET /v1/usage` on the configured origin and reports a top-level `credits` balance without inventing percentage windows, resets, or pace.
- Wire the provider into the registry, `ProviderId` types, `--provider` parsing/help, and unknown-effective-availability semantics, and extend TOON rendering to emit a `credits` block when a provider reports a balance.
- Document the provider across README (sources, provider windows, auth names, security posture), `AGENTS.md`, and the generated `SKILL.md`/`src/skill.ts`, and add focused adapter and CLI tests (`test/providers/sub2api.test.ts`, `test/cli.test.ts`).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
