### PR TITLE
chore(ci): skip pull_request runs for release-please output-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # release-please opens its release PR with GITHUB_TOKEN, which creates a
+    # pull_request run that can only sit in action_required. Its output set is
+    # exactly these files, so excluding them means no run is ever created.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 jobs:
   build-and-test:

--- a/.github/workflows/guard-generated-files.yml
+++ b/.github/workflows/guard-generated-files.yml
@@ -5,6 +5,13 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -6,6 +6,13 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches:
       - main
+    # Never create a run for a release-please PR. The job-level author exemption
+    # below cannot do this: it is evaluated inside a run, and a GITHUB_TOKEN PR's
+    # run is created in action_required and never starts.
+    paths-ignore:
+      - .release-please-manifest.json
+      - CHANGELOG.md
+      - package.json
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Releases are cut by release-please from conventional commit messages on `main`; 
 `.release-please-manifest.json` is primed at `0.1.0`, the version already published to npm by hand before release-please was wired up; release-please owns every version after that.
 `release-please-config.json` intentionally sets `bootstrap-sha` to `9f5dc949c50ab8ac0a441be777e1c3693ee0b612`, the commit that produced the already-published npm `0.1.0`; do not retarget it to later scaffolding commits unless the published baseline itself is being corrected.
 Do not hand-edit `CHANGELOG.md` or `.release-please-manifest.json` (a guard workflow blocks PRs that touch them), and regenerate `skills/quota-axi/SKILL.md` with `pnpm run build:skill` instead of editing it directly (`pnpm run build:skill -- --check` in CI fails if it drifts from `src/skill.ts`).
+Every `pull_request` workflow must `paths-ignore` the release-please output set (`.release-please-manifest.json`, `CHANGELOG.md`, `package.json`) so release PRs create zero runs; `test/release-ci-exclusions.test.ts` derives that set from `release-please-config.json` and fails if a workflow drifts.
 
 ## Lockfile formatting
 

--- a/package.json
+++ b/package.json
@@ -56,9 +56,11 @@
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "22.0.0",
     "eslint": "10.1.0",
     "globals": "17.7.0",
+    "js-yaml": "^4.1.1",
     "prettier": "3.8.1",
     "tsx": "4.23.1",
     "typescript": "6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       "@eslint/js":
         specifier: 10.0.1
         version: 10.0.1(eslint@10.1.0)
+      "@types/js-yaml":
+        specifier: ^4.0.9
+        version: 4.0.9
       "@types/node":
         specifier: 22.0.0
         version: 22.0.0
@@ -26,6 +29,9 @@ importers:
       globals:
         specifier: 17.7.0
         version: 17.7.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       prettier:
         specifier: 3.8.1
         version: 3.8.1
@@ -846,6 +852,12 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
+  "@types/js-yaml@4.0.9":
+    resolution:
+      {
+        integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==,
+      }
+
   "@types/json-schema@7.0.15":
     resolution:
       {
@@ -1023,6 +1035,12 @@ packages:
     resolution:
       {
         integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==,
+      }
+
+  argparse@2.0.1:
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
       }
 
   assertion-error@2.0.1:
@@ -1336,6 +1354,13 @@ packages:
       {
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
+
+  js-yaml@4.1.1:
+    resolution:
+      {
+        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+      }
+    hasBin: true
 
   json-buffer@3.0.1:
     resolution:
@@ -2052,6 +2077,8 @@ snapshots:
 
   "@types/estree@1.0.9": {}
 
+  "@types/js-yaml@4.0.9": {}
+
   "@types/json-schema@7.0.15": {}
 
   "@types/node@22.0.0":
@@ -2205,6 +2232,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -2424,6 +2453,10 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   json-buffer@3.0.1: {}
 

--- a/test/release-ci-exclusions.test.ts
+++ b/test/release-ci-exclusions.test.ts
@@ -1,0 +1,215 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { load as loadYaml } from "js-yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowsDir = join(root, ".github", "workflows");
+
+/**
+ * Derive the exact release-please output set from config + workflow inputs.
+ * Keep this aligned with the fleet audit rule: node -> package.json
+ * (+ package-lock.json if present), changelog, extra-files, and the manifest.
+ */
+function expectedReleaseOutputs(): string[] {
+  const config = JSON.parse(
+    readFileSync(join(root, "release-please-config.json"), "utf8"),
+  ) as {
+    "release-type"?: string;
+    "changelog-path"?: string;
+    "version-file"?: string;
+    "extra-files"?: Array<string | { path?: string }>;
+    packages?: Record<
+      string,
+      {
+        "release-type"?: string;
+        "changelog-path"?: string;
+        "version-file"?: string;
+        "extra-files"?: Array<string | { path?: string }>;
+      }
+    >;
+  };
+
+  const pkg = config.packages?.["."] ?? {};
+  const releaseType = pkg["release-type"] ?? config["release-type"] ?? "node";
+  const changelog =
+    pkg["changelog-path"] ?? config["changelog-path"] ?? "CHANGELOG.md";
+
+  const expected = [changelog];
+  switch (releaseType) {
+    case "simple":
+      expected.push(
+        pkg["version-file"] ?? config["version-file"] ?? "version.txt",
+      );
+      break;
+    case "node":
+      expected.push("package.json");
+      if (existsSync(join(root, "package-lock.json"))) {
+        expected.push("package-lock.json");
+      }
+      break;
+    case "go":
+      break;
+    default:
+      throw new Error(
+        `unsupported release-please release-type for ignore derivation: ${releaseType}`,
+      );
+  }
+
+  const extra = pkg["extra-files"] ?? config["extra-files"] ?? [];
+  for (const entry of extra) {
+    const path = typeof entry === "string" ? entry : entry?.path;
+    if (path) expected.push(path);
+  }
+
+  let manifest = ".release-please-manifest.json";
+  const releaseWorkflow = readFileSync(
+    join(workflowsDir, "release-please.yml"),
+    "utf8",
+  );
+  const manifestMatch = releaseWorkflow.match(/manifest-file:\s*(\S+)/);
+  if (manifestMatch) manifest = manifestMatch[1];
+  expected.push(manifest);
+
+  return [...new Set(expected)];
+}
+
+function loadWorkflowOn(filePath: string): Record<string, unknown> | null {
+  const doc = loadYaml(readFileSync(filePath, "utf8")) as
+    | Record<string | boolean, unknown>
+    | null
+    | undefined;
+  // js-yaml may parse a bare `on:` key as boolean true.
+  const on = doc?.on ?? doc?.true ?? null;
+  if (on == null || typeof on !== "object" || Array.isArray(on)) return null;
+  return on as Record<string, unknown>;
+}
+
+type PathFilter =
+  | { kind: "unfiltered" }
+  | { kind: "paths-ignore"; paths: string[] }
+  | { kind: "paths"; paths: string[] };
+
+function pullRequestFilterCoverage(pr: unknown): PathFilter {
+  if (pr == null) {
+    return { kind: "unfiltered" };
+  }
+  if (typeof pr !== "object" || Array.isArray(pr)) {
+    // `pull_request:` bare form means no path filter.
+    return { kind: "unfiltered" };
+  }
+
+  const record = pr as Record<string, unknown>;
+  if (Array.isArray(record["paths-ignore"])) {
+    return {
+      kind: "paths-ignore",
+      paths: record["paths-ignore"].map(String),
+    };
+  }
+
+  if (Array.isArray(record.paths)) {
+    return { kind: "paths", paths: record.paths.map(String) };
+  }
+
+  return { kind: "unfiltered" };
+}
+
+function globMatch(pattern: string, path: string): boolean {
+  // Minimal support for the `**` / `*` patterns used in workflow path filters.
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "::DOUBLE::")
+    .replace(/\*/g, "[^/]*")
+    .replace(/::DOUBLE::/g, ".*");
+  return new RegExp(`^${escaped}$`).test(path);
+}
+
+function isCovered(filter: PathFilter, releasePath: string): boolean {
+  if (filter.kind === "unfiltered") return false;
+
+  if (filter.kind === "paths-ignore") {
+    return filter.paths.includes(releasePath);
+  }
+
+  // paths allow-list: a release path is "covered" (will not create a run on its
+  // own) when no positive pattern matches it, or a later negation excludes it.
+  let matched = false;
+  for (const pattern of filter.paths) {
+    if (pattern.startsWith("!")) {
+      const negated = pattern.slice(1);
+      if (
+        matched &&
+        (negated === releasePath || globMatch(negated, releasePath))
+      ) {
+        matched = false;
+      }
+      continue;
+    }
+    if (pattern === releasePath || globMatch(pattern, releasePath)) {
+      matched = true;
+    }
+  }
+  // Covered means the path does NOT cause the workflow to run.
+  return !matched;
+}
+
+describe("release-please CI exclusions", () => {
+  const expected = expectedReleaseOutputs();
+
+  it("derives the node release-output set for this repository", () => {
+    expect(expected).toEqual([
+      "CHANGELOG.md",
+      "package.json",
+      ".release-please-manifest.json",
+    ]);
+  });
+
+  it("every pull_request workflow ignores the full release-output set", () => {
+    const files = readdirSync(workflowsDir).filter((name) =>
+      name.endsWith(".yml"),
+    );
+    const prWorkflows: Array<{ name: string; filter: PathFilter }> = [];
+
+    for (const name of files) {
+      const filePath = join(workflowsDir, name);
+      const on = loadWorkflowOn(filePath);
+      if (!on || !("pull_request" in on)) continue;
+      prWorkflows.push({
+        name,
+        filter: pullRequestFilterCoverage(on.pull_request),
+      });
+    }
+
+    expect(prWorkflows.map((w) => w.name).sort()).toEqual([
+      "ci.yml",
+      "guard-generated-files.yml",
+      "no-mistakes-required.yml",
+    ]);
+
+    const failures: string[] = [];
+    for (const { name, filter } of prWorkflows) {
+      const missing = expected.filter((path) => !isCovered(filter, path));
+      if (missing.length > 0) {
+        failures.push(`${name} missing coverage for: ${missing.join(", ")}`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+
+  it("does not attach path filters to non-pull_request triggers on ci.yml", () => {
+    const on = loadWorkflowOn(join(workflowsDir, "ci.yml"));
+    expect(on).not.toBeNull();
+    expect(on!.push).toEqual({ branches: ["main"] });
+    const pr = on!.pull_request as Record<string, unknown>;
+    expect(pr.branches).toEqual(["main"]);
+    expect(pr["paths-ignore"]).toEqual([
+      ".release-please-manifest.json",
+      "CHANGELOG.md",
+      "package.json",
+    ]);
+    expect(on!.release).toBeUndefined();
+    expect(on!.workflow_dispatch).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Release-please opens its release PR with `GITHUB_TOKEN`, which since 2026-07-01 creates `pull_request` workflow runs that sit in `action_required` forever. Job-level bot author `if` conditions cannot prevent run creation.

This PR adds `paths-ignore` for the exact release-please output set (`.release-please-manifest.json`, `CHANGELOG.md`, `package.json`) to every `pull_request`-triggered workflow:

- `.github/workflows/ci.yml`
- `.github/workflows/guard-generated-files.yml`
- `.github/workflows/no-mistakes-required.yml`

Existing job-level bot exemptions stay as defense in depth. `push`/`tag`/`release` triggers are unchanged.

Drift protection: `test/release-ci-exclusions.test.ts` derives the expected output set from `release-please-config.json` and asserts every PR workflow excludes it.

## Validation

- YAML parse of all four workflows (path filters only under `pull_request`)
- Focused drift test + full `pnpm test` (325 passed)
- Offline file-list simulation:
  - release PR #52 / #48 (manifest + CHANGELOG + package.json only) → would create **zero** runs
  - human PRs #51 / #49 / #47 → still create runs

## Notes for merge

Direct-PR delivery per captain override for the release-please CI fleet rollout. A failing `Require no-mistakes` check is expected on this PR and is non-blocking (no required status checks on this repo). Do not treat that red check as a defect of this change.