### PR TITLE
fix(pace): treat a missing resetsAt on a zero-use window as not-yet-triggered

### DIFF
--- a/.no-mistakes/evidence/fm/quotaaxi-runway-missing-resetsat-r1/runway-not-yet-triggered.txt
+++ b/.no-mistakes/evidence/fm/quotaaxi-runway-missing-resetsat-r1/runway-not-yet-triggered.txt
@@ -1,0 +1,77 @@
+=== Proof case: Claude five_hour not-yet-triggered (no resetsAt) + healthy seven_day ===
+
+--- effective all_models runway (the bug was: status=unknown, unmeasurableWindowIds=['five_hour']) ---
+{
+  "scope": "all_models",
+  "status": "known",
+  "effectivePercentRemaining": 90,
+  "runway": {
+    "status": "through_reset",
+    "projectionConfidence": "established",
+    "projectionBasis": "cycle_average"
+  }
+}
+
+--- five_hour window pace (unknown/missing_cycle - not started, correct) ---
+{"status":"unknown","reason":"missing_cycle"}
+
+=== Full --json quotaSemantics ===
+{
+  "status": "known",
+  "description": "Claude account windows bound every model. A model-specific window is an additional bound, so that model's effective remaining percentage is the minimum across the named windows.",
+  "effectiveAvailability": [
+    {
+      "scope": "all_models",
+      "status": "known",
+      "effectivePercentRemaining": 90,
+      "boundedBy": [
+        "five_hour",
+        "seven_day"
+      ],
+      "limitingWindowIds": [
+        "seven_day"
+      ],
+      "pace": {
+        "status": "behind",
+        "behindWindowIds": [
+          "seven_day"
+        ],
+        "unknownWindowIds": [
+          "five_hour"
+        ],
+        "worstReservePercentPoints": 40,
+        "worstReserveWindowId": "seven_day"
+      },
+      "runway": {
+        "status": "through_reset",
+        "projectionConfidence": "established",
+        "projectionBasis": "cycle_average"
+      }
+    }
+  ]
+}
+
+=== Human TOON report (renderQuotaToon --full) ===
+bin: quota-axi
+description: Report local agent-provider quota windows for routing-aware agents
+generatedAt: "2026-07-15T12:00:00.000Z"
+providers[1]{provider,plan,source,status,authStatus,refreshedAt}:
+  claude,unknown,api,fresh,unknown,none
+windows[2]{provider,id,label,percentRemaining,resetsAt,pace,state}:
+  claude,five_hour,five_hour,100,unknown,unknown,fresh
+  claude,seven_day,seven_day,90,"2026-07-19T00:00:00.000Z",behind,fresh
+effective[1]{provider,scope,effectivePercentRemaining,boundedBy,limitingWindowIds,runway,usableRunwaySeconds,projectedExhaustedAt,limitingWindowId,projectionConfidence,projectionBasis,unmeasurableWindowIds,unresolvedWindowIds,relationshipStatus}:
+  claude,all_models,90,five_hour + seven_day,seven_day,through_reset,unknown,unknown,unknown,established,cycle_average,none,none,known
+windowPace[2]{provider,id,reserve,burnMultiple,projectedExhaustedAt,projectionConfidence,projectionBasis}:
+  claude,five_hour,unknown,unknown,unknown,unknown,unknown
+  claude,seven_day,40,0.2,"2026-08-16T00:00:00.000Z",established,cycle_average
+effectivePace[1]{provider,scope,pace,aheadWindowIds,unknownWindowIds,worstReserve,worstReserveWindowId}:
+  claude,all_models,behind,none,five_hour,40,seven_day
+accounts[1]{provider,email,organization,accountId,identityStatus}:
+  claude,hidden,none,none,unknown
+attempts[0]:
+help[4]:
+  Default TOON reports effective headroom and usable runway; use --json or --full for reserve diagnostics
+  Run `quota-axi --provider claude --json` for JSON output
+  Run `quota-axi --full` to include account, source-attempt, and reserve details
+  Run `quota-axi auth` to inspect local auth source availability without printing secrets

--- a/README.md
+++ b/README.md
@@ -456,6 +456,8 @@ Each `effectiveAvailability` entry also carries a compact `pace` summary over **
 
 `usableRunwaySeconds` is nonnegative and is present only for finite results. `projectionConfidence` is `early` or `established`; `projectionBasis` is currently `cycle_average`. Zero observed usage with a valid current cycle proves `through_reset` under that same cycle-average basis. Named model or product windows are additional bounds only for their applicable scopes, so they can become the effective limiting window without changing other scopes.
 
+A bounding window with no `resetsAt` at all has not been triggered yet (e.g. a Claude `five_hour` window before its first request this window) rather than being a data gap. When that untriggered window also reports zero usage (100% remaining, 0% used), it is treated as fully available and excluded from `unmeasurableWindowIds`, so it never forces `runway.status: unknown` by itself; the report's other bounding windows still determine the aggregate. Its 100% can still contribute to `effectivePercentRemaining` as a headroom bound. quota-axi never synthesizes a `resetsAt` or starts the countdown client-side. A missing `resetsAt` paired with any other usage shape (unknown usage, or nonzero usage without an active clock) is a real data gap, not "not yet triggered," and still fails closed into `unmeasurableWindowIds` - alongside stale data, missing usage percent, an expired or malformed `resetsAt` that is actually present, and a missing projection when usage is nonzero and the cycle is known.
+
 ### Quota enums
 
 | Name                             | Values                                                                       |

--- a/src/pace.ts
+++ b/src/pace.ts
@@ -120,19 +120,36 @@ export function computeEffectiveRunway(
   for (const window of windows) {
     const remaining = finiteNumber(window.percentRemaining);
     const pace = window.pace;
-    const resetsAtMs = parseTimestamp(window.resetsAt);
+    const resetsAt = resolveResetsAtOutcome(window.resetsAt);
+
+    if (resetsAt.kind === "missing") {
+      // A missing resetsAt is non-bounding only when it also reports no
+      // usage (100% remaining, 0% used) - e.g. a Claude five_hour window
+      // before its first request this window. That shape's countdown has
+      // simply not started yet, so it does not block the aggregate. A
+      // missing resetsAt paired with any other usage shape (unknown usage,
+      // or nonzero usage without an active clock) is a real data gap, not
+      // "not yet triggered", and still fails closed.
+      if (remaining !== undefined && isZeroUse(window, remaining)) {
+        continue;
+      }
+      unmeasurableWindowIds.push(window.id);
+      continue;
+    }
+
     if (
       remaining === undefined ||
       remaining < 0 ||
       remaining > 100 ||
       pace === undefined ||
       pace.status === "unknown" ||
-      resetsAtMs === undefined ||
-      resetsAtMs <= generatedAtMs
+      resetsAt.kind === "malformed" ||
+      resetsAt.ms <= generatedAtMs
     ) {
       unmeasurableWindowIds.push(window.id);
       continue;
     }
+    const resetsAtMs = resetsAt.ms;
 
     if (isZeroUse(window, remaining)) {
       if ((pace.elapsedPercent ?? 0) < PACE_EARLY_ELAPSED_PERCENT) {
@@ -358,6 +375,23 @@ function parseTimestamp(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const ms = Date.parse(value);
   return Number.isFinite(ms) ? ms : undefined;
+}
+
+type ResetsAtOutcome =
+  | { kind: "missing" }
+  | { kind: "malformed" }
+  | { kind: "ok"; ms: number };
+
+/**
+ * Distinguishes a genuinely absent `resetsAt` (the cycle has not been
+ * triggered yet) from a present-but-unparseable one (a real data defect that
+ * claims a reset it cannot honor). Effective runway treats only the former
+ * as non-bounding.
+ */
+function resolveResetsAtOutcome(value: string | undefined): ResetsAtOutcome {
+  if (!value) return { kind: "missing" };
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? { kind: "ok", ms } : { kind: "malformed" };
 }
 
 function finiteNumber(value: number | undefined): number | undefined {

--- a/test/interpretation.test.ts
+++ b/test/interpretation.test.ts
@@ -125,6 +125,41 @@ describe("quota semantics", () => {
     ).toBe(true);
   });
 
+  it("does not block Claude effective runway when five_hour has not been triggered yet (no resetsAt)", () => {
+    const result = withQuotaSemantics(
+      provider("claude", [
+        window("five_hour", "session", 100, {
+          percentUsed: 0,
+          windowSeconds: 18_000,
+          // No resetsAt: the 5h clock has not started (first request not
+          // yet made this window). This must not make runway `unknown`.
+        }),
+        window("seven_day", "weekly", 90, {
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: weeklyResetsAt(0.5),
+        }),
+      ]),
+      GENERATED_AT,
+    );
+
+    const allModels = result.quotaSemantics?.effectiveAvailability.find(
+      (item) => item.scope === "all_models",
+    );
+    expect(allModels?.status).toBe("known");
+    expect(allModels?.effectivePercentRemaining).toBe(90);
+    expect(allModels?.runway?.status).not.toBe("unknown");
+    expect(["through_reset", "projected_exhaustion"]).toContain(
+      allModels?.runway?.status,
+    );
+    expect(allModels?.runway?.unmeasurableWindowIds).toBeUndefined();
+
+    const fiveHour = result.windows.find((item) => item.id === "five_hour");
+    expect(fiveHour?.pace).toEqual({
+      status: "unknown",
+      reason: "missing_cycle",
+    });
+  });
+
   it("surfaces pace on a non-currently-limiting bounding window that is ahead", () => {
     const result = withQuotaSemantics(
       provider("claude", [
@@ -347,6 +382,32 @@ describe("quota semantics", () => {
         },
       ],
       unresolvedWindowIds: ["limit:2"],
+    });
+  });
+
+  it("still fails Claude effective runway closed when a triggered window's reset already expired", () => {
+    const result = withQuotaSemantics(
+      provider("claude", [
+        window("five_hour", "session", 91, {
+          windowSeconds: 18_000,
+          // Present but already in the past: a real, expired reset - unlike
+          // an absent resetsAt this is genuine unmeasurability.
+          resetsAt: new Date(Date.parse(GENERATED_AT) - 1_000).toISOString(),
+        }),
+        window("seven_day", "weekly", 90, {
+          windowSeconds: WEEK_SECONDS,
+          resetsAt: weeklyResetsAt(0.5),
+        }),
+      ]),
+      GENERATED_AT,
+    );
+
+    const allModels = result.quotaSemantics?.effectiveAvailability.find(
+      (item) => item.scope === "all_models",
+    );
+    expect(allModels?.runway).toEqual({
+      status: "unknown",
+      unmeasurableWindowIds: ["five_hour"],
     });
   });
 

--- a/test/pace.test.ts
+++ b/test/pace.test.ts
@@ -462,6 +462,89 @@ describe("computeEffectiveRunway", () => {
     });
   });
 
+  it("treats a not-yet-triggered window (missing resetsAt) as fully available, not unmeasurable", () => {
+    const fiveHour = window({
+      id: "five_hour",
+      kind: "session",
+      percentUsed: 0,
+      percentRemaining: 100,
+      windowSeconds: FIVE_HOURS_SECONDS,
+      // No resetsAt: the clock has not started.
+    });
+    fiveHour.pace = computeWindowPace(fiveHour, GENERATED_AT);
+    expect(fiveHour.pace).toEqual({
+      status: "unknown",
+      reason: "missing_cycle",
+    });
+
+    const sevenDay = pacedWindow("seven_day", 90, 0.5);
+
+    const runway = computeEffectiveRunway([fiveHour, sevenDay], GENERATED_AT);
+    expect(runway.status).not.toBe("unknown");
+    expect(runway.unmeasurableWindowIds).toBeUndefined();
+    expect(["through_reset", "projected_exhaustion"]).toContain(runway.status);
+  });
+
+  it("reports through_reset when every window in scope has not yet triggered", () => {
+    const fiveHour = window({
+      id: "five_hour",
+      kind: "session",
+      percentUsed: 0,
+      percentRemaining: 100,
+      windowSeconds: FIVE_HOURS_SECONDS,
+    });
+    fiveHour.pace = computeWindowPace(fiveHour, GENERATED_AT);
+    const sevenDay = window({
+      id: "seven_day",
+      percentUsed: 0,
+      percentRemaining: 100,
+      windowSeconds: WEEK_SECONDS,
+    });
+    sevenDay.pace = computeWindowPace(sevenDay, GENERATED_AT);
+
+    expect(computeEffectiveRunway([fiveHour, sevenDay], GENERATED_AT)).toEqual({
+      status: "through_reset",
+      projectionConfidence: "established",
+      projectionBasis: "cycle_average",
+    });
+  });
+
+  it("still fails closed when a not-yet-triggered window also lacks usable percentRemaining", () => {
+    const broken = window({
+      id: "five_hour",
+      kind: "session",
+      windowSeconds: FIVE_HOURS_SECONDS,
+      // No resetsAt and no percentRemaining: a genuine data gap, not merely
+      // "not yet triggered".
+    });
+    const sevenDay = pacedWindow("seven_day", 90, 0.5);
+
+    expect(computeEffectiveRunway([broken, sevenDay], GENERATED_AT)).toEqual({
+      status: "unknown",
+      unmeasurableWindowIds: ["five_hour"],
+    });
+  });
+
+  it("fails closed for a malformed resetsAt even at 100% remaining (not merely missing)", () => {
+    const malformed = window({
+      id: "five_hour",
+      kind: "session",
+      percentUsed: 0,
+      percentRemaining: 100,
+      windowSeconds: FIVE_HOURS_SECONDS,
+      resetsAt: "not-a-timestamp",
+    });
+    malformed.pace = computeWindowPace(malformed, GENERATED_AT);
+    const sevenDay = pacedWindow("seven_day", 90, 0.5);
+
+    expect(computeEffectiveRunway([malformed, sevenDay], GENERATED_AT)).toEqual(
+      {
+        status: "unknown",
+        unmeasurableWindowIds: ["five_hour"],
+      },
+    );
+  });
+
   it("keeps early confidence and exact snapshot-clock edges deterministic", () => {
     const early = pacedWindow("weekly", 50, 0.05);
     expect(computeEffectiveRunway([early], GENERATED_AT)).toMatchObject({
@@ -547,6 +630,25 @@ describe("summarizeEffectivePace", () => {
     ).toEqual({
       status: "unknown",
       unknownWindowIds: ["x"],
+    });
+  });
+
+  it("does not let a not-yet-triggered window's unknown pace poison a mixed aggregate", () => {
+    const fiveHour = window({
+      id: "five_hour",
+      pace: { status: "unknown", reason: "missing_cycle" },
+    });
+    const weekly = window({
+      id: "weekly",
+      pace: { status: "on_pace", reservePercentPoints: 0.4 },
+    });
+
+    expect(summarizeEffectivePace([fiveHour, weekly])).toEqual({
+      status: "on_pace",
+      onPaceWindowIds: ["weekly"],
+      unknownWindowIds: ["five_hour"],
+      worstReservePercentPoints: 0.4,
+      worstReserveWindowId: "weekly",
     });
   });
 });


### PR DESCRIPTION
## Intent

quota-axi's effective usable runway (computeEffectiveRunway in src/pace.ts) was incorrectly failing closed on any window with no resetsAt, marking runway status=unknown and adding the window to unmeasurableWindowIds. That is wrong: when a window has no resetsAt, it has not been triggered yet (e.g. Claude five_hour at percentUsed=0/percentRemaining=100 with windowSeconds present but no countdown started) - it is fully available and must not make effective runway unknown.

Required behavior implemented:
1. computeEffectiveRunway now excludes a window whose resetsAt is missing from unmeasurable-blocking, but ONLY when that window also reports zero usage (percentRemaining=100, percentUsed 0/undefined) - the 'not yet triggered' shape. A missing resetsAt paired with any other usage shape (unknown/missing percentRemaining, or nonzero usage without an active clock) is treated as a genuine data gap and still fails closed into unmeasurableWindowIds. This narrower gate (reusing the existing isZeroUse check) was chosen deliberately over an unconditional 'any missing resetsAt is non-bounding' rule, because a window reporting real usage with no clock at all is an anomalous/corrupt shape, not evidence of 'not yet triggered' - and this narrower rule also left every pre-existing test fixture's behavior unchanged (they use nonzero percentUsed with missing resetsAt, which correctly stays unmeasurable).
2. A present-but-unparseable resetsAt (a malformed timestamp that claims a reset) still fails closed - distinguished from a genuinely absent resetsAt via a new resolveResetsAtOutcome helper with missing/malformed/ok outcomes.
3. Kept failing closed for all other real unmeasurability: stale data (unaffected - stale is provider-wide and short-circuits upstream in staleSemantics), missing/out-of-range usage percent, an invalid/expired reset that IS present, and a missing cycle-average projection when usage>0 and the cycle is known.
4. No synthetic resetsAt is ever invented and the 5h clock is never started client-side.
5. The untriggered window's 100% remaining still contributes to effectivePercentRemaining as a headroom bound (unaffected, computed independently in interpretation.ts).
6. summarizeEffectivePace (pace aggregation) was inspected but needed no code change: a window whose pace is unknown only due to missing_cycle from a missing resetsAt never has a reservePercentPoints value, so it already could not poison worstReservePercentPoints/worstReserveWindowId, and the overall aggregate status already isn't forced to unknown when other windows have known pace (aggregatePaceStatus only returns unknown when zero windows have known pace). Added a regression test proving this.

Live proof case implemented as a test: Claude all_models scope with five_hour {percentRemaining:100, percentUsed:0, windowSeconds:18000, no resetsAt} plus a healthy seven_day window now yields runway status through_reset or projected_exhaustion from the week alone, never unmeasurableWindowIds:['five_hour'] for a missing cycle alone (see test/interpretation.test.ts and test/pace.test.ts).

Tests added: unit coverage in test/pace.test.ts (not-yet-triggered window is non-blocking; all-windows-untriggered still resolves through_reset; negative controls - missing resetsAt AND missing percentRemaining still fails closed; malformed (non-empty, unparseable) resetsAt still fails closed even at 100% remaining; summarizeEffectivePace aggregate not poisoned) and an integration proof plus a negative control (expired-but-present resetsAt still fails closed) in test/interpretation.test.ts. Full pnpm test/lint/format:check/build/build:skill --check all pass locally, including every pre-existing fixture-based test unchanged.

README.md "Effective usable runway" section updated with a new paragraph documenting this contract (missing resetsAt = not yet triggered only when usage is zero; any other missing-resetsAt shape or a malformed-but-present resetsAt still fails closed). Generated skill/TOON help text did not need changes since it only makes the already-still-true claim that unknown runway names unmeasurable bounds - it never claimed a bare missing resetsAt alone was unmeasurable.

This is a public, data-only CLI (quota-axi never routes, recommends, proxies, or mutates provider state) - the change is evidence-shape-only.

## What Changed

- `computeEffectiveRunway` in `src/pace.ts` no longer fails effective runway closed to `status=unknown` for a window that has zero usage (`percentRemaining=100`, `percentUsed` 0/undefined) but no `resetsAt`; that "not yet triggered" shape is now excluded from `unmeasurableWindowIds`, while any other missing-`resetsAt` shape (unknown/missing `percentRemaining`, or nonzero usage without a clock) still fails closed.
- Added a `resolveResetsAtOutcome` helper distinguishing missing / malformed / ok, so a present-but-unparseable `resetsAt` still fails closed even at 100% remaining, and no synthetic reset is ever invented.
- Documented the contract in README.md's "Effective usable runway" section and added regression coverage in `test/pace.test.ts` and `test/interpretation.test.ts` (not-yet-triggered non-blocking, all-untriggered resolving through the healthy week, and negative controls for missing `percentRemaining`, malformed `resetsAt`, and expired-but-present `resetsAt`).

## Risk Assessment

✅ Low: A tightly-scoped, evidence-shape-only change to one runway helper that fully satisfies every required intent constraint, preserves all prior fail-closed paths, and is covered by behavior-based tests with explicit negative controls.

## Testing

Baseline build plus the two targeted suites (`test/pace.test.ts`, `test/interpretation.test.ts`, 32 tests) pass. A pre-fix regression run proves the new tests fail against base and pass after the fix, while the fail-closed negative controls (missing percentRemaining, malformed resetsAt, expired-present resetsAt) hold in both states. The end-user output artifact shows the proof case now yields effective `all_models` runway `through_reset` with `unmeasurableWindowIds: none`, the five_hour pace correctly `unknown/missing_cycle` without poisoning the aggregate, and effectivePercentRemaining=90 from the week alone - exactly the intended behavior. This is a data-only CLI with no UI surface, so the reviewer-visible evidence is the rendered JSON/TOON output model rather than a screenshot.

<details>
<summary>Evidence: Proof-case runway output (JSON quotaSemantics + human TOON report)</summary>

Source: [Proof-case runway output (JSON quotaSemantics + human TOON report)](https://github.com/kunchenguid/quota-axi/blob/ab9e49e469a34448a9e20a5683ab1ae1ad8b6c09/.no-mistakes/evidence/fm/quotaaxi-runway-missing-resetsat-r1/runway-not-yet-triggered.txt)

```text
effective all_models runway (was unknown/unmeasurableWindowIds:[five_hour] before fix):
{
"status": "through_reset",
"projectionConfidence": "established",
"projectionBasis": "cycle_average"
}
five_hour pace: {"status":"unknown","reason":"missing_cycle"}
TOON effective row: claude,all_models,90,five_hour + seven_day,seven_day,through_reset,...,unmeasurableWindowIds=none
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"ab9e49e469a34448a9e20a5683ab1ae1ad8b6c09","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm run build &amp;&amp; pnpm exec vitest run test/pace.test.ts test/interpretation.test.ts` - 32 pass (19 pace + 13 interpretation), including the new not-yet-triggered, all-untriggered, malformed-resetsAt, missing-percentRemaining, expired-present-resetsAt, and summarizeEffectivePace aggregate cases</code>
- <code>Regression check: reverted `src/pace.ts` to base commit 1ee328a, rebuilt, and reran the two suites - the 3 new behavioral tests fail pre-fix (`computeEffectiveRunway` returns `{status:&#39;unknown&#39;, unmeasurableWindowIds:[&#39;five_hour&#39;]}`) and the negative-control tests still pass, confirming the fix is what changes behavior; restored the fixed file and rebuilt</code>
- <code>Manual end-user artifact: ran the exact proof-case Claude report (five_hour 100% remaining/0 used, windowSeconds present, no resetsAt + healthy seven_day at 90%) through the real `withQuotaSemantics` + `renderQuotaToon` render path to produce the actual `--json` quotaSemantics and human TOON report a user would see</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
