### PR TITLE
Add agy (Antigravity) + cline providers with live daily-quota adapters + Gemini 3.7 Flash

### DIFF
--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -106,11 +106,12 @@ commands[3]:
 output:
   Default TOON reports local quota evidence. models is a deterministic data join; --sort runway is explicit opt-in ordering. --tui renders a live human terminal report instead (q quits).
 flags[11]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,kimi,agy,cline>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
   quota-axi --provider cursor,copilot,grok,kimi
+  quota-axi --provider agy,cline
   quota-axi --json
   quota-axi --full
   quota-axi --tui

--- a/src/args.ts
+++ b/src/args.ts
@@ -58,7 +58,7 @@ export function parseModelsFlags(args: string[]): ModelsFlags {
     throw new AxiError(
       `models does not support provider: ${unsupported}`,
       "VALIDATION_ERROR",
-      ["Supported model providers: claude, codex, grok, kimi"],
+      ["Supported model providers: claude, codex, grok, kimi, agy"],
     );
   }
   return flags;
@@ -240,7 +240,9 @@ function parseProviderScope(value: string | undefined): ProviderId[] {
     throw new AxiError(
       error instanceof Error ? error.message : "unsupported provider",
       "VALIDATION_ERROR",
-      ["Supported providers: claude, codex, cursor, copilot, grok, kimi"],
+      [
+        "Supported providers: claude, codex, cursor, copilot, grok, kimi, agy, cline",
+      ],
     );
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,11 +16,12 @@ commands[3]:
 output:
   Default TOON reports local quota evidence. models is a deterministic data join; --sort runway is explicit opt-in ordering. --tui renders a live human terminal report instead (q quits).
 flags[11]:
-  --provider <claude,codex,cursor,copilot,grok,kimi>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,kimi,agy,cline>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude
   quota-axi --provider cursor,copilot,grok,kimi
+  quota-axi --provider agy,cline
   quota-axi --json
   quota-axi --full
   quota-axi --tui

--- a/src/interpretation.ts
+++ b/src/interpretation.ts
@@ -91,6 +91,8 @@ function semanticsFor(
     case "cursor":
       return cursorSemantics(provider.windows, generatedAt);
     case "copilot":
+    case "agy":
+    case "cline":
       return unknownSemantics(
         provider.windows,
         `quota-axi does not know whether ${provider.label}'s reported windows are independent or jointly bounding, so it does not claim an effective remaining percentage.`,

--- a/src/model-kb.ts
+++ b/src/model-kb.ts
@@ -96,5 +96,12 @@ export const MODEL_CATALOG: ModelCatalog = {
       label: "Kimi K1.5",
       intelligence: "low",
     },
+    {
+      provider: "agy",
+      id: "gemini-3.7-flash",
+      label: "Gemini 3.7 Flash",
+      intelligence: "medium",
+      aliases: ["gemini-flash-latest"],
+    },
   ],
 };

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -1,33 +1,48 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { readCachedProvider } from "../cache.js";
 import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import { clampPercent, nowIso, retryAfterToIso } from "../lib/time.js";
 import type {
   AuthProviderReport,
   AuthSourceReport,
   ProviderAdapter,
   ProviderOptions,
   ProviderQuota,
+  ProviderSource,
+  QuotaWindow,
   SourceAttempt,
 } from "../types.js";
-import { failedProvider, statusFromError } from "./common.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+} from "./common.js";
 
-// TODO(phase-2): wire Antigravity/Gemini usage endpoint. Phase 1 only detects
-// the oauth token and reports auth status; no usage windows are fetched yet.
+// Antigravity (Google Code Assist) exposes a per-model daily request quota
+// through the cloudcode-pa endpoint. Each bucket carries a remainingFraction
+// (0..1) and a resetTime, so agy reports one real-percent window per model.
+const QUOTA_URL =
+  "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
+const API_TIMEOUT_MS = 15_000;
+const RESPONSE_LIMIT_BYTES = 256 * 1024;
 
 const AUTH_SOURCE = "antigravity-oauth-token";
-
-type AgyCredentials = {
-  token: string;
-  authMethod?: string;
-};
+const AGY_SOURCE: ProviderSource = "oauth";
+const AGY_SIGN_IN_REQUIRED_ERROR = "Antigravity sign-in required";
+const AGY_ACCESS_TOKEN_EXPIRED_ERROR = "Antigravity access token expired";
+const AGY_QUOTA_UNAVAILABLE_ERROR = "Antigravity quota unavailable";
 
 type CredentialState =
-  | {
-      status: "available";
-      credentials: AgyCredentials;
-      source: AuthSourceReport;
-    }
+  | { status: "available"; token: string; source: AuthSourceReport }
   | { status: "missing" | "invalid" | "expired"; source: AuthSourceReport };
+
+type NormalizedAgyQuota = {
+  windows: QuotaWindow[];
+  refreshedAt: string;
+};
 
 export const agyAdapter: ProviderAdapter = {
   id: "agy",
@@ -41,47 +56,69 @@ export async function fetchQuota(
 ): Promise<ProviderQuota> {
   const state = readCredentialState();
 
-  if (state.status === "available") {
-    // TODO(phase-2): replace this stub with a real usage-window fetch.
-    const attempts: SourceAttempt[] = [
-      {
-        source: AUTH_SOURCE,
-        status: "skipped",
-        error: "phase_2_pending",
-        credentialPresent: true,
-      },
-    ];
+  if (state.status !== "available") {
+    const error =
+      state.status === "expired"
+        ? AGY_ACCESS_TOKEN_EXPIRED_ERROR
+        : AGY_SIGN_IN_REQUIRED_ERROR;
     return failedProvider({
       provider: "agy",
       label: "Antigravity",
-      status: "unavailable",
-      source: "oauth",
-      error: "agy usage endpoint not yet implemented (phase 2)",
-      sourcesTried: [AUTH_SOURCE],
-      attempts,
+      status: statusFromError(error),
+      error,
+      source: AGY_SOURCE,
+      sourcesTried: [state.source.source],
+      attempts: [
+        {
+          source: state.source.source,
+          status: "skipped",
+          error: `credentials_${state.status}`,
+          credentialPresent: false,
+        },
+      ],
     });
   }
 
-  const error =
-    state.status === "expired"
-      ? "Antigravity access token expired"
-      : "Antigravity sign-in required";
-  const attempts: SourceAttempt[] = [
-    {
-      source: AUTH_SOURCE,
-      status: "skipped",
-      error: `credentials_${state.status}`,
-      credentialPresent: false,
-    },
-  ];
-  return failedProvider({
-    provider: "agy",
-    label: "Antigravity",
-    status: statusFromError(error),
-    error,
-    sourcesTried: [AUTH_SOURCE],
-    attempts,
-  });
+  const attempts: SourceAttempt[] = [{ source: "api", status: "failed" }];
+
+  try {
+    const quota = await fetchAgyQuota(state.token);
+    attempts[attempts.length - 1] = { source: "api", status: "success" };
+    return successProvider({
+      provider: "agy",
+      label: "Antigravity",
+      source: AGY_SOURCE,
+      windows: quota.windows,
+      refreshedAt: quota.refreshedAt,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  } catch (error) {
+    const finalError = errorMessage(error);
+    const retryAfter =
+      error instanceof RateLimitError ? error.retryAfter : undefined;
+    attempts[attempts.length - 1] = {
+      source: "api",
+      status: "failed",
+      error: finalError,
+    };
+
+    const cached = readCachedProvider("agy");
+    if (cached) {
+      return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+    }
+
+    return failedProvider({
+      provider: "agy",
+      label: "Antigravity",
+      status: retryAfter ? "rate_limited" : statusFromError(finalError),
+      error: finalError,
+      retryAfter,
+      source: AGY_SOURCE,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  }
 }
 
 export async function inspectAuth(
@@ -89,6 +126,124 @@ export async function inspectAuth(
 ): Promise<AuthProviderReport> {
   const state = readCredentialState();
   return { provider: "agy", sources: [state.source] };
+}
+
+/**
+ * One QuotaWindow per model bucket. `remainingFraction` (0..1) is real percent
+ * data, so each window carries percentRemaining/percentUsed and the bucket's
+ * resetTime. tokenType REQUESTS maps to the model-scoped window kind.
+ */
+export async function fetchAgyQuota(token: string): Promise<NormalizedAgyQuota> {
+  const payload = objectValue(await retrieveUserQuota(token));
+  const buckets = Array.isArray(payload?.buckets) ? payload.buckets : [];
+
+  const windows: QuotaWindow[] = [];
+  for (const raw of buckets) {
+    const bucket = objectValue(raw);
+    const modelId = stringValue(bucket?.modelId);
+    if (!modelId) continue;
+    const fraction = numberValue(bucket?.remainingFraction);
+    const percentRemaining =
+      fraction === undefined ? undefined : clampPercent(fraction * 100);
+    const resetsAt = stringValue(bucket?.resetTime);
+    windows.push({
+      id: modelId,
+      label: modelId,
+      kind: "model",
+      ...(percentRemaining !== undefined
+        ? {
+            percentRemaining,
+            percentUsed: clampPercent(100 - percentRemaining),
+          }
+        : {}),
+      ...(resetsAt ? { resetsAt } : {}),
+    });
+  }
+
+  if (windows.length === 0)
+    throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+
+  return { windows, refreshedAt: nowIso() };
+}
+
+async function retrieveUserQuota(token: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    let response: Response;
+    try {
+      response = await fetch(QUOTA_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        body: "{}",
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (isAbortError(error) || controller.signal.aborted)
+        throw new SafeAgyError("Antigravity quota request timed out");
+      throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+    }
+    rejectUnusableResponse(response);
+    return await readBoundedJson(response);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function rejectUnusableResponse(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new SafeAgyError(AGY_SIGN_IN_REQUIRED_ERROR);
+  }
+  if (response.status === 429) {
+    throw new RateLimitError(retryAfterToIso(response.headers.get("retry-after")));
+  }
+  if (!response.ok) throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const contentLength = response.headers.get("content-length");
+  if (
+    contentLength &&
+    /^\d+$/.test(contentLength) &&
+    Number(contentLength) > RESPONSE_LIMIT_BYTES
+  ) {
+    throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+  }
+  if (!response.body) throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.length;
+      if (length > RESPONSE_LIMIT_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new SafeAgyError(AGY_QUOTA_UNAVAILABLE_ERROR);
+  }
 }
 
 function readCredentialState(path = agyTokenFile()): CredentialState {
@@ -107,17 +262,13 @@ function extractCredentialState(
       source: authSource(path, "invalid", raw.error),
     };
   const data = objectValue(raw.value);
-  // Shape is {token, auth_method}. `token` may be a bare string or a nested
-  // OAuth object ({access_token, refresh_token, expiry, ...}); both count as a
-  // present credential.
-  const tokenString = stringValue(data?.token);
-  const tokenObject = objectValue(data?.token);
-  const hasToken = Boolean(tokenString ?? tokenObject);
-  if (!data || !hasToken)
+  const token = accessTokenFrom(data);
+  if (!data || !token)
     return { status: "invalid", source: authSource(path, "invalid") };
 
-  // Only treat the credential as expired when an expiry is actually exposed —
-  // either at the top level or inside the nested token object.
+  // Treat the credential as expired only when an expiry is actually exposed —
+  // at the top level or inside the nested token object.
+  const tokenObject = objectValue(data.token);
   const expiresAt =
     stringValue(data.expires_at) ??
     stringValue(data.expiresAt) ??
@@ -125,19 +276,43 @@ function extractCredentialState(
     stringValue(tokenObject?.expires_at) ??
     stringValue(tokenObject?.expiresAt);
   if (isExpired(expiresAt))
-    return {
-      status: "expired",
-      source: authSource(path, "expired"),
-    };
+    return { status: "expired", source: authSource(path, "expired") };
 
   return {
     status: "available",
-    credentials: {
-      token: tokenString ?? "present",
-      authMethod: stringValue(data.auth_method),
-    },
+    token,
     source: authSource(path, "available"),
   };
+}
+
+/**
+ * The access token lives at `token.access_token`. `token` may instead be a
+ * bare string, or expose `accessToken`/`id_token`; as a last resort accept any
+ * long string field. auth_method is "consumer".
+ */
+function accessTokenFrom(data: Record<string, unknown> | undefined):
+  | string
+  | undefined {
+  if (!data) return undefined;
+  const tokenString = stringValue(data.token);
+  if (tokenString) return tokenString;
+  const tokenObject = objectValue(data.token);
+  if (!tokenObject) return undefined;
+  return (
+    stringValue(tokenObject.access_token) ??
+    stringValue(tokenObject.accessToken) ??
+    stringValue(tokenObject.id_token) ??
+    firstLongStringField(tokenObject)
+  );
+}
+
+function firstLongStringField(
+  object: Record<string, unknown>,
+): string | undefined {
+  for (const value of Object.values(object)) {
+    if (typeof value === "string" && value.length > 40) return value;
+  }
+  return undefined;
 }
 
 function agyTokenFile(): string {
@@ -176,4 +351,31 @@ function objectValue(value: unknown): Record<string, unknown> | undefined {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof SafeAgyError
+    ? error.message
+    : AGY_QUOTA_UNAVAILABLE_ERROR;
+}
+
+class SafeAgyError extends Error {}
+
+class RateLimitError extends SafeAgyError {
+  constructor(readonly retryAfter?: string) {
+    super("Antigravity quota endpoint rate limited");
+  }
 }

--- a/src/providers/agy.ts
+++ b/src/providers/agy.ts
@@ -1,0 +1,179 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  SourceAttempt,
+} from "../types.js";
+import { failedProvider, statusFromError } from "./common.js";
+
+// TODO(phase-2): wire Antigravity/Gemini usage endpoint. Phase 1 only detects
+// the oauth token and reports auth status; no usage windows are fetched yet.
+
+const AUTH_SOURCE = "antigravity-oauth-token";
+
+type AgyCredentials = {
+  token: string;
+  authMethod?: string;
+};
+
+type CredentialState =
+  | {
+      status: "available";
+      credentials: AgyCredentials;
+      source: AuthSourceReport;
+    }
+  | { status: "missing" | "invalid" | "expired"; source: AuthSourceReport };
+
+export const agyAdapter: ProviderAdapter = {
+  id: "agy",
+  label: "Antigravity",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  const state = readCredentialState();
+
+  if (state.status === "available") {
+    // TODO(phase-2): replace this stub with a real usage-window fetch.
+    const attempts: SourceAttempt[] = [
+      {
+        source: AUTH_SOURCE,
+        status: "skipped",
+        error: "phase_2_pending",
+        credentialPresent: true,
+      },
+    ];
+    return failedProvider({
+      provider: "agy",
+      label: "Antigravity",
+      status: "unavailable",
+      source: "oauth",
+      error: "agy usage endpoint not yet implemented (phase 2)",
+      sourcesTried: [AUTH_SOURCE],
+      attempts,
+    });
+  }
+
+  const error =
+    state.status === "expired"
+      ? "Antigravity access token expired"
+      : "Antigravity sign-in required";
+  const attempts: SourceAttempt[] = [
+    {
+      source: AUTH_SOURCE,
+      status: "skipped",
+      error: `credentials_${state.status}`,
+      credentialPresent: false,
+    },
+  ];
+  return failedProvider({
+    provider: "agy",
+    label: "Antigravity",
+    status: statusFromError(error),
+    error,
+    sourcesTried: [AUTH_SOURCE],
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const state = readCredentialState();
+  return { provider: "agy", sources: [state.source] };
+}
+
+function readCredentialState(path = agyTokenFile()): CredentialState {
+  return extractCredentialState(readJsonFileResult(path), path);
+}
+
+function extractCredentialState(
+  raw: JsonFileReadResult,
+  path: string,
+): CredentialState {
+  if (raw.status === "missing")
+    return { status: "missing", source: authSource(path, "missing") };
+  if (raw.status === "invalid")
+    return {
+      status: "invalid",
+      source: authSource(path, "invalid", raw.error),
+    };
+  const data = objectValue(raw.value);
+  // Shape is {token, auth_method}. `token` may be a bare string or a nested
+  // OAuth object ({access_token, refresh_token, expiry, ...}); both count as a
+  // present credential.
+  const tokenString = stringValue(data?.token);
+  const tokenObject = objectValue(data?.token);
+  const hasToken = Boolean(tokenString ?? tokenObject);
+  if (!data || !hasToken)
+    return { status: "invalid", source: authSource(path, "invalid") };
+
+  // Only treat the credential as expired when an expiry is actually exposed —
+  // either at the top level or inside the nested token object.
+  const expiresAt =
+    stringValue(data.expires_at) ??
+    stringValue(data.expiresAt) ??
+    stringValue(tokenObject?.expiry) ??
+    stringValue(tokenObject?.expires_at) ??
+    stringValue(tokenObject?.expiresAt);
+  if (isExpired(expiresAt))
+    return {
+      status: "expired",
+      source: authSource(path, "expired"),
+    };
+
+  return {
+    status: "available",
+    credentials: {
+      token: tokenString ?? "present",
+      authMethod: stringValue(data.auth_method),
+    },
+    source: authSource(path, "available"),
+  };
+}
+
+function agyTokenFile(): string {
+  return (
+    stringValue(process.env.AGY_OAUTH_TOKEN) ??
+    stringValue(process.env.ANTIGRAVITY_OAUTH_TOKEN) ??
+    join(homedir(), ".gemini", "antigravity-cli", "antigravity-oauth-token")
+  );
+}
+
+function authSource(
+  path: string,
+  status: AuthSourceReport["status"],
+  error?: string,
+): AuthSourceReport {
+  return {
+    source: AUTH_SOURCE,
+    path,
+    status,
+    ...(error ? { error } : {}),
+    credentialPresent: status === "available",
+  };
+}
+
+function isExpired(expiresAt: string | undefined): boolean {
+  if (!expiresAt) return false;
+  const time = Date.parse(expiresAt);
+  return Number.isFinite(time) && time <= Date.now();
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/providers/cline.ts
+++ b/src/providers/cline.ts
@@ -1,26 +1,49 @@
-import { statSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { readJsonFileResult } from "../lib/fs.js";
+import { readCachedProvider } from "../cache.js";
+import { readJsonFileResult, type JsonFileReadResult } from "../lib/fs.js";
+import { nowIso, retryAfterToIso } from "../lib/time.js";
 import type {
   AuthProviderReport,
   AuthSourceReport,
   ProviderAdapter,
   ProviderOptions,
   ProviderQuota,
+  ProviderSource,
+  QuotaWindow,
   SourceAttempt,
 } from "../types.js";
-import { failedProvider, statusFromError } from "./common.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+} from "./common.js";
 
-// TODO(phase-2): wire cline daily-free + daily-subscription usage windows
-// (app.cline.bot account usage). Phase 1 only detects a local config/token
-// file and reports auth status; no usage windows are fetched yet.
+// Cline (app.cline.bot) exposes a daily-resetting credit balance through its
+// public API. Phase 2 reads the local Bearer token, resolves the account's
+// organization, and reports the absolute remaining daily credit balance.
+const API_BASE = "https://api.cline.bot/api/v1";
+const API_TIMEOUT_MS = 15_000;
+const RESPONSE_LIMIT_BYTES = 256 * 1024;
 
-const AUTH_SOURCE = "cline-config";
+const PROVIDERS_JSON_SOURCE = "cline-providers-json";
+const API_KEY_SOURCE = "cline-api-key";
+const CLINE_SOURCE: ProviderSource = "api";
+const CLINE_SIGN_IN_REQUIRED_ERROR = "Cline sign-in required";
+const CLINE_QUOTA_UNAVAILABLE_ERROR = "Cline quota unavailable";
 
 type CredentialState =
-  | { status: "available"; source: AuthSourceReport }
+  | { status: "available"; token: string; source: AuthSourceReport }
   | { status: "missing" | "invalid"; source: AuthSourceReport };
+
+type NormalizedClineQuota = {
+  account?: ProviderQuota["account"];
+  windows: QuotaWindow[];
+  credits: ProviderQuota["credits"];
+  refreshedAt: string;
+};
 
 export const clineAdapter: ProviderAdapter = {
   id: "cline",
@@ -34,44 +57,66 @@ export async function fetchQuota(
 ): Promise<ProviderQuota> {
   const state = readCredentialState();
 
-  if (state.status === "available") {
-    // TODO(phase-2): replace this stub with a real usage-window fetch.
-    const attempts: SourceAttempt[] = [
-      {
-        source: AUTH_SOURCE,
-        status: "skipped",
-        error: "phase_2_pending",
-        credentialPresent: true,
-      },
-    ];
+  if (state.status !== "available") {
     return failedProvider({
       provider: "cline",
       label: "Cline",
-      status: "unavailable",
-      source: "web",
-      error: "cline usage endpoint not yet implemented (phase 2)",
-      sourcesTried: [AUTH_SOURCE],
-      attempts,
+      status: statusFromError(CLINE_SIGN_IN_REQUIRED_ERROR),
+      error: CLINE_SIGN_IN_REQUIRED_ERROR,
+      sourcesTried: [state.source.source],
+      attempts: [
+        {
+          source: state.source.source,
+          status: "skipped",
+          error: `credentials_${state.status}`,
+          credentialPresent: false,
+        },
+      ],
     });
   }
 
-  const error = "Cline sign-in required";
-  const attempts: SourceAttempt[] = [
-    {
-      source: AUTH_SOURCE,
-      status: "skipped",
-      error: `credentials_${state.status}`,
-      credentialPresent: false,
-    },
-  ];
-  return failedProvider({
-    provider: "cline",
-    label: "Cline",
-    status: statusFromError(error),
-    error,
-    sourcesTried: [AUTH_SOURCE],
-    attempts,
-  });
+  const attempts: SourceAttempt[] = [{ source: "api", status: "failed" }];
+
+  try {
+    const quota = await fetchClineQuota(state.token);
+    attempts[attempts.length - 1] = { source: "api", status: "success" };
+    return successProvider({
+      provider: "cline",
+      label: "Cline",
+      source: CLINE_SOURCE,
+      ...(quota.account ? { account: quota.account } : {}),
+      windows: quota.windows,
+      credits: quota.credits,
+      refreshedAt: quota.refreshedAt,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  } catch (error) {
+    const finalError = errorMessage(error);
+    const retryAfter =
+      error instanceof RateLimitError ? error.retryAfter : undefined;
+    attempts[attempts.length - 1] = {
+      source: "api",
+      status: "failed",
+      error: finalError,
+    };
+
+    const cached = readCachedProvider("cline");
+    if (cached) {
+      return staleFromCache(cached, finalError, sourceNames(attempts), attempts);
+    }
+
+    return failedProvider({
+      provider: "cline",
+      label: "Cline",
+      status: retryAfter ? "rate_limited" : statusFromError(finalError),
+      error: finalError,
+      retryAfter,
+      source: CLINE_SOURCE,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  }
 }
 
 export async function inspectAuth(
@@ -81,127 +126,210 @@ export async function inspectAuth(
   return { provider: "cline", sources: [state.source] };
 }
 
-type Candidate = { path: string; explicit: boolean };
+/**
+ * Resolve the account's organization, then read its daily credit balance.
+ * `balance` is an absolute integer credit count that resets daily, so it is
+ * reported through `credits` (like a prepaid balance) plus a percent-less
+ * `daily_credits` window carrying the next UTC-midnight reset. No daily maximum
+ * is exposed, so no percentage is fabricated.
+ */
+export async function fetchClineQuota(
+  token: string,
+): Promise<NormalizedClineQuota> {
+  const me = objectValue(await clineGet("/users/me", token));
+  const meData = objectValue(me?.data);
+  const organizations = Array.isArray(meData?.organizations)
+    ? meData.organizations
+    : [];
+  const organization = objectValue(organizations[0]);
+  const organizationId = stringValue(organization?.organizationId);
+  if (!organizationId) throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
 
-// Field names that identify a file as an actual Cline (app.cline.bot)
-// credential/config rather than an unrelated file that happens to sit at
-// ~/.cline (a name other tools also use).
-const CLINE_AUTH_KEYS = [
-  "token",
-  "apiKey",
-  "api_key",
-  "apiToken",
-  "accessToken",
-  "access_token",
-  "authToken",
-  "auth_token",
-  "clineApiKey",
-  "clineAccountId",
-  "clineAccountUserId",
-  "credentials",
-  "sessionToken",
-  "userInfo",
-];
+  const balancePayload = objectValue(
+    await clineGet(
+      `/organizations/${encodeURIComponent(organizationId)}/balance`,
+      token,
+    ),
+  );
+  const balance = numberValue(objectValue(balancePayload?.data)?.balance);
+  if (balance === undefined) throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
 
-function readCredentialState(
-  candidates = clineConfigCandidates(),
-): CredentialState {
-  // Probe candidate config/token files in priority order. A directory is
-  // skipped (some tools use ~/.cline as a directory). An explicit env override
-  // is authoritative: a parseable file there is available, an unparseable one
-  // is invalid. Discovered (non-explicit) files must actually look like Cline
-  // auth to count — this avoids false positives from unrelated JSON that
-  // happens to share the path. If nothing matches, report missing cleanly.
-  for (const { path, explicit } of candidates) {
-    let stat;
-    try {
-      stat = statSync(path);
-    } catch {
-      continue; // missing
-    }
-    if (!stat.isFile()) continue; // skip directories
-    const raw = readJsonFileResult(path);
-    if (raw.status === "missing") continue;
-    if (raw.status === "invalid") {
-      if (explicit)
-        return {
-          status: "invalid",
-          source: authSource(path, "invalid", raw.error),
-        };
-      continue; // corrupt/unrelated non-Cline file — keep looking
-    }
-    if (explicit || looksLikeClineAuth(raw.value))
-      return { status: "available", source: authSource(path, "available") };
-    // Parseable but not recognizable as Cline auth — keep looking.
-  }
-  const primary = candidates[0]?.path ?? join(homedir(), ".cline", "auth.json");
-  return { status: "missing", source: authSource(primary, "missing") };
-}
+  const email = stringValue(meData?.email);
+  const organizationName = stringValue(organization?.name);
+  const account =
+    email || organizationName
+      ? {
+          ...(email ? { email } : {}),
+          ...(organizationName ? { organization: organizationName } : {}),
+        }
+      : undefined;
 
-function looksLikeClineAuth(value: unknown): boolean {
-  const data = objectValue(value);
-  if (!data) return false;
-  return CLINE_AUTH_KEYS.some((key) => key in data);
-}
-
-function clineConfigCandidates(): Candidate[] {
-  const home = homedir();
-  const candidates: Candidate[] = [];
-
-  const envConfig = stringValue(process.env.CLINE_CONFIG);
-  if (envConfig) candidates.push({ path: envConfig, explicit: true });
-  const envAuth = stringValue(process.env.CLINE_AUTH);
-  if (envAuth) candidates.push({ path: envAuth, explicit: true });
-
-  // Dedicated dotfile locations.
-  for (const path of [
-    join(home, ".cline", "auth.json"),
-    join(home, ".cline", "config.json"),
-    join(home, ".config", "cline", "auth.json"),
-    join(home, ".config", "cline", "config.json"),
-  ]) {
-    candidates.push({ path, explicit: false });
-  }
-
-  // VS Code (and forks) globalStorage for the Cline / Claude Dev extension.
-  const extensionIds = ["saoudrizwan.claude-dev", "cline.cline"];
-  const configFiles = [
-    "auth.json",
-    "config.json",
-    join("settings", "cline_mcp_settings.json"),
+  const windows: QuotaWindow[] = [
+    {
+      id: "daily_credits",
+      label: "daily credits",
+      kind: "credits",
+      resetsAt: nextUtcMidnightIso(),
+    },
   ];
-  for (const base of vscodeGlobalStorageBases(home)) {
-    for (const extensionId of extensionIds) {
-      for (const file of configFiles) {
-        candidates.push({ path: join(base, extensionId, file), explicit: false });
-      }
-    }
-  }
 
-  return candidates;
+  return {
+    ...(account ? { account } : {}),
+    windows,
+    credits: { remaining: balance, unit: "credits" },
+    refreshedAt: nowIso(),
+  };
 }
 
-function vscodeGlobalStorageBases(home: string): string[] {
-  const apps = ["Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"];
-  const roots =
-    process.platform === "darwin"
-      ? [join(home, "Library", "Application Support")]
-      : process.platform === "win32"
-        ? [process.env.APPDATA || join(home, "AppData", "Roaming")]
-        : [process.env.XDG_CONFIG_HOME || join(home, ".config")];
-  return roots.flatMap((root) =>
-    apps.map((app) => join(root, app, "User", "globalStorage")),
+async function clineGet(path: string, token: string): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    let response: Response;
+    try {
+      response = await fetch(`${API_BASE}${path}`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "application/json",
+        },
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (isAbortError(error) || controller.signal.aborted)
+        throw new SafeClineError("Cline quota request timed out");
+      throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+    }
+    rejectUnusableResponse(response);
+    return await readBoundedJson(response);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function rejectUnusableResponse(response: Response): void {
+  if (response.status === 401 || response.status === 403) {
+    throw new SafeClineError(CLINE_SIGN_IN_REQUIRED_ERROR);
+  }
+  if (response.status === 429) {
+    throw new RateLimitError(retryAfterToIso(response.headers.get("retry-after")));
+  }
+  if (!response.ok) throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+}
+
+async function readBoundedJson(response: Response): Promise<unknown> {
+  const contentLength = response.headers.get("content-length");
+  if (
+    contentLength &&
+    /^\d+$/.test(contentLength) &&
+    Number(contentLength) > RESPONSE_LIMIT_BYTES
+  ) {
+    throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+  }
+  if (!response.body) throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let length = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      length += value.length;
+      if (length > RESPONSE_LIMIT_BYTES) {
+        await reader.cancel().catch(() => undefined);
+        throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new SafeClineError(CLINE_QUOTA_UNAVAILABLE_ERROR);
+  }
+}
+
+function readCredentialState(): CredentialState {
+  const inlineToken = stringValue(process.env.CLINE_API_KEY);
+  if (inlineToken) {
+    return {
+      status: "available",
+      token: inlineToken,
+      source: authSource(API_KEY_SOURCE, undefined, "available"),
+    };
+  }
+  const path = clineProvidersFile();
+  return extractCredentialState(readJsonFileResult(path), path);
+}
+
+function extractCredentialState(
+  raw: JsonFileReadResult,
+  path: string,
+): CredentialState {
+  if (raw.status === "missing")
+    return {
+      status: "missing",
+      source: authSource(PROVIDERS_JSON_SOURCE, path, "missing"),
+    };
+  if (raw.status === "invalid")
+    return {
+      status: "invalid",
+      source: authSource(PROVIDERS_JSON_SOURCE, path, "invalid", raw.error),
+    };
+  const token = accessTokenFrom(raw.value);
+  if (!token)
+    return {
+      status: "invalid",
+      source: authSource(PROVIDERS_JSON_SOURCE, path, "invalid"),
+    };
+  return {
+    status: "available",
+    token,
+    source: authSource(PROVIDERS_JSON_SOURCE, path, "available"),
+  };
+}
+
+/** JSON path: providers.cline.settings.auth.accessToken. */
+function accessTokenFrom(value: unknown): string | undefined {
+  const providers = objectValue(objectValue(value)?.providers);
+  const cline = objectValue(providers?.cline);
+  const settings = objectValue(cline?.settings);
+  const auth = objectValue(settings?.auth);
+  return stringValue(auth?.accessToken);
+}
+
+function clineProvidersFile(): string {
+  return (
+    stringValue(process.env.CLINE_CONFIG) ??
+    join(homedir(), ".cline", "data", "settings", "providers.json")
   );
 }
 
+function nextUtcMidnightIso(from: Date = new Date()): string {
+  return new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate() + 1),
+  ).toISOString();
+}
+
 function authSource(
-  path: string,
+  source: string,
+  path: string | undefined,
   status: AuthSourceReport["status"],
   error?: string,
 ): AuthSourceReport {
   return {
-    source: AUTH_SOURCE,
-    path,
+    source,
+    ...(path ? { path } : {}),
     status,
     ...(error ? { error } : {}),
     credentialPresent: status === "available",
@@ -216,4 +344,31 @@ function objectValue(value: unknown): Record<string, unknown> | undefined {
 
 function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof SafeClineError
+    ? error.message
+    : CLINE_QUOTA_UNAVAILABLE_ERROR;
+}
+
+class SafeClineError extends Error {}
+
+class RateLimitError extends SafeClineError {
+  constructor(readonly retryAfter?: string) {
+    super("Cline quota endpoint rate limited");
+  }
 }

--- a/src/providers/cline.ts
+++ b/src/providers/cline.ts
@@ -1,0 +1,219 @@
+import { statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readJsonFileResult } from "../lib/fs.js";
+import type {
+  AuthProviderReport,
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  SourceAttempt,
+} from "../types.js";
+import { failedProvider, statusFromError } from "./common.js";
+
+// TODO(phase-2): wire cline daily-free + daily-subscription usage windows
+// (app.cline.bot account usage). Phase 1 only detects a local config/token
+// file and reports auth status; no usage windows are fetched yet.
+
+const AUTH_SOURCE = "cline-config";
+
+type CredentialState =
+  | { status: "available"; source: AuthSourceReport }
+  | { status: "missing" | "invalid"; source: AuthSourceReport };
+
+export const clineAdapter: ProviderAdapter = {
+  id: "cline",
+  label: "Cline",
+  fetchQuota,
+  inspectAuth,
+};
+
+export async function fetchQuota(
+  _options: ProviderOptions,
+): Promise<ProviderQuota> {
+  const state = readCredentialState();
+
+  if (state.status === "available") {
+    // TODO(phase-2): replace this stub with a real usage-window fetch.
+    const attempts: SourceAttempt[] = [
+      {
+        source: AUTH_SOURCE,
+        status: "skipped",
+        error: "phase_2_pending",
+        credentialPresent: true,
+      },
+    ];
+    return failedProvider({
+      provider: "cline",
+      label: "Cline",
+      status: "unavailable",
+      source: "web",
+      error: "cline usage endpoint not yet implemented (phase 2)",
+      sourcesTried: [AUTH_SOURCE],
+      attempts,
+    });
+  }
+
+  const error = "Cline sign-in required";
+  const attempts: SourceAttempt[] = [
+    {
+      source: AUTH_SOURCE,
+      status: "skipped",
+      error: `credentials_${state.status}`,
+      credentialPresent: false,
+    },
+  ];
+  return failedProvider({
+    provider: "cline",
+    label: "Cline",
+    status: statusFromError(error),
+    error,
+    sourcesTried: [AUTH_SOURCE],
+    attempts,
+  });
+}
+
+export async function inspectAuth(
+  _options: ProviderOptions,
+): Promise<AuthProviderReport> {
+  const state = readCredentialState();
+  return { provider: "cline", sources: [state.source] };
+}
+
+type Candidate = { path: string; explicit: boolean };
+
+// Field names that identify a file as an actual Cline (app.cline.bot)
+// credential/config rather than an unrelated file that happens to sit at
+// ~/.cline (a name other tools also use).
+const CLINE_AUTH_KEYS = [
+  "token",
+  "apiKey",
+  "api_key",
+  "apiToken",
+  "accessToken",
+  "access_token",
+  "authToken",
+  "auth_token",
+  "clineApiKey",
+  "clineAccountId",
+  "clineAccountUserId",
+  "credentials",
+  "sessionToken",
+  "userInfo",
+];
+
+function readCredentialState(
+  candidates = clineConfigCandidates(),
+): CredentialState {
+  // Probe candidate config/token files in priority order. A directory is
+  // skipped (some tools use ~/.cline as a directory). An explicit env override
+  // is authoritative: a parseable file there is available, an unparseable one
+  // is invalid. Discovered (non-explicit) files must actually look like Cline
+  // auth to count — this avoids false positives from unrelated JSON that
+  // happens to share the path. If nothing matches, report missing cleanly.
+  for (const { path, explicit } of candidates) {
+    let stat;
+    try {
+      stat = statSync(path);
+    } catch {
+      continue; // missing
+    }
+    if (!stat.isFile()) continue; // skip directories
+    const raw = readJsonFileResult(path);
+    if (raw.status === "missing") continue;
+    if (raw.status === "invalid") {
+      if (explicit)
+        return {
+          status: "invalid",
+          source: authSource(path, "invalid", raw.error),
+        };
+      continue; // corrupt/unrelated non-Cline file — keep looking
+    }
+    if (explicit || looksLikeClineAuth(raw.value))
+      return { status: "available", source: authSource(path, "available") };
+    // Parseable but not recognizable as Cline auth — keep looking.
+  }
+  const primary = candidates[0]?.path ?? join(homedir(), ".cline", "auth.json");
+  return { status: "missing", source: authSource(primary, "missing") };
+}
+
+function looksLikeClineAuth(value: unknown): boolean {
+  const data = objectValue(value);
+  if (!data) return false;
+  return CLINE_AUTH_KEYS.some((key) => key in data);
+}
+
+function clineConfigCandidates(): Candidate[] {
+  const home = homedir();
+  const candidates: Candidate[] = [];
+
+  const envConfig = stringValue(process.env.CLINE_CONFIG);
+  if (envConfig) candidates.push({ path: envConfig, explicit: true });
+  const envAuth = stringValue(process.env.CLINE_AUTH);
+  if (envAuth) candidates.push({ path: envAuth, explicit: true });
+
+  // Dedicated dotfile locations.
+  for (const path of [
+    join(home, ".cline", "auth.json"),
+    join(home, ".cline", "config.json"),
+    join(home, ".config", "cline", "auth.json"),
+    join(home, ".config", "cline", "config.json"),
+  ]) {
+    candidates.push({ path, explicit: false });
+  }
+
+  // VS Code (and forks) globalStorage for the Cline / Claude Dev extension.
+  const extensionIds = ["saoudrizwan.claude-dev", "cline.cline"];
+  const configFiles = [
+    "auth.json",
+    "config.json",
+    join("settings", "cline_mcp_settings.json"),
+  ];
+  for (const base of vscodeGlobalStorageBases(home)) {
+    for (const extensionId of extensionIds) {
+      for (const file of configFiles) {
+        candidates.push({ path: join(base, extensionId, file), explicit: false });
+      }
+    }
+  }
+
+  return candidates;
+}
+
+function vscodeGlobalStorageBases(home: string): string[] {
+  const apps = ["Code", "Code - Insiders", "VSCodium", "Cursor", "Windsurf"];
+  const roots =
+    process.platform === "darwin"
+      ? [join(home, "Library", "Application Support")]
+      : process.platform === "win32"
+        ? [process.env.APPDATA || join(home, "AppData", "Roaming")]
+        : [process.env.XDG_CONFIG_HOME || join(home, ".config")];
+  return roots.flatMap((root) =>
+    apps.map((app) => join(root, app, "User", "globalStorage")),
+  );
+}
+
+function authSource(
+  path: string,
+  status: AuthSourceReport["status"],
+  error?: string,
+): AuthSourceReport {
+  return {
+    source: AUTH_SOURCE,
+    path,
+    status,
+    ...(error ? { error } : {}),
+    credentialPresent: status === "available",
+  };
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,6 @@
+import { agyAdapter } from "./agy.js";
 import { claudeAdapter } from "./claude.js";
+import { clineAdapter } from "./cline.js";
 import { codexAdapter } from "./codex.js";
 import { copilotAdapter } from "./copilot.js";
 import { cursorAdapter } from "./cursor.js";
@@ -17,6 +19,8 @@ export const PROVIDERS: Record<ProviderId, ProviderAdapter> = {
   copilot: copilotAdapter,
   grok: grokAdapter,
   kimi: kimiAdapter,
+  agy: agyAdapter,
+  cline: clineAdapter,
 };
 
 export function parseProviders(value: string | undefined): ProviderId[] {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -73,6 +73,8 @@ const ACCENTS: Record<ProviderId, StyleSpec> = {
   copilot: { rgb: [116, 199, 236], ansi16: "94", bold: true },
   grok: { rgb: [180, 190, 254], ansi16: "95", bold: true },
   kimi: { rgb: [245, 194, 231], ansi16: "95", bold: true },
+  agy: { rgb: [166, 227, 161], ansi16: "92", bold: true },
+  cline: { rgb: [148, 226, 213], ansi16: "96", bold: true },
 };
 
 const STYLES: Record<Exclude<StyleName, `accent:${ProviderId}`>, StyleSpec> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,9 @@ export type ProviderId =
   | "cursor"
   | "copilot"
   | "grok"
-  | "kimi";
+  | "kimi"
+  | "agy"
+  | "cline";
 
 export const PROVIDER_IDS = [
   "claude",
@@ -13,6 +15,8 @@ export const PROVIDER_IDS = [
   "copilot",
   "grok",
   "kimi",
+  "agy",
+  "cline",
 ] as const satisfies readonly ProviderId[];
 
 export type ProviderSource =
@@ -237,7 +241,7 @@ export type IntelligenceBucket = "high" | "medium" | "low";
 
 /** Native-provider model knowledge used by the `models` evidence join. */
 export type ModelCatalogEntry = {
-  provider: "claude" | "codex" | "grok" | "kimi";
+  provider: "claude" | "codex" | "grok" | "kimi" | "agy";
   id: string;
   label: string;
   intelligence: IntelligenceBucket;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -46,6 +46,8 @@ describe("CLI flag parsing", () => {
       "copilot",
       "grok",
       "kimi",
+      "agy",
+      "cline",
     ]);
   });
 
@@ -66,7 +68,16 @@ describe("CLI flag parsing", () => {
   it("collects the boolean flags", () => {
     expect(parseFlags(["--json", "--full", "--allow-keychain-prompt"])).toEqual(
       {
-        providers: ["claude", "codex", "cursor", "copilot", "grok", "kimi"],
+        providers: [
+          "claude",
+          "codex",
+          "cursor",
+          "copilot",
+          "grok",
+          "kimi",
+          "agy",
+          "cline",
+        ],
         json: true,
         full: true,
         tui: false,

--- a/test/models-command.test.ts
+++ b/test/models-command.test.ts
@@ -10,6 +10,7 @@ const originalCursor = PROVIDERS.cursor;
 const originalCopilot = PROVIDERS.copilot;
 const originalGrok = PROVIDERS.grok;
 const originalKimi = PROVIDERS.kimi;
+const originalAgy = PROVIDERS.agy;
 
 afterEach(() => {
   PROVIDERS.claude = originalClaude;
@@ -18,6 +19,7 @@ afterEach(() => {
   PROVIDERS.copilot = originalCopilot;
   PROVIDERS.grok = originalGrok;
   PROVIDERS.kimi = originalKimi;
+  PROVIDERS.agy = originalAgy;
   process.exitCode = undefined;
 });
 
@@ -139,7 +141,7 @@ describe("models command", () => {
   });
 
   it("fails when every catalog provider fails and rejects non-catalog scopes", async () => {
-    for (const provider of ["claude", "codex", "grok", "kimi"] as const) {
+    for (const provider of ["claude", "codex", "grok", "kimi", "agy"] as const) {
       PROVIDERS[provider] = adapter(failedQuota(provider));
     }
     PROVIDERS.cursor = adapter({
@@ -185,7 +187,7 @@ function adapter(quota: ProviderQuota): ProviderAdapter {
 }
 
 function failedQuota(
-  provider: "claude" | "codex" | "grok" | "kimi",
+  provider: "claude" | "codex" | "grok" | "kimi" | "agy",
 ): ProviderQuota {
   return {
     provider,

--- a/test/models-command.test.ts
+++ b/test/models-command.test.ts
@@ -151,7 +151,7 @@ describe("models command", () => {
     });
 
     const json = JSON.parse(await capture(["models", "--json"]));
-    expect(json.models).toHaveLength(12);
+    expect(json.models).toHaveLength(13);
     expect(process.exitCode).toBe(1);
 
     process.exitCode = undefined;

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -20,7 +20,7 @@ describe("model catalog", () => {
     expect(() => validateModelCatalog(MODEL_CATALOG)).not.toThrow();
     expect(
       new Set(MODEL_CATALOG.entries.map((entry) => entry.provider)),
-    ).toEqual(new Set(["claude", "codex", "grok", "kimi"]));
+    ).toEqual(new Set(["claude", "codex", "grok", "kimi", "agy"]));
     expect(
       new Set(MODEL_CATALOG.entries.map((entry) => entry.intelligence)),
     ).toEqual(new Set(["high", "medium", "low"]));

--- a/test/providers/agy.test.ts
+++ b/test/providers/agy.test.ts
@@ -1,0 +1,230 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchQuota, inspectAuth } from "../../src/providers/agy.js";
+
+const options = { allowKeychainPrompt: false };
+
+const originalAgyOauthToken = process.env.AGY_OAUTH_TOKEN;
+const originalAntigravityOauthToken = process.env.ANTIGRAVITY_OAUTH_TOKEN;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+// Response shape captured live from cloudcode-pa retrieveUserQuota.
+const BUCKETS_RESPONSE = {
+  buckets: [
+    {
+      resetTime: "2026-08-15T18:16:05Z",
+      tokenType: "REQUESTS",
+      modelId: "gemini-2.5-flash",
+      remainingFraction: 1,
+    },
+    {
+      resetTime: "2026-08-15T18:16:05Z",
+      tokenType: "REQUESTS",
+      modelId: "gemini-2.5-flash-lite",
+      remainingFraction: 1,
+    },
+    {
+      resetTime: "2026-08-15T18:16:05Z",
+      tokenType: "REQUESTS",
+      modelId: "gemini-2.5-pro",
+      remainingFraction: 1,
+    },
+    {
+      resetTime: "2026-08-15T18:16:05Z",
+      tokenType: "REQUESTS",
+      modelId: "gemini-3.1-flash-lite",
+      remainingFraction: 1,
+    },
+  ],
+};
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-agy-"));
+  process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+  process.env.AGY_OAUTH_TOKEN = join(tempDir, "antigravity-oauth-token");
+  delete process.env.ANTIGRAVITY_OAUTH_TOKEN;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  restore("AGY_OAUTH_TOKEN", originalAgyOauthToken);
+  restore("ANTIGRAVITY_OAUTH_TOKEN", originalAntigravityOauthToken);
+  restore("XDG_CACHE_HOME", originalXdgCacheHome);
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function writeToken(accessToken: string, expiry: string): void {
+  writeFileSync(
+    process.env.AGY_OAUTH_TOKEN!,
+    JSON.stringify({
+      token: {
+        access_token: accessToken,
+        token_type: "Bearer",
+        refresh_token: "refresh_xyz",
+        expiry,
+      },
+      auth_method: "consumer",
+    }),
+  );
+}
+
+function futureIso(): string {
+  return new Date(Date.now() + 3_600_000).toISOString();
+}
+
+function pastIso(): string {
+  return new Date(Date.now() - 3_600_000).toISOString();
+}
+
+function stubFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("agy fetchQuota", () => {
+  it("reports one real-percent window per model bucket", async () => {
+    writeToken("tok_ABC", futureIso());
+    const fetchMock = stubFetch(200, BUCKETS_RESPONSE);
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.source).toBe("oauth");
+    expect(result.windows.map((window) => window.id)).toEqual([
+      "gemini-2.5-flash",
+      "gemini-2.5-flash-lite",
+      "gemini-2.5-pro",
+      "gemini-3.1-flash-lite",
+    ]);
+    expect(result.windows[0]).toMatchObject({
+      id: "gemini-2.5-flash",
+      label: "gemini-2.5-flash",
+      kind: "model",
+      percentRemaining: 100,
+      percentUsed: 0,
+      resetsAt: "2026-08-15T18:16:05Z",
+    });
+
+    // POST retrieveUserQuota with Bearer token and empty JSON body.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(
+      "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
+    );
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe("{}");
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer tok_ABC",
+    );
+  });
+
+  it("maps a partial remainingFraction to a percentage", async () => {
+    writeToken("tok_ABC", futureIso());
+    stubFetch(200, {
+      buckets: [
+        {
+          resetTime: "2026-08-15T18:16:05Z",
+          tokenType: "REQUESTS",
+          modelId: "gemini-2.5-pro",
+          remainingFraction: 0.5,
+        },
+      ],
+    });
+
+    const result = await fetchQuota(options);
+
+    expect(result.windows[0]).toMatchObject({
+      percentRemaining: 50,
+      percentUsed: 50,
+    });
+  });
+
+  it("reports access-token-expired without calling the API", async () => {
+    writeToken("tok_STALE", pastIso());
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Antigravity access token expired");
+    expect(result.windows).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports sign-in required when no token is present", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Antigravity sign-in required");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a 403 as sign-in required", async () => {
+    writeToken("tok_ABC", futureIso());
+    stubFetch(403, { error: { status: "PERMISSION_DENIED" } });
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Antigravity sign-in required");
+    expect(result.windows).toHaveLength(0);
+  });
+
+  it("reports quota unavailable when no buckets are returned", async () => {
+    writeToken("tok_ABC", futureIso());
+    stubFetch(200, { buckets: [] });
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("error");
+    expect(result.state.error).toBe("Antigravity quota unavailable");
+  });
+});
+
+describe("agy inspectAuth", () => {
+  it("reports available for a present, unexpired token", async () => {
+    writeToken("tok_ABC", futureIso());
+    const report = await inspectAuth(options);
+    expect(report.provider).toBe("agy");
+    expect(report.sources[0]).toMatchObject({
+      source: "antigravity-oauth-token",
+      status: "available",
+    });
+  });
+
+  it("reports expired when the token expiry is in the past", async () => {
+    writeToken("tok_STALE", pastIso());
+    const report = await inspectAuth(options);
+    expect(report.sources[0]).toMatchObject({
+      source: "antigravity-oauth-token",
+      status: "expired",
+    });
+  });
+
+  it("reports missing when no token file exists", async () => {
+    const report = await inspectAuth(options);
+    expect(report.sources[0]).toMatchObject({
+      source: "antigravity-oauth-token",
+      status: "missing",
+    });
+  });
+});

--- a/test/providers/cline.test.ts
+++ b/test/providers/cline.test.ts
@@ -1,0 +1,212 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchQuota, inspectAuth } from "../../src/providers/cline.js";
+
+const options = { allowKeychainPrompt: false };
+
+const originalClineConfig = process.env.CLINE_CONFIG;
+const originalClineApiKey = process.env.CLINE_API_KEY;
+const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
+let tempDir: string | undefined;
+
+// Response shapes captured live against a Cline Pass account.
+const ME_RESPONSE = {
+  data: {
+    id: "user_1",
+    email: "adi@example.com",
+    organizations: [
+      {
+        memberId: "mem_1",
+        organizationId: "org_1",
+        name: "Cyber Security RO",
+        roles: ["owner"],
+        active: true,
+      },
+    ],
+  },
+  success: true,
+};
+
+const BALANCE_RESPONSE = {
+  data: { organizationId: "org_1", balance: 17075999 },
+  success: true,
+};
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "quota-axi-cline-"));
+  // Isolate the cache so stale-from-cache never masks a fresh/failed result.
+  process.env.XDG_CACHE_HOME = join(tempDir, "cache");
+  process.env.CLINE_CONFIG = join(tempDir, "providers.json");
+  delete process.env.CLINE_API_KEY;
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  restore("CLINE_CONFIG", originalClineConfig);
+  restore("CLINE_API_KEY", originalClineApiKey);
+  restore("XDG_CACHE_HOME", originalXdgCacheHome);
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function restore(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+function writeProvidersJson(accessToken: string): void {
+  const path = process.env.CLINE_CONFIG!;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(
+    path,
+    JSON.stringify({
+      providers: {
+        cline: {
+          settings: {
+            auth: { accessToken, metadata: { tokenType: "Bearer" } },
+          },
+        },
+      },
+    }),
+  );
+}
+
+function stubApi(
+  responses: Record<string, { status?: number; body: unknown }>,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+    const target = String(url);
+    const match = Object.keys(responses).find((key) => target.includes(key));
+    if (!match) throw new Error(`unexpected fetch: ${target}`);
+    const { status = 200, body } = responses[match]!;
+    void init;
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("cline fetchQuota", () => {
+  it("reports the daily credit balance for an authenticated account", async () => {
+    writeProvidersJson("tok_ABC");
+    const fetchMock = stubApi({
+      "/users/me": { body: ME_RESPONSE },
+      "/organizations/org_1/balance": { body: BALANCE_RESPONSE },
+    });
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("fresh");
+    expect(result.source).toBe("api");
+    expect(result.credits).toEqual({ remaining: 17075999, unit: "credits" });
+    expect(result.account).toEqual({
+      email: "adi@example.com",
+      organization: "Cyber Security RO",
+    });
+    expect(result.windows).toHaveLength(1);
+    expect(result.windows[0]).toMatchObject({
+      id: "daily_credits",
+      kind: "credits",
+    });
+    // No daily maximum is exposed, so no percentage is fabricated.
+    expect(result.windows[0]?.percentRemaining).toBeUndefined();
+    expect(result.windows[0]?.percentUsed).toBeUndefined();
+    expect(result.windows[0]?.resetsAt).toMatch(/T00:00:00\.000Z$/);
+
+    // Bearer token forwarded; org resolved before the balance call.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [firstUrl, firstInit] = fetchMock.mock.calls[0]!;
+    expect(String(firstUrl)).toContain("/users/me");
+    expect(new Headers(firstInit?.headers).get("authorization")).toBe(
+      "Bearer tok_ABC",
+    );
+    expect(String(fetchMock.mock.calls[1]![0])).toContain(
+      "/organizations/org_1/balance",
+    );
+  });
+
+  it("honors the CLINE_API_KEY inline token override", async () => {
+    process.env.CLINE_API_KEY = "tok_ENV";
+    const fetchMock = stubApi({
+      "/users/me": { body: ME_RESPONSE },
+      "/balance": { body: BALANCE_RESPONSE },
+    });
+
+    const result = await fetchQuota(options);
+
+    expect(result.credits).toEqual({ remaining: 17075999, unit: "credits" });
+    expect(
+      new Headers(fetchMock.mock.calls[0]![1]?.headers).get("authorization"),
+    ).toBe("Bearer tok_ENV");
+  });
+
+  it("reports sign-in required when no local token is present", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Cline sign-in required");
+    expect(result.windows).toHaveLength(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("treats a 401 as sign-in required", async () => {
+    writeProvidersJson("tok_STALE");
+    stubApi({ "/users/me": { status: 401, body: { error: "unauthorized" } } });
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("auth_required");
+    expect(result.state.error).toBe("Cline sign-in required");
+    expect(result.windows).toHaveLength(0);
+  });
+
+  it("reports quota unavailable when the balance payload is malformed", async () => {
+    writeProvidersJson("tok_ABC");
+    stubApi({
+      "/users/me": { body: ME_RESPONSE },
+      "/balance": { body: { data: {}, success: true } },
+    });
+
+    const result = await fetchQuota(options);
+
+    expect(result.state.status).toBe("error");
+    expect(result.state.error).toBe("Cline quota unavailable");
+  });
+});
+
+describe("cline inspectAuth", () => {
+  it("reports available when a providers.json token is present", async () => {
+    writeProvidersJson("tok_ABC");
+    const report = await inspectAuth(options);
+    expect(report.provider).toBe("cline");
+    expect(report.sources[0]).toMatchObject({
+      source: "cline-providers-json",
+      status: "available",
+    });
+  });
+
+  it("reports missing when no providers.json exists", async () => {
+    const report = await inspectAuth(options);
+    expect(report.sources[0]).toMatchObject({
+      source: "cline-providers-json",
+      status: "missing",
+    });
+  });
+
+  it("reports available via the CLINE_API_KEY override", async () => {
+    process.env.CLINE_API_KEY = "tok_ENV";
+    const report = await inspectAuth(options);
+    expect(report.sources[0]).toMatchObject({
+      source: "cline-api-key",
+      status: "available",
+    });
+  });
+});


### PR DESCRIPTION
Adds two providers to quota-axi (branch based on v0.1.28):

- **agy** (Antigravity, Google Code Assist consumer backend): per-model daily request quota via `POST cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota` → one QuotaWindow per model with real `remainingFraction`→percent + `resetTime`. Token from ~/.gemini/antigravity-cli/antigravity-oauth-token.
- **cline** (Cline Pass): daily credit balance via `api.cline.bot/api/v1/organizations/{id}/balance` (org resolved from /users/me). Token from ~/.cline/data/settings/providers.json.
- Model catalog: Gemini 3.7 Flash under agy.
- Wired into ProviderId/PROVIDER_IDS, providers registry, interpretation semantics, tui accents, args/cli allowlists + help.

496 tests pass (build + lint clean). Note: branch is based off the v0.1.28 tag since upstream main trails the release tags — maintainer may prefer to retarget the base.