### PR TITLE
feat(models): add intelligence-aware quota evidence

### DIFF
--- a/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-high.json
+++ b/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-high.json
@@ -1,0 +1,94 @@
+{
+  "generatedAt": "2026-08-05T21:25:54.463Z",
+  "schemaVersion": 1,
+  "catalog": {
+    "version": "2026-08-05",
+    "provenance": "Curated editorial intelligence buckets informed by public provider materials and leaderboards, including Artificial Analysis (https://artificialanalysis.ai/). No third-party scores are reproduced."
+  },
+  "models": [
+    {
+      "provider": "codex",
+      "id": "gpt-5.1-codex",
+      "label": "GPT-5.1-Codex",
+      "intelligence": "high",
+      "quotaScopes": [
+        "all_models"
+      ],
+      "effective": {
+        "scope": "all_models",
+        "status": "known",
+        "effectivePercentRemaining": 18,
+        "boundedBy": [
+          "weekly"
+        ],
+        "limitingWindowIds": [
+          "weekly"
+        ],
+        "pace": {
+          "status": "ahead",
+          "aheadWindowIds": [
+            "weekly"
+          ],
+          "worstReservePercentPoints": -14.2395,
+          "worstReserveWindowId": "weekly"
+        },
+        "runway": {
+          "status": "projected_exhaustion",
+          "usableRunwaySeconds": 89959,
+          "projectedExhaustedAt": "2026-08-06T22:25:13.954Z",
+          "limitingWindowId": "weekly",
+          "projectionConfidence": "established",
+          "projectionBasis": "cycle_average"
+        }
+      },
+      "state": {
+        "status": "fresh",
+        "stale": false
+      }
+    },
+    {
+      "provider": "codex",
+      "id": "gpt-5.3-codex",
+      "label": "GPT-5.3-Codex",
+      "intelligence": "high",
+      "quotaScopes": [
+        "model:codex_bengalfox"
+      ],
+      "effective": {
+        "scope": "model:codex_bengalfox",
+        "status": "known",
+        "effectivePercentRemaining": 18,
+        "boundedBy": [
+          "weekly",
+          "model:codex_bengalfox:7d"
+        ],
+        "limitingWindowIds": [
+          "weekly"
+        ],
+        "pace": {
+          "status": "ahead",
+          "aheadWindowIds": [
+            "weekly"
+          ],
+          "onPaceWindowIds": [
+            "model:codex_bengalfox:7d"
+          ],
+          "worstReservePercentPoints": -14.2395,
+          "worstReserveWindowId": "weekly"
+        },
+        "runway": {
+          "status": "projected_exhaustion",
+          "usableRunwaySeconds": 89959,
+          "projectedExhaustedAt": "2026-08-06T22:25:13.954Z",
+          "limitingWindowId": "weekly",
+          "projectionConfidence": "established",
+          "projectionBasis": "cycle_average"
+        }
+      },
+      "state": {
+        "status": "fresh",
+        "stale": false
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-live.json
+++ b/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-live.json
@@ -1,0 +1,134 @@
+{
+  "generatedAt": "2026-08-05T21:25:17.455Z",
+  "schemaVersion": 1,
+  "catalog": {
+    "version": "2026-08-05",
+    "provenance": "Curated editorial intelligence buckets informed by public provider materials and leaderboards, including Artificial Analysis (https://artificialanalysis.ai/). No third-party scores are reproduced."
+  },
+  "models": [
+    {
+      "provider": "codex",
+      "id": "gpt-5-codex-mini",
+      "label": "GPT-5-Codex Mini",
+      "intelligence": "medium",
+      "quotaScopes": [
+        "all_models"
+      ],
+      "effective": {
+        "scope": "all_models",
+        "status": "known",
+        "effectivePercentRemaining": 18,
+        "boundedBy": [
+          "weekly"
+        ],
+        "limitingWindowIds": [
+          "weekly"
+        ],
+        "pace": {
+          "status": "ahead",
+          "aheadWindowIds": [
+            "weekly"
+          ],
+          "worstReservePercentPoints": -14.2456,
+          "worstReserveWindowId": "weekly"
+        },
+        "runway": {
+          "status": "projected_exhaustion",
+          "usableRunwaySeconds": 89951,
+          "projectedExhaustedAt": "2026-08-06T22:24:28.823Z",
+          "limitingWindowId": "weekly",
+          "projectionConfidence": "established",
+          "projectionBasis": "cycle_average"
+        }
+      },
+      "state": {
+        "status": "fresh",
+        "stale": false
+      }
+    },
+    {
+      "provider": "codex",
+      "id": "gpt-5.1-codex",
+      "label": "GPT-5.1-Codex",
+      "intelligence": "high",
+      "quotaScopes": [
+        "all_models"
+      ],
+      "effective": {
+        "scope": "all_models",
+        "status": "known",
+        "effectivePercentRemaining": 18,
+        "boundedBy": [
+          "weekly"
+        ],
+        "limitingWindowIds": [
+          "weekly"
+        ],
+        "pace": {
+          "status": "ahead",
+          "aheadWindowIds": [
+            "weekly"
+          ],
+          "worstReservePercentPoints": -14.2456,
+          "worstReserveWindowId": "weekly"
+        },
+        "runway": {
+          "status": "projected_exhaustion",
+          "usableRunwaySeconds": 89951,
+          "projectedExhaustedAt": "2026-08-06T22:24:28.823Z",
+          "limitingWindowId": "weekly",
+          "projectionConfidence": "established",
+          "projectionBasis": "cycle_average"
+        }
+      },
+      "state": {
+        "status": "fresh",
+        "stale": false
+      }
+    },
+    {
+      "provider": "codex",
+      "id": "gpt-5.3-codex",
+      "label": "GPT-5.3-Codex",
+      "intelligence": "high",
+      "quotaScopes": [
+        "model:codex_bengalfox"
+      ],
+      "effective": {
+        "scope": "model:codex_bengalfox",
+        "status": "known",
+        "effectivePercentRemaining": 18,
+        "boundedBy": [
+          "weekly",
+          "model:codex_bengalfox:7d"
+        ],
+        "limitingWindowIds": [
+          "weekly"
+        ],
+        "pace": {
+          "status": "ahead",
+          "aheadWindowIds": [
+            "weekly"
+          ],
+          "onPaceWindowIds": [
+            "model:codex_bengalfox:7d"
+          ],
+          "worstReservePercentPoints": -14.2456,
+          "worstReserveWindowId": "weekly"
+        },
+        "runway": {
+          "status": "projected_exhaustion",
+          "usableRunwaySeconds": 89951,
+          "projectedExhaustedAt": "2026-08-06T22:24:28.823Z",
+          "limitingWindowId": "weekly",
+          "projectionConfidence": "established",
+          "projectionBasis": "cycle_average"
+        }
+      },
+      "state": {
+        "status": "fresh",
+        "stale": false
+      }
+    }
+  ]
+}

--- a/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-runway.toon
+++ b/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-runway.toon
@@ -1,0 +1,22 @@
+bin: ~/.no-mistakes/worktrees/6eca570dbcdb/01KZ9VYHYF1HS694BSFJDNAJD5/dist/bin/quota-axi.js
+description: Join curated provider-native model intelligence buckets with local quota evidence
+generatedAt: "2026-08-05T21:25:23.311Z"
+catalogVersion: 2026-08-05
+models[3]{provider,id,label,intelligence,quotaScopes,status,stale,effectivePercentRemaining,runway,usableRunwaySeconds}:
+  codex,gpt-5-codex-mini,GPT-5-Codex Mini,medium,all_models,fresh,false,18,projected_exhaustion,89953
+  codex,gpt-5.1-codex,GPT-5.1-Codex,high,all_models,fresh,false,18,projected_exhaustion,89953
+  codex,gpt-5.3-codex,GPT-5.3-Codex,high,"model:codex_bengalfox",fresh,false,18,projected_exhaustion,89953
+sort:
+  key: runway
+  tieGroups[1]:
+    - [3]:
+      - provider: codex
+        id: gpt-5-codex-mini
+      - provider: codex
+        id: gpt-5.1-codex
+      - provider: codex
+        id: gpt-5.3-codex
+help[3]:
+  Default model order is deterministic and non-preferential (provider, then id)
+  Run `quota-axi models --sort runway` for the documented opt-in runway comparator
+  Run `quota-axi models --json` for catalog provenance and full quota evidence

--- a/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/package-root-runtime.json
+++ b/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/package-root-runtime.json
@@ -1,0 +1,8 @@
+{
+  "runtimeExport": "createModelsResponse",
+  "schemaVersion": 1,
+  "sortKeys": [
+    "runway"
+  ],
+  "models": []
+}

--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 
 ### Model catalog and `models`
 
-`quota-axi models [--intelligence high|medium|low] [--sort runway] [--provider ...] [--json|--full]` joins a reviewed catalog of native Claude, Codex, Grok, and Kimi models to the provider's effective quota evidence. Cursor and Copilot are excluded from this first catalog because their hosted model availability and quota relationships are plan-dependent and currently unknown.
+`quota-axi models [--intelligence high|medium|low] [--sort runway] [--provider ...] [--json|--full]` joins a reviewed catalog of native Claude, Codex, Grok, and Kimi models to the provider's effective quota evidence. It queries those four catalog-backed providers by default and accepts only those providers in an explicit models scope. Cursor and Copilot are excluded from this first catalog because their hosted model availability and quota relationships are plan-dependent and currently unknown.
 
 Catalog buckets are coarse editorial classifications relative to the current frontier, not scores. They are curated from public provider material and public leaderboards, including [Artificial Analysis](https://artificialanalysis.ai/) as an informing source. quota-axi does not reproduce Artificial Analysis scores, has no runtime Artificial Analysis dependency, and never commits an Artificial Analysis key. `scripts/refresh-model-kb.ts` is a maintainer-only review aid: it may use a private `AA_API_KEY` to suggest changes, but it never writes the catalog.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Agents need quota state before they choose where work can safely run.
 Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth sources.
 
 quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows in one [AXI](https://axi.md)-shaped call.
-It is data only: it never routes, recommends, proxies, intercepts, logs in, imports browser cookies, or mutates provider state.
+It is data only: it never routes, recommends a provider, model, harness, credential, or route, proxies, intercepts, logs in, imports browser cookies, or mutates provider state. Default output has no ordering preference. The opt-in `models --sort runway` surface applies only its documented deterministic comparator to quota evidence, preserves all evidence and explicit ties, and is not a recommendation.
 
 - **Official sources** - quota-axi reads local provider auth sources and calls the first-party quota, usage, billing, or entitlement endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
 - **Local first** - quota and auth reports run on the machine that holds the credentials; their network calls go to first-party provider endpoints, never a third-party relay.
@@ -309,27 +309,36 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ## CLI Reference
 
-| Command          | Description                                       |
-| ---------------- | ------------------------------------------------- |
-| `quota-axi`      | Report supported local quota windows              |
-| `auth`           | Report local auth-source availability, no values  |
-| `update`         | Upgrade quota-axi to the latest published version |
-| `update --check` | Report current vs. latest without installing      |
+| Command          | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| `quota-axi`      | Report supported local quota windows                 |
+| `auth`           | Report local auth-source availability, no values     |
+| `models`         | Join curated model buckets with local quota evidence |
+| `update`         | Upgrade quota-axi to the latest published version    |
+| `update --check` | Report current vs. latest without installing         |
 
 ### Flags
 
-| Flag                                               | Description                                            |
-| -------------------------------------------------- | ------------------------------------------------------ |
-| `--provider claude,codex,cursor,copilot,grok,kimi` | Scope providers                                        |
-| `--json`                                           | Emit normalized JSON instead of TOON for quota or auth |
-| `--full`                                           | Include account, source attempts, and reserve details  |
-| `--allow-keychain-prompt`                          | Permit macOS Claude Keychain access that could prompt  |
-| `-h`, `--help`                                     | Print terse [AXI](https://axi.md) help                 |
-| `-v`, `-V`, `--version`                            | Print version                                          |
+| Flag                                               | Description                                                     |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| `--provider claude,codex,cursor,copilot,grok,kimi` | Scope providers                                                 |
+| `--json`                                           | Emit normalized JSON instead of TOON for quota, auth, or models |
+| `--full`                                           | Include account, source attempts, and reserve details           |
+| `--allow-keychain-prompt`                          | Permit macOS Claude Keychain access that could prompt           |
+| `--intelligence high\|medium\|low`                 | Filter `models` by editorial intelligence bucket                |
+| `--sort runway`                                    | Explicitly sort `models` by documented usable-runway evidence   |
+| `-h`, `--help`                                     | Print terse [AXI](https://axi.md) help                          |
+| `-v`, `-V`, `--version`                            | Print version                                                   |
 
 ## Output Model
 
-`--json` emits `schemaVersion: 3`.
+The `quota` command's `--json` emits `schemaVersion: 3`.
+
+### Normalized schema contract
+
+The package publishes TypeScript declarations from its package root, so consumers can use `import type { QuotaAxiResponse, ModelsResponse } from "quota-axi"`. The adapter contract is `ProviderAdapter` in and normalized `ProviderQuota` out: adapters report observed quota data, never rank, mutate provider state, or retain raw responses.
+
+`schemaVersion` is command-specific. Additive optional fields do not bump it. A semantic or incompatible shape change does. The `quota` report is version 3, `auth` is version 1, and `models` is version 1.
 
 ### Quota report shape
 
@@ -461,6 +470,16 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 | Grok                   | With a usable Grok CLI session bearer, can report the shared `credits` window, optional product-scoped `product:<slug>` windows, the current-period `startsAt` and reset, and optional prepaid credit balance from the consumer Usage-page operation. Pi `xai` auth alone establishes usability but cannot provide these consumer windows. Top-level `credits.remaining` is prepaid/on-demand balance, distinct from the shared period `windows` credits percentage used for effective availability. Pace prefers the startsAt/resetsAt pair.                          |
 | Grok proto3 zero       | For the exact consumer operation only, an omitted usage float is the official proto3 zero when a valid weekly or monthly current period proves the config is present; quota-axi reports `0` used and `100` remaining rather than deriving usage from money.                                                                                                                                                                                                                                                                                                            |
 | Kimi                   | Reports the principal `weekly` subscription window (with trusted 604,800s duration) plus every valid self-described limit in wire order. Only a limit whose normalized duration is exactly 18,000 seconds is identified as `five_hour`; future limits remain `limit:<index>` unknown windows.                                                                                                                                                                                                                                                                          |
+
+### Model catalog and `models`
+
+`quota-axi models [--intelligence high|medium|low] [--sort runway] [--provider ...] [--json|--full]` joins a reviewed catalog of native Claude, Codex, Grok, and Kimi models to the provider's effective quota evidence. Cursor and Copilot are excluded from this first catalog because their hosted model availability and quota relationships are plan-dependent and currently unknown.
+
+Catalog buckets are coarse editorial classifications relative to the current frontier, not scores. They are curated from public provider material and public leaderboards, including [Artificial Analysis](https://artificialanalysis.ai/) as an informing source. quota-axi does not reproduce Artificial Analysis scores, has no runtime Artificial Analysis dependency, and never commits an Artificial Analysis key. `scripts/refresh-model-kb.ts` is a maintainer-only review aid: it may use a private `AA_API_KEY` to suggest changes, but it never writes the catalog.
+
+Every models response includes `catalog.version` and `catalog.provenance`; callers must treat catalog freshness and unmapped `unmatchedWindowIds` as explicit uncertainty. A model row exposes the applicable effective quota scope and provider state. When no model-specific scope is known, the provider account scope remains the evidence rather than an invented model limit.
+
+Default model order is deterministic and non-preferential: provider, then model ID. `--sort runway` is an explicit, evidence-preserving comparator only: finite `usableRunwaySeconds` descend, then `through_reset`, then `exhausted_now`, with unknown evidence last. Equal evidence appears in `sort.tieGroups`; no hidden score or model, provider, harness, credential, or route recommendation is implied. The comparator registry is intentionally extensible for a future separately sourced `cost` comparator, which is not shipped in v1.
 
 ### `auth --json` shape
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
   "bin": {
     "quota-axi": "./dist/bin/quota-axi.js"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "types": "./dist/src/index.d.ts",
   "files": [
     "dist",
     "skills/quota-axi",
@@ -38,7 +45,7 @@
   "scripts": {
     "build": "tsc",
     "build:skill": "tsx scripts/build-skill.ts",
-    "test": "vitest run",
+    "test": "pnpm run build && vitest run",
     "test:watch": "vitest",
     "dev": "tsx bin/quota-axi.ts",
     "lint": "eslint bin src test scripts",

--- a/scripts/refresh-model-kb.ts
+++ b/scripts/refresh-model-kb.ts
@@ -1,0 +1,134 @@
+#!/usr/bin/env tsx
+/**
+ * Maintainer-only curation aid. It never writes the catalog and never prints
+ * Artificial Analysis scores. Set AA_API_KEY for this one command, then review
+ * the suggestions and edit src/model-kb.ts deliberately.
+ *
+ * Optional --provider-models <file> accepts a reviewed JSON array of current
+ * first-party provider model records ({ provider, id, label? }) so additions
+ * can be compared before a human updates the committed catalog.
+ */
+import { readFile } from "node:fs/promises";
+
+import { MODEL_CATALOG } from "../src/model-kb.js";
+import { validateModelCatalog } from "../src/models.js";
+
+type ProviderModel = {
+  provider: string;
+  id: string;
+  label?: string;
+};
+
+type AaModel = {
+  name?: string;
+  slug?: string;
+  model_creator?: string;
+};
+
+const AA_MODELS_URL =
+  "https://api.artificialanalysis.ai/api/v2/data/llms/models";
+
+async function main(): Promise<void> {
+  validateModelCatalog(MODEL_CATALOG);
+  const key = process.env.AA_API_KEY;
+  if (!key) {
+    throw new Error(
+      "AA_API_KEY is required for this maintainer-only refresh aid",
+    );
+  }
+
+  const providerModels = await loadProviderModels(process.argv.slice(2));
+  const response = await fetch(AA_MODELS_URL, {
+    headers: { "x-api-key": key, accept: "application/json" },
+  });
+  if (!response.ok)
+    throw new Error(
+      `Artificial Analysis request failed: HTTP ${response.status}`,
+    );
+  const payload: unknown = await response.json();
+  const aaModels = modelsFromPayload(payload);
+  const known = new Set(
+    MODEL_CATALOG.entries.map((entry) => `${entry.provider}/${entry.id}`),
+  );
+
+  console.log(`Catalog version: ${MODEL_CATALOG.version}`);
+  console.log(`Catalog entries: ${MODEL_CATALOG.entries.length}`);
+  console.log(`Artificial Analysis model records fetched: ${aaModels.length}`);
+  if (providerModels.length === 0) {
+    console.log(
+      "Provider list: none supplied (pass --provider-models <reviewed-json>)",
+    );
+    return;
+  }
+
+  const additions = providerModels.filter(
+    (model) => !known.has(`${model.provider}/${model.id}`),
+  );
+  console.log(`Provider model records reviewed: ${providerModels.length}`);
+  if (additions.length === 0) {
+    console.log("Suggested catalog additions: none");
+    return;
+  }
+  console.log(
+    "Suggested catalog additions (review intelligence buckets manually):",
+  );
+  for (const model of additions) {
+    const aaMatch = aaModels.some((candidate) =>
+      matchesAaModel(model, candidate),
+    );
+    console.log(
+      `- ${model.provider}/${model.id}${model.label ? ` (${model.label})` : ""}; AA name match: ${aaMatch ? "yes" : "no"}`,
+    );
+  }
+}
+
+async function loadProviderModels(args: string[]): Promise<ProviderModel[]> {
+  if (args.length === 0) return [];
+  if (args.length !== 2 || args[0] !== "--provider-models") {
+    throw new Error(
+      "usage: refresh-model-kb.ts [--provider-models <reviewed-json>]",
+    );
+  }
+  const parsed: unknown = JSON.parse(await readFile(args[1]!, "utf8"));
+  if (!Array.isArray(parsed))
+    throw new Error("provider model list must be a JSON array");
+  return parsed.map((value) => {
+    if (
+      !value ||
+      typeof value !== "object" ||
+      typeof value.provider !== "string" ||
+      typeof value.id !== "string" ||
+      (value.label !== undefined && typeof value.label !== "string")
+    ) {
+      throw new Error(
+        "each provider model requires string provider, id, and optional label",
+      );
+    }
+    return value;
+  });
+}
+
+function modelsFromPayload(payload: unknown): AaModel[] {
+  if (!payload || typeof payload !== "object") return [];
+  const records =
+    "data" in payload
+      ? payload.data
+      : "models" in payload
+        ? payload.models
+        : [];
+  return Array.isArray(records)
+    ? records.filter((record): record is AaModel =>
+        Boolean(record && typeof record === "object"),
+      )
+    : [];
+}
+
+function matchesAaModel(model: ProviderModel, candidate: AaModel): boolean {
+  const haystack = [candidate.name, candidate.slug, candidate.model_creator]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(model.id.toLowerCase());
+}
+
+await main();

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, with no routing, recommendation, or provider mutation. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, with no routing, provider mutation, or default ordering preference. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -23,12 +23,14 @@ metadata:
 
 # quota-axi
 
-Report local agent-provider quota windows for routing-aware agents.
+Report local agent-provider quota windows and model quota evidence.
 
 You do not need quota-axi installed globally - invoke it with `npx -y quota-axi`.
 
-quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local provider auth sources and calls
+quota-axi is data only: it never routes, recommends a provider, model, harness, credential, or
+route, proxies, intercepts, logs in, imports browser cookies, or mutates provider state. Default
+output has no ordering preference. The explicit `models --sort runway` comparator only orders
+quota evidence, preserves ties, and is never a recommendation. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
 Claude, Grok, Pi, or Kimi CLIs, so it cannot spend the quota it measures.
 
@@ -54,7 +56,12 @@ or when comparing supported local provider headroom side by side.
    `--json` and `--full` retain it. If relationship status is `partial` or `unknown`, do not infer
    one. Stale reports keep raw windows for diagnostics, but effective availability, pace, and
    runway are always unknown; never route from a stale raw percentage as though it were current
-   headroom. quota-axi never recommends a provider, model, or route.
+   headroom. Default output has no ordering preference. For a provider-native model evidence join,
+   use `npx -y quota-axi models --intelligence high --json`. This catalog covers Claude, Codex,
+   Grok, and Kimi only; its buckets are coarse editorial classifications, not scores. Its response
+   includes catalog provenance and unmatched model windows. `--sort runway` is an explicit,
+   documented quota-evidence comparator, not a provider, model, harness, credential, or route
+   recommendation; inspect `sort.tieGroups` rather than treating equal evidence as a preference.
 4. Pass `--full` to include account identity, per-source attempts, and raw reserve diagnostics.
 5. Run `npx -y quota-axi auth` to check local auth-source availability without printing
    secret values.
@@ -90,13 +97,13 @@ or when comparing supported local provider headroom side by side.
 ## Usage
 
 ```
-usage: quota-axi [auth] [flags]
-commands[2]:
-  (none)=quota, auth
+usage: quota-axi [quota|auth|models] [flags]
+commands[3]:
+  (none)=quota, auth, models
 output:
-  Default TOON reports effective headroom and usable-runway evidence; use --full or --json for reserve diagnostics.
-flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  Default TOON reports local quota evidence. models is a deterministic data join; --sort runway is explicit opt-in ordering.
+flags[8]:
+  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
@@ -104,6 +111,8 @@ examples:
   quota-axi --json
   quota-axi --full
   quota-axi auth
+  quota-axi models --intelligence high
+  quota-axi models --sort runway
 ```
 
 ## Tips

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,4 +1,5 @@
 import { AxiError } from "axi-sdk-js";
+import { MODEL_CATALOG_PROVIDER_IDS } from "./models.js";
 import { parseProviders } from "./providers/index.js";
 import type { IntelligenceBucket, ModelSortKey, ProviderId } from "./types.js";
 
@@ -33,10 +34,24 @@ export function parseFlags(args: string[]): QuotaFlags {
 
 /** Parse flags accepted by the `models` evidence-join command. */
 export function parseModelsFlags(args: string[]): ModelsFlags {
-  return parseCommonFlags(args);
+  const flags = parseCommonFlags(args, MODEL_CATALOG_PROVIDER_IDS);
+  const unsupported = flags.providers.find(
+    (provider) => !MODEL_CATALOG_PROVIDER_IDS.includes(provider),
+  );
+  if (unsupported) {
+    throw new AxiError(
+      `models does not support provider: ${unsupported}`,
+      "VALIDATION_ERROR",
+      ["Supported model providers: claude, codex, grok, kimi"],
+    );
+  }
+  return flags;
 }
 
-function parseCommonFlags(args: string[]): ModelsFlags {
+function parseCommonFlags(
+  args: string[],
+  defaultProviders?: readonly ProviderId[],
+): ModelsFlags {
   let providerValue: string | undefined;
   let json = false;
   let full = false;
@@ -105,7 +120,10 @@ function parseCommonFlags(args: string[]): ModelsFlags {
   }
 
   return {
-    providers: parseProviderScope(providerValue),
+    providers:
+      providerValue === undefined && defaultProviders
+        ? [...defaultProviders]
+        : parseProviderScope(providerValue),
     json,
     full,
     allowKeychainPrompt,

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,6 +1,6 @@
 import { AxiError } from "axi-sdk-js";
 import { parseProviders } from "./providers/index.js";
-import type { ProviderId } from "./types.js";
+import type { IntelligenceBucket, ModelSortKey, ProviderId } from "./types.js";
 
 export type QuotaFlags = {
   providers: ProviderId[];
@@ -9,16 +9,40 @@ export type QuotaFlags = {
   allowKeychainPrompt: boolean;
 };
 
+export type ModelsFlags = QuotaFlags & {
+  intelligence?: IntelligenceBucket;
+  sort?: ModelSortKey;
+};
+
 /**
  * Parse the flags shared by the `quota` and `auth` commands. Command routing is
  * owned by {@link runAxiCli}; this only interprets the flags that follow.
  * `--full` is accepted by both commands but only consumed by `quota`.
  */
 export function parseFlags(args: string[]): QuotaFlags {
+  const flags = parseCommonFlags(args);
+  if (flags.intelligence !== undefined || flags.sort !== undefined) {
+    throw new AxiError(
+      "--intelligence and --sort are only supported by the models command",
+      "VALIDATION_ERROR",
+      ["Run `quota-axi models --help` for supported models flags"],
+    );
+  }
+  return flags;
+}
+
+/** Parse flags accepted by the `models` evidence-join command. */
+export function parseModelsFlags(args: string[]): ModelsFlags {
+  return parseCommonFlags(args);
+}
+
+function parseCommonFlags(args: string[]): ModelsFlags {
   let providerValue: string | undefined;
   let json = false;
   let full = false;
   let allowKeychainPrompt = false;
+  let intelligence: IntelligenceBucket | undefined;
+  let sort: ModelSortKey | undefined;
 
   for (let index = 0; index < args.length; index++) {
     const arg = args[index];
@@ -35,6 +59,27 @@ export function parseFlags(args: string[]): QuotaFlags {
     }
     if (arg === "--allow-keychain-prompt") {
       allowKeychainPrompt = true;
+      continue;
+    }
+    if (arg === "--intelligence") {
+      intelligence = parseIntelligenceValue(args[index + 1], "--intelligence");
+      index++;
+      continue;
+    }
+    if (arg.startsWith("--intelligence=")) {
+      intelligence = parseIntelligenceValue(
+        arg.slice("--intelligence=".length),
+        "--intelligence",
+      );
+      continue;
+    }
+    if (arg === "--sort") {
+      sort = parseSortValue(args[index + 1]);
+      index++;
+      continue;
+    }
+    if (arg.startsWith("--sort=")) {
+      sort = parseSortValue(arg.slice("--sort=".length));
       continue;
     }
     if (arg === "--provider") {
@@ -64,7 +109,30 @@ export function parseFlags(args: string[]): QuotaFlags {
     json,
     full,
     allowKeychainPrompt,
+    ...(intelligence ? { intelligence } : {}),
+    ...(sort ? { sort } : {}),
   };
+}
+
+function parseIntelligenceValue(
+  value: string | undefined,
+  flag: string,
+): IntelligenceBucket {
+  if (value === "high" || value === "medium" || value === "low") return value;
+  throw new AxiError(
+    `${flag} requires high, medium, or low`,
+    "VALIDATION_ERROR",
+    ["Run `quota-axi models --help` for supported models flags"],
+  );
+}
+
+function parseSortValue(value: string | undefined): ModelSortKey {
+  if (value === "runway") return value;
+  throw new AxiError(
+    "--sort requires a supported comparator",
+    "VALIDATION_ERROR",
+    ["Supported sort keys: runway"],
+  );
 }
 
 function parseProviderScope(value: string | undefined): ProviderId[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,17 +1,22 @@
 import { runAxiCli } from "axi-sdk-js";
-import { authCommand, quotaCommand, type QuotaContext } from "./commands.js";
+import {
+  authCommand,
+  modelsCommand,
+  quotaCommand,
+  type QuotaContext,
+} from "./commands.js";
 import { VERSION } from "./version.js";
 
 export const DESCRIPTION =
-  "Report local agent-provider quota windows for routing-aware agents.";
+  "Report local agent-provider quota windows and model quota evidence.";
 
-export const TOP_HELP = `usage: quota-axi [auth] [flags]
-commands[2]:
-  (none)=quota, auth
+export const TOP_HELP = `usage: quota-axi [quota|auth|models] [flags]
+commands[3]:
+  (none)=quota, auth, models
 output:
-  Default TOON reports effective headroom and usable-runway evidence; use --full or --json for reserve diagnostics.
-flags[6]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --help, -v/--version
+  Default TOON reports local quota evidence. models is a deterministic data join; --sort runway is explicit opt-in ordering.
+flags[8]:
+  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
@@ -19,6 +24,8 @@ examples:
   quota-axi --json
   quota-axi --full
   quota-axi auth
+  quota-axi models --intelligence high
+  quota-axi models --sort runway
 `;
 
 type MainOptions = {
@@ -40,13 +47,16 @@ export async function main(options: MainOptions = {}): Promise<void> {
     commands: {
       quota: quotaCommand,
       auth: authCommand,
+      models: modelsCommand,
     },
     // `quota` is the implicit default command, so the bare-invocation home view
     // is never reached (see normalizeArgv); wiring it keeps the SDK contract.
     home: quotaCommand,
     resolveContext: () => ({ binPath }),
     getCommandHelp: (command) =>
-      command === "quota" || command === "auth" ? TOP_HELP : undefined,
+      command === "quota" || command === "auth" || command === "models"
+        ? TOP_HELP
+        : undefined,
   });
 }
 
@@ -78,7 +88,12 @@ export function normalizeArgv(raw: string[]): string[] {
   if (raw.length === 1 && isTopLevelFlag(first)) {
     return raw;
   }
-  if (first === "quota" || first === "auth" || first === "update") {
+  if (
+    first === "quota" ||
+    first === "auth" ||
+    first === "models" ||
+    first === "update"
+  ) {
     return raw;
   }
   if (first.startsWith("-")) {
@@ -117,7 +132,14 @@ function findCommand(raw: string[]): number {
       index++;
       continue;
     }
-    if (arg === "quota" || arg === "auth" || arg === "update") return index;
+    if (
+      arg === "quota" ||
+      arg === "auth" ||
+      arg === "models" ||
+      arg === "update"
+    ) {
+      return index;
+    }
   }
   return -1;
 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,10 +1,16 @@
 import { annotateQuotaAdvice } from "./advice.js";
-import { parseFlags } from "./args.js";
+import { parseFlags, parseModelsFlags } from "./args.js";
 import { writeCachedProviders } from "./cache.js";
 import { withQuotaSemantics } from "./interpretation.js";
+import { createModelsResponse } from "./models.js";
 import { nowIso } from "./lib/time.js";
 import { PROVIDERS } from "./providers/index.js";
-import { redactedResponse, renderAuthToon, renderQuotaToon } from "./render.js";
+import {
+  redactedResponse,
+  renderAuthToon,
+  renderModelsToon,
+  renderQuotaToon,
+} from "./render.js";
 import type {
   AuthProviderReport,
   ProviderId,
@@ -40,6 +46,28 @@ export async function quotaCommand(
     : renderQuotaToon(redacted, binPath, flags.full);
 }
 
+export async function modelsCommand(
+  args: string[],
+  context: QuotaContext | undefined,
+): Promise<string> {
+  const binPath = context?.binPath ?? "quota-axi";
+  const flags = parseModelsFlags(args);
+  const options: ProviderOptions = {
+    allowKeychainPrompt: flags.allowKeychainPrompt,
+  };
+  const quota = await fetchQuota(flags.providers, options);
+  writeCachedProvidersBestEffort(quota.providers);
+  const response = createModelsResponse(quota, {
+    ...(flags.intelligence ? { intelligence: flags.intelligence } : {}),
+    ...(flags.sort ? { sort: flags.sort } : {}),
+  });
+
+  if (quota.providers.every(isFailed)) process.exitCode = 1;
+  return flags.json
+    ? JSON.stringify(response, null, 2)
+    : renderModelsToon(response, binPath, flags.full);
+}
+
 export async function authCommand(
   args: string[],
   context: QuotaContext | undefined,
@@ -60,7 +88,7 @@ export async function authCommand(
     : renderAuthToon(reports, binPath);
 }
 
-async function fetchQuota(
+export async function fetchQuota(
   providers: ProviderId[],
   options: ProviderOptions,
 ): Promise<QuotaAxiResponse> {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,7 +2,10 @@ import { annotateQuotaAdvice } from "./advice.js";
 import { parseFlags, parseModelsFlags } from "./args.js";
 import { writeCachedProviders } from "./cache.js";
 import { withQuotaSemantics } from "./interpretation.js";
-import { createModelsResponse } from "./models.js";
+import {
+  createModelsResponse,
+  MODEL_CATALOG_PROVIDER_IDS,
+} from "./models.js";
 import { nowIso } from "./lib/time.js";
 import { PROVIDERS } from "./providers/index.js";
 import {
@@ -62,7 +65,10 @@ export async function modelsCommand(
     ...(flags.sort ? { sort: flags.sort } : {}),
   });
 
-  if (quota.providers.every(isFailed)) process.exitCode = 1;
+  const modelProviders = quota.providers.filter((provider) =>
+    MODEL_CATALOG_PROVIDER_IDS.includes(provider.provider),
+  );
+  if (modelProviders.every(isFailed)) process.exitCode = 1;
   return flags.json
     ? JSON.stringify(response, null, 2)
     : renderModelsToon(response, binPath, flags.full);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,10 +2,7 @@ import { annotateQuotaAdvice } from "./advice.js";
 import { parseFlags, parseModelsFlags } from "./args.js";
 import { writeCachedProviders } from "./cache.js";
 import { withQuotaSemantics } from "./interpretation.js";
-import {
-  createModelsResponse,
-  MODEL_CATALOG_PROVIDER_IDS,
-} from "./models.js";
+import { createModelsResponse, MODEL_CATALOG_PROVIDER_IDS } from "./models.js";
 import { nowIso } from "./lib/time.js";
 import { PROVIDERS } from "./providers/index.js";
 import {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  compareModelsByRunway,
+  createModelsResponse,
+  MODEL_COMPARATORS,
+  MODEL_SORT_KEYS,
+  validateModelCatalog,
+} from "./models.js";
+export type * from "./types.js";

--- a/src/model-kb.ts
+++ b/src/model-kb.ts
@@ -1,0 +1,100 @@
+import type { ModelCatalog } from "./types.js";
+
+/**
+ * A deliberately coarse, editorial catalog of provider-native models.
+ *
+ * Buckets are relative to the current general-purpose frontier, not scores or
+ * claims of exact capability. They are maintained from public provider
+ * materials and leaderboards, including Artificial Analysis, without copying
+ * or redistributing any third-party scores.
+ */
+export const MODEL_CATALOG: ModelCatalog = {
+  version: "2026-08-05",
+  provenance:
+    "Curated editorial intelligence buckets informed by public provider materials and leaderboards, including Artificial Analysis (https://artificialanalysis.ai/). No third-party scores are reproduced.",
+  entries: [
+    {
+      provider: "claude",
+      id: "claude-opus-4-5",
+      label: "Claude Opus 4.5",
+      intelligence: "high",
+      windowIds: ["model:fable"],
+      aliases: ["Fable", "claude-opus-4.5"],
+    },
+    {
+      provider: "claude",
+      id: "claude-sonnet-4-5",
+      label: "Claude Sonnet 4.5",
+      intelligence: "high",
+      aliases: ["claude-sonnet-4.5"],
+    },
+    {
+      provider: "claude",
+      id: "claude-haiku-4-5",
+      label: "Claude Haiku 4.5",
+      intelligence: "medium",
+      aliases: ["claude-haiku-4.5"],
+    },
+    {
+      provider: "codex",
+      id: "gpt-5.3-codex",
+      label: "GPT-5.3-Codex",
+      intelligence: "high",
+      windowIds: ["model:codex_bengalfox"],
+      aliases: ["codex_bengalfox", "GPT-5.3-Codex-Spark"],
+    },
+    {
+      provider: "codex",
+      id: "gpt-5.1-codex",
+      label: "GPT-5.1-Codex",
+      intelligence: "high",
+      windowIds: ["model:gpt-5.1-codex"],
+    },
+    {
+      provider: "codex",
+      id: "gpt-5-codex-mini",
+      label: "GPT-5-Codex Mini",
+      intelligence: "medium",
+      windowIds: ["model:gpt-5-codex-mini"],
+    },
+    {
+      provider: "grok",
+      id: "grok-4",
+      label: "Grok 4",
+      intelligence: "high",
+      aliases: ["grok-4-latest"],
+    },
+    {
+      provider: "grok",
+      id: "grok-4-fast",
+      label: "Grok 4 Fast",
+      intelligence: "medium",
+      aliases: ["grok-4-fast-reasoning"],
+    },
+    {
+      provider: "grok",
+      id: "grok-3-mini",
+      label: "Grok 3 Mini",
+      intelligence: "low",
+    },
+    {
+      provider: "kimi",
+      id: "kimi-k2.5",
+      label: "Kimi K2.5",
+      intelligence: "high",
+      aliases: ["kimi-k2-5"],
+    },
+    {
+      provider: "kimi",
+      id: "kimi-k2",
+      label: "Kimi K2",
+      intelligence: "medium",
+    },
+    {
+      provider: "kimi",
+      id: "kimi-k1.5",
+      label: "Kimi K1.5",
+      intelligence: "low",
+    },
+  ],
+};

--- a/src/models.ts
+++ b/src/models.ts
@@ -19,12 +19,10 @@ const INTELLIGENCE_BUCKETS = new Set<IntelligenceBucket>([
   "medium",
   "low",
 ]);
-const MODEL_KB_PROVIDERS = new Set<ProviderId>([
-  "claude",
-  "codex",
-  "grok",
-  "kimi",
-]);
+export const MODEL_CATALOG_PROVIDER_IDS: readonly ProviderId[] = [
+  ...new Set(MODEL_CATALOG.entries.map((entry) => entry.provider)),
+];
+const MODEL_KB_PROVIDERS = new Set<ProviderId>(MODEL_CATALOG_PROVIDER_IDS);
 
 export const MODEL_SORT_KEYS = [
   "runway",

--- a/src/models.ts
+++ b/src/models.ts
@@ -123,9 +123,11 @@ export function compareModelsByRunway(
 }
 
 export function validateModelCatalog(catalog: ModelCatalog): void {
+  const versionTimestamp = Date.parse(`${catalog.version}T00:00:00.000Z`);
   if (
     !/^\d{4}-\d{2}-\d{2}$/.test(catalog.version) ||
-    Number.isNaN(Date.parse(`${catalog.version}T00:00:00.000Z`))
+    Number.isNaN(versionTimestamp) ||
+    new Date(versionTimestamp).toISOString().slice(0, 10) !== catalog.version
   ) {
     throw new Error("model catalog version must be an ISO calendar date");
   }
@@ -201,10 +203,16 @@ function unmatchedModelWindowIds(
       .flatMap((entry) => entry.windowIds ?? [])
       .map(normalizedModelScope),
   );
+  const unmatchedScopes = new Set<string>();
   return provider.windows
     .filter((window) => window.kind === "model")
     .map((window) => normalizedModelScope(window.id))
     .filter((scope) => !knownScopes.has(scope))
+    .filter((scope) => {
+      if (unmatchedScopes.has(scope)) return false;
+      unmatchedScopes.add(scope);
+      return true;
+    })
     .map((scope) => `${provider.provider}/${scope}`);
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,274 @@
+import { MODEL_CATALOG } from "./model-kb.js";
+import type {
+  EffectiveAvailability,
+  IntelligenceBucket,
+  ModelCatalog,
+  ModelCatalogEntry,
+  ModelQuotaRecord,
+  ModelReference,
+  ModelSortKey,
+  ModelsResponse,
+  ProviderId,
+  ProviderQuota,
+  ProviderStateSummary,
+  QuotaAxiResponse,
+} from "./types.js";
+
+const INTELLIGENCE_BUCKETS = new Set<IntelligenceBucket>([
+  "high",
+  "medium",
+  "low",
+]);
+const MODEL_KB_PROVIDERS = new Set<ProviderId>([
+  "claude",
+  "codex",
+  "grok",
+  "kimi",
+]);
+
+export const MODEL_SORT_KEYS = [
+  "runway",
+] as const satisfies readonly ModelSortKey[];
+
+export type ModelComparator = {
+  compare: (left: ModelQuotaRecord, right: ModelQuotaRecord) => number;
+  tieKey: (model: ModelQuotaRecord) => string;
+};
+
+/**
+ * Registry for explicit, evidence-only ordering. New comparators (such as a
+ * future cost comparator) belong here with their data dependency and docs.
+ */
+export const MODEL_COMPARATORS: Readonly<
+  Record<ModelSortKey, ModelComparator>
+> = {
+  runway: {
+    compare: compareModelsByRunway,
+    tieKey: runwayTieKey,
+  },
+};
+
+validateModelCatalog(MODEL_CATALOG);
+
+export function createModelsResponse(
+  quota: QuotaAxiResponse,
+  options: {
+    intelligence?: IntelligenceBucket;
+    sort?: ModelSortKey;
+    catalog?: ModelCatalog;
+  } = {},
+): ModelsResponse {
+  const catalog = options.catalog ?? MODEL_CATALOG;
+  validateModelCatalog(catalog);
+  const providers = new Map(
+    quota.providers.map((provider) => [provider.provider, provider]),
+  );
+  const models = catalog.entries
+    .filter(
+      (entry) =>
+        providers.has(entry.provider) &&
+        (options.intelligence === undefined ||
+          entry.intelligence === options.intelligence),
+    )
+    .map((entry) => modelRecord(entry, providers.get(entry.provider)!))
+    .sort(compareModelIdentity);
+  const unmatchedWindowIds = quota.providers.flatMap((provider) =>
+    unmatchedModelWindowIds(provider, catalog.entries),
+  );
+
+  if (!options.sort) {
+    return {
+      generatedAt: quota.generatedAt,
+      schemaVersion: 1,
+      catalog: catalogSummary(catalog),
+      models,
+      ...(unmatchedWindowIds.length > 0 ? { unmatchedWindowIds } : {}),
+    };
+  }
+
+  const comparator = MODEL_COMPARATORS[options.sort];
+  const sorted = [...models].sort(
+    (left, right) =>
+      comparator.compare(left, right) || compareModelIdentity(left, right),
+  );
+  return {
+    generatedAt: quota.generatedAt,
+    schemaVersion: 1,
+    catalog: catalogSummary(catalog),
+    models: sorted,
+    ...(unmatchedWindowIds.length > 0 ? { unmatchedWindowIds } : {}),
+    sort: {
+      key: options.sort,
+      tieGroups: tieGroups(sorted, comparator),
+    },
+  };
+}
+
+/**
+ * Sort by observable usable runway only. It does not assess model capability,
+ * task fit, credentials, prices, or a route. Unknown evidence remains last.
+ */
+export function compareModelsByRunway(
+  left: ModelQuotaRecord,
+  right: ModelQuotaRecord,
+): number {
+  const leftRank = runwayRank(left);
+  const rightRank = runwayRank(right);
+  if (leftRank !== rightRank) return leftRank - rightRank;
+  if (leftRank !== 0) return 0;
+  return (
+    (right.effective?.runway?.usableRunwaySeconds ?? 0) -
+    (left.effective?.runway?.usableRunwaySeconds ?? 0)
+  );
+}
+
+export function validateModelCatalog(catalog: ModelCatalog): void {
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(catalog.version) ||
+    Number.isNaN(Date.parse(`${catalog.version}T00:00:00.000Z`))
+  ) {
+    throw new Error("model catalog version must be an ISO calendar date");
+  }
+  if (!catalog.provenance.trim())
+    throw new Error("model catalog provenance is required");
+
+  const seen = new Set<string>();
+  for (const entry of catalog.entries) {
+    if (!MODEL_KB_PROVIDERS.has(entry.provider)) {
+      throw new Error(
+        `model catalog provider is unsupported: ${entry.provider}`,
+      );
+    }
+    if (!entry.id.trim() || !entry.label.trim()) {
+      throw new Error("model catalog entries require id and label");
+    }
+    if (!INTELLIGENCE_BUCKETS.has(entry.intelligence)) {
+      throw new Error(
+        `model catalog intelligence is invalid: ${entry.intelligence}`,
+      );
+    }
+    const key = `${entry.provider}/${entry.id}`;
+    if (seen.has(key)) throw new Error(`duplicate model catalog entry: ${key}`);
+    seen.add(key);
+    for (const windowId of entry.windowIds ?? []) {
+      if (!/^model:[a-z0-9][a-z0-9_.:-]*$/i.test(windowId)) {
+        throw new Error(`model catalog window id is invalid: ${windowId}`);
+      }
+    }
+  }
+}
+
+function modelRecord(
+  entry: ModelCatalogEntry,
+  provider: ProviderQuota,
+): ModelQuotaRecord {
+  const effective = availabilityFor(entry, provider);
+  return {
+    provider: entry.provider,
+    id: entry.id,
+    label: entry.label,
+    intelligence: entry.intelligence,
+    quotaScopes: effective ? [effective.scope] : [],
+    ...(effective ? { effective } : {}),
+    state: stateSummary(provider),
+  };
+}
+
+function availabilityFor(
+  entry: ModelCatalogEntry,
+  provider: ProviderQuota,
+): EffectiveAvailability | undefined {
+  const availability = provider.quotaSemantics?.effectiveAvailability ?? [];
+  for (const windowId of entry.windowIds ?? []) {
+    const found = availability.find(
+      (candidate) => candidate.scope === normalizedModelScope(windowId),
+    );
+    if (found) return found;
+  }
+  return availability.find(
+    (candidate) =>
+      candidate.scope === "all_models" || candidate.scope === "all_products",
+  );
+}
+
+function unmatchedModelWindowIds(
+  provider: ProviderQuota,
+  entries: ModelCatalogEntry[],
+): string[] {
+  const knownScopes = new Set(
+    entries
+      .filter((entry) => entry.provider === provider.provider)
+      .flatMap((entry) => entry.windowIds ?? [])
+      .map(normalizedModelScope),
+  );
+  return provider.windows
+    .filter((window) => window.kind === "model")
+    .map((window) => normalizedModelScope(window.id))
+    .filter((scope) => !knownScopes.has(scope))
+    .map((scope) => `${provider.provider}/${scope}`);
+}
+
+function normalizedModelScope(windowId: string): string {
+  return windowId.replace(/_\d+$/, "").replace(/:(?:5h|7d|window:[^:]+)$/, "");
+}
+
+function stateSummary(provider: ProviderQuota): ProviderStateSummary {
+  const { status, stale, authStatus, reason, remedyCommand } = provider.state;
+  return {
+    status,
+    stale,
+    ...(authStatus ? { authStatus } : {}),
+    ...(reason ? { reason } : {}),
+    ...(remedyCommand ? { remedyCommand } : {}),
+  };
+}
+
+function catalogSummary(catalog: ModelCatalog) {
+  return { version: catalog.version, provenance: catalog.provenance };
+}
+
+function compareModelIdentity(
+  left: ModelReference,
+  right: ModelReference,
+): number {
+  return (
+    left.provider.localeCompare(right.provider) ||
+    left.id.localeCompare(right.id)
+  );
+}
+
+function runwayRank(model: ModelQuotaRecord): number {
+  const runway = model.effective?.runway;
+  if (
+    runway?.status === "projected_exhaustion" &&
+    runway.usableRunwaySeconds !== undefined
+  )
+    return 0;
+  if (runway?.status === "through_reset") return 1;
+  if (runway?.status === "exhausted_now") return 2;
+  return 3;
+}
+
+function runwayTieKey(model: ModelQuotaRecord): string {
+  const rank = runwayRank(model);
+  return rank === 0
+    ? `finite:${model.effective?.runway?.usableRunwaySeconds}`
+    : ["through_reset", "exhausted_now", "unknown"][rank - 1]!;
+}
+
+function tieGroups(
+  models: ModelQuotaRecord[],
+  comparator: ModelComparator,
+): ModelReference[][] {
+  const groups: ModelReference[][] = [];
+  for (let index = 0; index < models.length; ) {
+    const key = comparator.tieKey(models[index]!);
+    const group: ModelReference[] = [];
+    while (index < models.length && comparator.tieKey(models[index]!) === key) {
+      const model = models[index++]!;
+      group.push({ provider: model.provider, id: model.id });
+    }
+    if (group.length > 1) groups.push(group);
+  }
+  return groups;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -29,7 +29,7 @@ export function parseProviders(value: string | undefined): ProviderId[] {
   if (invalid) {
     throw new Error(`unsupported provider: ${invalid}`);
   }
-  return providers as ProviderId[];
+  return [...new Set(providers)] as ProviderId[];
 }
 
 function isProviderId(value: string): value is ProviderId {

--- a/src/render.ts
+++ b/src/render.ts
@@ -3,6 +3,7 @@ import { quotaHelpLines } from "./advice.js";
 import { collapseHome } from "./lib/fs.js";
 import type {
   AuthProviderReport,
+  ModelsResponse,
   ProviderQuota,
   QuotaAxiResponse,
   SourceAttempt,
@@ -179,6 +180,64 @@ export function renderAuthToon(
       "Run `quota-axi --allow-keychain-prompt auth` to permit macOS Keychain access",
     ]),
   ].join("\n");
+}
+
+export function renderModelsToon(
+  response: ModelsResponse,
+  binPath: string,
+  full: boolean,
+): string {
+  const models = response.models.map((model) => ({
+    provider: model.provider,
+    id: model.id,
+    label: model.label,
+    intelligence: model.intelligence,
+    quotaScopes: model.quotaScopes.join(" + ") || "unknown",
+    status: model.state.status,
+    stale: model.state.stale,
+    effectivePercentRemaining:
+      model.effective?.effectivePercentRemaining ?? ("unknown" as const),
+    runway: model.effective?.runway?.status ?? "unknown",
+    usableRunwaySeconds:
+      model.effective?.runway?.usableRunwaySeconds ?? ("unknown" as const),
+  }));
+  const blocks = [
+    encode({
+      bin: collapseHome(binPath),
+      description:
+        "Join curated provider-native model intelligence buckets with local quota evidence",
+      generatedAt: response.generatedAt,
+      catalogVersion: response.catalog.version,
+    }),
+    encode({ models }),
+  ];
+  if (response.sort) blocks.push(encode({ sort: response.sort }));
+  if (response.unmatchedWindowIds?.length) {
+    blocks.push(encode({ unmatchedWindowIds: response.unmatchedWindowIds }));
+  }
+  if (full) {
+    const evidence = response.models.map((model) => ({
+      provider: model.provider,
+      id: model.id,
+      boundedBy: model.effective?.boundedBy.join(" + ") ?? "unknown",
+      limitingWindowIds:
+        model.effective?.limitingWindowIds?.join(" + ") ?? "unknown",
+      projectedExhaustedAt:
+        model.effective?.runway?.projectedExhaustedAt ?? "unknown",
+      authStatus: model.state.authStatus ?? "unknown",
+      reason: model.state.reason ?? "none",
+      remedyCommand: model.state.remedyCommand ?? "none",
+    }));
+    blocks.push(encode({ evidence }));
+  }
+  blocks.push(
+    renderHelp([
+      "Default model order is deterministic and non-preferential (provider, then id)",
+      "Run `quota-axi models --sort runway` for the documented opt-in runway comparator",
+      "Run `quota-axi models --json` for catalog provenance and full quota evidence",
+    ]),
+  );
+  return blocks.join("\n");
 }
 
 export function redactedResponse(

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -5,7 +5,7 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 export const SKILL_DESCRIPTION =
   "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows via the quota-axi CLI - remaining " +
   "effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, and provider status read from local auth sources, " +
-  "with no routing, recommendation, or provider mutation. Use before deciding whether it is safe " +
+  "with no routing, provider mutation, or default ordering preference. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or " +
   "remaining quota, or when comparing local provider headroom.";
 
@@ -58,8 +58,10 @@ ${DESCRIPTION}
 
 You do not need quota-axi installed globally - invoke it with \`npx -y quota-axi\`.
 
-quota-axi is data only: it never routes, recommends, proxies, intercepts, logs in, imports
-browser cookies, or mutates provider state. It reads local provider auth sources and calls
+quota-axi is data only: it never routes, recommends a provider, model, harness, credential, or
+route, proxies, intercepts, logs in, imports browser cookies, or mutates provider state. Default
+output has no ordering preference. The explicit \`models --sort runway\` comparator only orders
+quota evidence, preserves ties, and is never a recommendation. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, or entitlement endpoints; it never launches the
 Claude, Grok, Pi, or Kimi CLIs, so it cannot spend the quota it measures.
 
@@ -85,7 +87,12 @@ or when comparing supported local provider headroom side by side.
    \`--json\` and \`--full\` retain it. If relationship status is \`partial\` or \`unknown\`, do not infer
    one. Stale reports keep raw windows for diagnostics, but effective availability, pace, and
    runway are always unknown; never route from a stale raw percentage as though it were current
-   headroom. quota-axi never recommends a provider, model, or route.
+   headroom. Default output has no ordering preference. For a provider-native model evidence join,
+   use \`npx -y quota-axi models --intelligence high --json\`. This catalog covers Claude, Codex,
+   Grok, and Kimi only; its buckets are coarse editorial classifications, not scores. Its response
+   includes catalog provenance and unmatched model windows. \`--sort runway\` is an explicit,
+   documented quota-evidence comparator, not a provider, model, harness, credential, or route
+   recommendation; inspect \`sort.tieGroups\` rather than treating equal evidence as a preference.
 4. Pass \`--full\` to include account identity, per-source attempts, and raw reserve diagnostics.
 5. Run \`npx -y quota-axi auth\` to check local auth-source availability without printing
    secret values.

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,3 +231,65 @@ export type AuthProviderReport = {
   provider: ProviderId;
   sources: AuthSourceReport[];
 };
+
+/** A coarse editorial classification relative to the current model frontier. */
+export type IntelligenceBucket = "high" | "medium" | "low";
+
+/** Native-provider model knowledge used by the `models` evidence join. */
+export type ModelCatalogEntry = {
+  provider: "claude" | "codex" | "grok" | "kimi";
+  id: string;
+  label: string;
+  intelligence: IntelligenceBucket;
+  /** Known model-scoped quota window IDs, without period suffixes. */
+  windowIds?: string[];
+  /** Human-facing or provider naming aliases, never launch identifiers. */
+  aliases?: string[];
+  notes?: string;
+};
+
+export type ModelCatalog = {
+  /** ISO calendar date for this reviewed catalog snapshot. */
+  version: string;
+  provenance: string;
+  entries: ModelCatalogEntry[];
+};
+
+export type ProviderStateSummary = Pick<
+  ProviderQuota["state"],
+  "status" | "stale" | "authStatus" | "reason" | "remedyCommand"
+>;
+
+export type ModelQuotaRecord = {
+  provider: ModelCatalogEntry["provider"];
+  id: string;
+  label: string;
+  intelligence: IntelligenceBucket;
+  /** The effective availability scope used as evidence for this row. */
+  quotaScopes: string[];
+  /** Omitted when quota relationships are unavailable or unknown. */
+  effective?: EffectiveAvailability;
+  state: ProviderStateSummary;
+};
+
+export type ModelReference = Pick<ModelQuotaRecord, "provider" | "id">;
+
+/** Opt-in ordering keys. Future keys require their own evidence and docs. */
+export type ModelSortKey = "runway";
+
+export type ModelSortResult = {
+  key: ModelSortKey;
+  /** Groups with equal comparator evidence, never hidden behind array order. */
+  tieGroups: ModelReference[][];
+};
+
+export type ModelsResponse = {
+  generatedAt: string;
+  schemaVersion: 1;
+  catalog: Pick<ModelCatalog, "version" | "provenance">;
+  models: ModelQuotaRecord[];
+  /** Provider/model window scopes with no corresponding catalog entry. */
+  unmatchedWindowIds?: string[];
+  /** Present only when an explicit comparator was requested. */
+  sort?: ModelSortResult;
+};

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -577,13 +577,13 @@ describe("CLI plumbing via the axi SDK", () => {
 
   it("prints the top-level help for --help", async () => {
     const output = await capture(["--help"]);
-    expect(output).toContain("usage: quota-axi [auth] [flags]");
+    expect(output).toContain("usage: quota-axi [quota|auth|models] [flags]");
     expect(process.exitCode).toBeUndefined();
   });
 
   it("prints the top-level help for legacy -h", async () => {
     const output = await capture(["auth", "-h"]);
-    expect(output).toContain("usage: quota-axi [auth] [flags]");
+    expect(output).toContain("usage: quota-axi [quota|auth|models] [flags]");
     expect(process.exitCode).toBeUndefined();
   });
 

--- a/test/fixtures/public-contract-consumer.ts
+++ b/test/fixtures/public-contract-consumer.ts
@@ -1,0 +1,31 @@
+import {
+  compareModelsByRunway,
+  type ModelQuotaRecord,
+  type ModelsResponse,
+  type QuotaAxiResponse,
+} from "quota-axi";
+
+const quota: QuotaAxiResponse = {
+  generatedAt: "2026-08-05T12:00:00.000Z",
+  schemaVersion: 3,
+  providers: [],
+};
+
+const model: ModelQuotaRecord = {
+  provider: "claude",
+  id: "consumer-fixture",
+  label: "Consumer fixture",
+  intelligence: "high",
+  quotaScopes: [],
+  state: { status: "fresh", stale: false },
+};
+
+const models: ModelsResponse = {
+  generatedAt: quota.generatedAt,
+  schemaVersion: 1,
+  catalog: { version: "2026-08-05", provenance: "consumer fixture" },
+  models: [model],
+};
+
+void models;
+void compareModelsByRunway(model, model);

--- a/test/models-command.test.ts
+++ b/test/models-command.test.ts
@@ -5,9 +5,19 @@ import { PROVIDERS } from "../src/providers/index.js";
 import type { ProviderAdapter, ProviderQuota } from "../src/types.js";
 
 const originalClaude = PROVIDERS.claude;
+const originalCodex = PROVIDERS.codex;
+const originalCursor = PROVIDERS.cursor;
+const originalCopilot = PROVIDERS.copilot;
+const originalGrok = PROVIDERS.grok;
+const originalKimi = PROVIDERS.kimi;
 
 afterEach(() => {
   PROVIDERS.claude = originalClaude;
+  PROVIDERS.codex = originalCodex;
+  PROVIDERS.cursor = originalCursor;
+  PROVIDERS.copilot = originalCopilot;
+  PROVIDERS.grok = originalGrok;
+  PROVIDERS.kimi = originalKimi;
   process.exitCode = undefined;
 });
 
@@ -97,6 +107,28 @@ describe("models command", () => {
     expect(sort).toContain("Supported sort keys: runway");
     expect(process.exitCode).toBe(2);
   });
+
+  it("fails when every catalog provider fails and rejects non-catalog scopes", async () => {
+    for (const provider of ["claude", "codex", "grok", "kimi"] as const) {
+      PROVIDERS[provider] = adapter(failedQuota(provider));
+    }
+    PROVIDERS.cursor = adapter({
+      provider: "cursor",
+      label: "Cursor",
+      source: "api",
+      windows: [],
+      state: { status: "fresh", stale: false, sourcesTried: ["api"] },
+    });
+
+    const json = JSON.parse(await capture(["models", "--json"]));
+    expect(json.models).toHaveLength(12);
+    expect(process.exitCode).toBe(1);
+
+    process.exitCode = undefined;
+    const unsupported = await capture(["models", "--provider", "cursor"]);
+    expect(unsupported).toContain("models does not support provider: cursor");
+    expect(process.exitCode).toBe(2);
+  });
 });
 
 async function capture(argv: string[]): Promise<string> {
@@ -118,6 +150,22 @@ function adapter(quota: ProviderQuota): ProviderAdapter {
     },
     async inspectAuth() {
       return { provider: quota.provider, sources: [] };
+    },
+  };
+}
+
+function failedQuota(
+  provider: "claude" | "codex" | "grok" | "kimi",
+): ProviderQuota {
+  return {
+    provider,
+    label: provider,
+    source: "unavailable",
+    windows: [],
+    state: {
+      status: "unavailable",
+      stale: false,
+      sourcesTried: ["unavailable"],
     },
   };
 }

--- a/test/models-command.test.ts
+++ b/test/models-command.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { main } from "../src/cli.js";
+import { PROVIDERS } from "../src/providers/index.js";
+import type { ProviderAdapter, ProviderQuota } from "../src/types.js";
+
+const originalClaude = PROVIDERS.claude;
+
+afterEach(() => {
+  PROVIDERS.claude = originalClaude;
+  process.exitCode = undefined;
+});
+
+describe("models command", () => {
+  it("emits filtered JSON model evidence and compact TOON", async () => {
+    PROVIDERS.claude = adapter({
+      provider: "claude",
+      label: "Claude",
+      source: "oauth",
+      windows: [
+        {
+          id: "model:fable",
+          label: "Fable week",
+          kind: "model",
+          percentUsed: 20,
+          percentRemaining: 80,
+        },
+      ],
+      state: { status: "fresh", stale: false, sourcesTried: ["oauth"] },
+    });
+
+    const json = JSON.parse(
+      await capture([
+        "models",
+        "--provider",
+        "claude",
+        "--intelligence",
+        "high",
+        "--json",
+      ]),
+    );
+    expect(json).toMatchObject({
+      schemaVersion: 1,
+      catalog: { version: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/) },
+    });
+    expect(json.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "claude",
+          id: "claude-opus-4-5",
+          intelligence: "high",
+          quotaScopes: ["model:fable"],
+          state: { status: "fresh", stale: false },
+        }),
+      ]),
+    );
+    expect(json.models).toHaveLength(2);
+
+    const sorted = JSON.parse(
+      await capture([
+        "models",
+        "--provider",
+        "claude",
+        "--sort",
+        "runway",
+        "--json",
+      ]),
+    );
+    expect(sorted.sort).toMatchObject({ key: "runway" });
+    expect(sorted.sort.tieGroups).toContainEqual([
+      { provider: "claude", id: "claude-haiku-4-5" },
+      { provider: "claude", id: "claude-opus-4-5" },
+      { provider: "claude", id: "claude-sonnet-4-5" },
+    ]);
+
+    const toon = await capture(["models", "--provider", "claude"]);
+    expect(toon).toContain("models[");
+    expect(toon).toContain("claude-opus-4-5");
+    expect(toon).toContain(
+      "Default model order is deterministic and non-preferential",
+    );
+  });
+
+  it("rejects unsupported model filters and comparators as usage errors", async () => {
+    const intelligence = await capture([
+      "models",
+      "--intelligence",
+      "frontier",
+    ]);
+    expect(intelligence).toContain(
+      "--intelligence requires high, medium, or low",
+    );
+    expect(process.exitCode).toBe(2);
+
+    process.exitCode = undefined;
+    const sort = await capture(["models", "--sort", "cost"]);
+    expect(sort).toContain("Supported sort keys: runway");
+    expect(process.exitCode).toBe(2);
+  });
+});
+
+async function capture(argv: string[]): Promise<string> {
+  const chunks: string[] = [];
+  await main({
+    argv,
+    binPath: "quota-axi",
+    stdout: { write: (chunk) => chunks.push(String(chunk)) },
+  });
+  return chunks.join("");
+}
+
+function adapter(quota: ProviderQuota): ProviderAdapter {
+  return {
+    id: quota.provider,
+    label: quota.label,
+    async fetchQuota() {
+      return quota;
+    },
+    async inspectAuth() {
+      return { provider: quota.provider, sources: [] };
+    },
+  };
+}

--- a/test/models-command.test.ts
+++ b/test/models-command.test.ts
@@ -108,6 +108,36 @@ describe("models command", () => {
     expect(process.exitCode).toBe(2);
   });
 
+  it("fetches repeated provider scopes once and emits distinct unmatched scopes", async () => {
+    let fetches = 0;
+    const quota: ProviderQuota = {
+      provider: "claude",
+      label: "Claude",
+      source: "oauth",
+      windows: [
+        {
+          id: "model:unmapped",
+          label: "Unmapped",
+          kind: "model",
+        },
+      ],
+      state: { status: "fresh", stale: false, sourcesTried: ["oauth"] },
+    };
+    PROVIDERS.claude = {
+      ...adapter(quota),
+      async fetchQuota() {
+        fetches++;
+        return quota;
+      },
+    };
+
+    const json = JSON.parse(
+      await capture(["models", "--provider", "claude,claude", "--json"]),
+    );
+    expect(fetches).toBe(1);
+    expect(json.unmatchedWindowIds).toEqual(["claude/model:unmapped"]);
+  });
+
   it("fails when every catalog provider fails and rejects non-catalog scopes", async () => {
     for (const provider of ["claude", "codex", "grok", "kimi"] as const) {
       PROVIDERS[provider] = adapter(failedQuota(provider));

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+
+import { MODEL_CATALOG } from "../src/model-kb.js";
+import {
+  compareModelsByRunway,
+  createModelsResponse,
+  validateModelCatalog,
+} from "../src/models.js";
+import type {
+  EffectiveRunway,
+  ModelCatalog,
+  ModelQuotaRecord,
+  QuotaAxiResponse,
+} from "../src/types.js";
+
+const generatedAt = "2026-08-05T12:00:00.000Z";
+
+describe("model catalog", () => {
+  it("is a valid native-provider catalog with unique entries and coarse buckets", () => {
+    expect(() => validateModelCatalog(MODEL_CATALOG)).not.toThrow();
+    expect(
+      new Set(MODEL_CATALOG.entries.map((entry) => entry.provider)),
+    ).toEqual(new Set(["claude", "codex", "grok", "kimi"]));
+    expect(
+      new Set(MODEL_CATALOG.entries.map((entry) => entry.intelligence)),
+    ).toEqual(new Set(["high", "medium", "low"]));
+  });
+
+  it("rejects malformed catalog data before it can be joined", () => {
+    const invalid: ModelCatalog = {
+      ...MODEL_CATALOG,
+      version: "not-a-date",
+      entries: [MODEL_CATALOG.entries[0]!, MODEL_CATALOG.entries[0]!],
+    };
+    expect(() => validateModelCatalog(invalid)).toThrow(
+      "model catalog version must be an ISO calendar date",
+    );
+  });
+});
+
+describe("model quota join", () => {
+  it("uses the specific scope when known, falls back to account evidence, and discloses unmapped windows", () => {
+    const response = createModelsResponse(quotaResponse(), {
+      catalog: testCatalog(),
+    });
+
+    expect(
+      response.models.map((model) => `${model.provider}/${model.id}`),
+    ).toEqual(["claude/account-only", "claude/scoped", "codex/codex-model"]);
+    expect(response.models[0]).toMatchObject({
+      quotaScopes: ["all_models"],
+      effective: { scope: "all_models", effectivePercentRemaining: 70 },
+    });
+    expect(response.models[1]).toMatchObject({
+      quotaScopes: ["model:fable"],
+      effective: { scope: "model:fable", effectivePercentRemaining: 30 },
+    });
+    expect(response.models[2]).toMatchObject({
+      quotaScopes: [],
+      state: { status: "stale", stale: true },
+    });
+    expect(response.unmatchedWindowIds).toEqual(["claude/model:unmapped"]);
+  });
+
+  it("filters intelligence without inventing availability for failed providers", () => {
+    const response = createModelsResponse(quotaResponse(), {
+      catalog: testCatalog(),
+      intelligence: "high",
+    });
+
+    expect(response.models).toHaveLength(1);
+    expect(response.models[0]).toMatchObject({
+      id: "scoped",
+      intelligence: "high",
+      quotaScopes: ["model:fable"],
+    });
+  });
+
+  it("sorts runway evidence only and exposes equal evidence as ties", () => {
+    const response = createModelsResponse(quotaResponseWithRunways(), {
+      catalog: testCatalogWithRunways(),
+      sort: "runway",
+    });
+
+    expect(response.models.map((model) => model.id)).toEqual([
+      "longer",
+      "same-a",
+      "same-b",
+      "reset",
+      "empty",
+      "unknown",
+    ]);
+    expect(response.sort).toEqual({
+      key: "runway",
+      tieGroups: [
+        [
+          { provider: "claude", id: "same-a" },
+          { provider: "claude", id: "same-b" },
+        ],
+      ],
+    });
+  });
+
+  it("exports a comparator that treats unknown evidence as last rather than zero", () => {
+    expect(
+      compareModelsByRunway(
+        runwayRecord("unknown"),
+        runwayRecord("finite", 10),
+      ),
+    ).toBeGreaterThan(0);
+  });
+});
+
+function quotaResponse(): QuotaAxiResponse {
+  return {
+    generatedAt,
+    schemaVersion: 3,
+    providers: [
+      {
+        provider: "claude",
+        label: "Claude",
+        source: "oauth",
+        windows: [
+          { id: "five_hour", label: "session", kind: "session" },
+          { id: "model:fable", label: "Fable", kind: "model" },
+          { id: "model:unmapped", label: "Unmapped", kind: "model" },
+        ],
+        quotaSemantics: {
+          status: "known",
+          description: "test",
+          effectiveAvailability: [
+            {
+              scope: "all_models",
+              status: "known",
+              effectivePercentRemaining: 70,
+              boundedBy: ["five_hour"],
+              runway: { status: "through_reset" },
+            },
+            {
+              scope: "model:fable",
+              status: "known",
+              effectivePercentRemaining: 30,
+              boundedBy: ["five_hour", "model:fable"],
+              runway: {
+                status: "projected_exhaustion",
+                usableRunwaySeconds: 100,
+              },
+            },
+          ],
+        },
+        state: { status: "fresh", stale: false, sourcesTried: ["oauth"] },
+      },
+      {
+        provider: "codex",
+        label: "Codex",
+        source: "cache",
+        windows: [],
+        quotaSemantics: {
+          status: "unknown",
+          description: "stale",
+          effectiveAvailability: [],
+        },
+        state: { status: "stale", stale: true, sourcesTried: ["cache"] },
+      },
+    ],
+  };
+}
+
+function testCatalog(): ModelCatalog {
+  return {
+    version: "2026-08-05",
+    provenance: "test catalog",
+    entries: [
+      {
+        provider: "claude",
+        id: "scoped",
+        label: "Scoped",
+        intelligence: "high",
+        windowIds: ["model:fable"],
+      },
+      {
+        provider: "claude",
+        id: "account-only",
+        label: "Account only",
+        intelligence: "medium",
+      },
+      {
+        provider: "codex",
+        id: "codex-model",
+        label: "Codex model",
+        intelligence: "low",
+      },
+    ],
+  };
+}
+
+function testCatalogWithRunways(): ModelCatalog {
+  const records = [
+    ["longer", "high"],
+    ["same-a", "high"],
+    ["same-b", "high"],
+    ["reset", "medium"],
+    ["empty", "medium"],
+    ["unknown", "low"],
+  ] as const;
+  return {
+    version: "2026-08-05",
+    provenance: "test catalog",
+    entries: records.map(([id, intelligence]) => ({
+      provider: "claude",
+      id,
+      label: id,
+      intelligence,
+      windowIds: [`model:${id}`],
+    })),
+  };
+}
+
+function quotaResponseWithRunways(): QuotaAxiResponse {
+  const availability: Array<[string, EffectiveRunway]> = [
+    ["longer", { status: "projected_exhaustion", usableRunwaySeconds: 100 }],
+    ["same-a", { status: "projected_exhaustion", usableRunwaySeconds: 50 }],
+    ["same-b", { status: "projected_exhaustion", usableRunwaySeconds: 50 }],
+    ["reset", { status: "through_reset" }],
+    ["empty", { status: "exhausted_now", usableRunwaySeconds: 0 }],
+    ["unknown", { status: "unknown" }],
+  ];
+  return {
+    generatedAt,
+    schemaVersion: 3,
+    providers: [
+      {
+        provider: "claude",
+        label: "Claude",
+        source: "oauth",
+        windows: availability.map(([id]) => ({
+          id: `model:${id}`,
+          label: id,
+          kind: "model" as const,
+        })),
+        quotaSemantics: {
+          status: "known",
+          description: "test",
+          effectiveAvailability: availability.map(([id, runway]) => ({
+            scope: `model:${id}`,
+            status:
+              runway.status === "unknown"
+                ? ("unknown" as const)
+                : ("known" as const),
+            boundedBy: [`model:${id}`],
+            runway,
+          })),
+        },
+        state: { status: "fresh", stale: false, sourcesTried: ["oauth"] },
+      },
+    ],
+  };
+}
+
+function runwayRecord(
+  kind: "unknown" | "finite",
+  usableRunwaySeconds?: number,
+): ModelQuotaRecord {
+  return {
+    provider: "claude",
+    id: kind,
+    label: kind,
+    intelligence: "high",
+    quotaScopes: ["all_models"],
+    effective:
+      kind === "finite"
+        ? {
+            scope: "all_models",
+            status: "known",
+            boundedBy: [],
+            runway: {
+              status: "projected_exhaustion",
+              usableRunwaySeconds,
+            },
+          }
+        : { scope: "all_models", status: "unknown", boundedBy: [] },
+    state: { status: "fresh", stale: false },
+  };
+}

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -36,6 +36,12 @@ describe("model catalog", () => {
       "model catalog version must be an ISO calendar date",
     );
   });
+
+  it("rejects calendar dates whose day overflows into another month", () => {
+    expect(() =>
+      validateModelCatalog({ ...MODEL_CATALOG, version: "2026-02-31" }),
+    ).toThrow("model catalog version must be an ISO calendar date");
+  });
 });
 
 describe("model quota join", () => {
@@ -123,7 +129,8 @@ function quotaResponse(): QuotaAxiResponse {
         windows: [
           { id: "five_hour", label: "session", kind: "session" },
           { id: "model:fable", label: "Fable", kind: "model" },
-          { id: "model:unmapped", label: "Unmapped", kind: "model" },
+          { id: "model:unmapped:5h", label: "Unmapped 5h", kind: "model" },
+          { id: "model:unmapped:7d", label: "Unmapped 7d", kind: "model" },
         ],
         quotaSemantics: {
           status: "known",

--- a/test/public-contract.test.ts
+++ b/test/public-contract.test.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("published package contract", () => {
+  it("type-checks a consumer against the built package root", () => {
+    const typecheck = spawnSync(
+      process.execPath,
+      [
+        resolve("node_modules/typescript/bin/tsc"),
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "ES2022",
+        "--module",
+        "Node16",
+        "--moduleResolution",
+        "Node16",
+        "test/fixtures/public-contract-consumer.ts",
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+    expect(typecheck.status, `${typecheck.stdout}${typecheck.stderr}`).toBe(0);
+  });
+});


### PR DESCRIPTION
## Intent

Implement quota-axi intelligence-aware dispatch phases 1-3 end to end. Ship a public normalized-schema contract with package exports and type re-exports, README contract documentation, and consumer-shaped behavior/type tests rather than source-text tests. Add a committed TypeScript model knowledge base only for Claude, Codex, Grok, and Kimi, with curated high/medium/low editorial intelligence buckets, validation, a maintainer-only refresh aid, README catalog/sourcing posture, and Artificial Analysis attribution only. Do not republish Artificial Analysis scores, add a runtime AA fetch/dependency, commit AA keys, or add Cursor/Copilot KB rows. Ship quota-axi models with --intelligence high|medium|low and --sort runway, TOON and JSON output, a live quota-to-catalog evidence join, deterministic non-preferential default order, explicit ties for sorted results, and a comparator registry designed for a future cost sort but do not ship cost. Captain decision C+A: the default must remain data-only and non-preferential; opt-in runway ordering must be documented, evidence-preserving, deterministic, never a hidden score or recommendation of a provider, model, harness, credential, or route. Soften matching README and generated skill wording atomically. Reuse existing provider/caching safety contracts and do not route, recommend, proxy, mutate provider state, or add firstmate phase 4 changes.

## What Changed

- Add a `models` command with intelligence filtering, live quota-to-catalog evidence joins, JSON and TOON output, and opt-in deterministic runway sorting with explicit ties.
- Introduce a validated, curated model catalog for Claude, Codex, Grok, and Kimi, plus a maintainer-only refresh aid and documented sourcing posture.
- Publish normalized response types and model utilities through the package root, with README documentation and consumer-facing behavior and type coverage.

## Risk Assessment

✅ Low: The change is well-bounded, satisfies the stated source-level requirements, and the prior review findings are correctly resolved without introducing another substantiated defect.

## Testing

The focused build and model, CLI, and consumer-contract tests passed; built-CLI checks used fresh local Codex quota data to demonstrate JSON and TOON evidence joins, high-intelligence filtering, and explicit runway ties, while a package-root runtime import verified the public exports. This is a CLI-only change, so reviewer-visible command outputs and JSON were captured instead of screenshots; generated build and cache files were removed afterward.

- Evidence: [Live Codex quota-to-catalog join](https://github.com/kunchenguid/quota-axi/blob/048467cfa5b901385c742157bd5b7732be32c95f/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-live.json)
- Evidence: [Runway-sorted TOON with explicit ties](https://github.com/kunchenguid/quota-axi/blob/048467cfa5b901385c742157bd5b7732be32c95f/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-runway.toon)
- Evidence: [High-intelligence filtered model output](https://github.com/kunchenguid/quota-axi/blob/048467cfa5b901385c742157bd5b7732be32c95f/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/models-codex-high.json)
- Evidence: [Built package-root runtime exports](https://github.com/kunchenguid/quota-axi/blob/048467cfa5b901385c742157bd5b7732be32c95f/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/package-root-runtime.json)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `src/models.ts:127` - `Date.parse` normalizes impossible dates such as `2026-02-31`, so the exported validator accepts values that are not ISO calendar dates. Validate by round-tripping the parsed UTC year, month, and day, and add an observable validator regression case.
- ⚠️ `src/models.ts:204` - Codex emits separate 5h and 7d windows for one model, but both IDs are normalized to the same scope and returned twice when that model is absent from the catalog. Deduplicate normalized unmatched scopes while preserving first-seen order so `unmatchedWindowIds` accurately represents distinct scopes.

🔧 Fix: Validate catalog dates and deduplicate unmatched scopes
1 warning still open:
- ⚠️ `src/commands.ts:65` - The default models invocation fetches all six providers, so a fresh Cursor or Copilot result can keep the exit code at 0 even when every catalog-backed provider (Claude, Codex, Grok, and Kimi) failed and no live model quota evidence exists. Scope the success check to providers represented by the model catalog, and decide whether explicitly requesting an unsupported catalog provider should return an empty success or a validation error.

🔧 Fix: Scope models command to catalog-backed providers
1 warning still open:
- ⚠️ `src/models.ts:73` - `--provider claude,claude` fetches Claude twice, and `flatMap` emits the same normalized unmatched scope once per provider report. Deduplicate provider IDs in `parseProviders` before fetching so `unmatchedWindowIds` remains distinct and duplicate network requests are avoided.

🔧 Fix: Deduplicate provider scopes before fetching quotas
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm run build && pnpm exec vitest run test/models.test.ts test/models-command.test.ts test/public-contract.test.ts`
- `XDG_CACHE_HOME="$PWD/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/cache" node dist/bin/quota-axi.js auth --provider claude,codex,grok,kimi --json`
- `XDG_CACHE_HOME="$PWD/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/cache" node dist/bin/quota-axi.js models --provider codex --json`
- `XDG_CACHE_HOME="$PWD/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/cache" node dist/bin/quota-axi.js models --provider codex --sort runway`
- `XDG_CACHE_HOME="$PWD/.no-mistakes/evidence/fm/quota-axi-intelligence-models-ship-r1/cache" node dist/bin/quota-axi.js models --provider codex --intelligence high --json`
- `node --input-type=module -e 'import { createModelsResponse, MODEL_SORT_KEYS } from "quota-axi"; ...'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
