### PR TITLE
docs: define project vision and acceptance policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
 
+- [VISION.md](VISION.md) is the project's acceptance policy, co-authored with the repo owner against 17 recorded hypothetical verdicts; check a proposed surface against its closing aligns/resisted tests before building it.
+  It deliberately sits ahead of today's implementation in places: accuracy of the reported number is the first obligation, and boundaries such as read-only and never-launch hold as "least action that yields a true reading" rather than as absolutes.
+  README Security Posture remains the description of what actually ships today; do not restate VISION.md wording as a current guarantee.
 - quota-axi is data only.
 - It reports local Claude, Codex, Cursor, GitHub Copilot, Grok, and Kimi quota windows, and it must never route, recommend, rank a winner, order providers preferentially, proxy, intercept, log in, import browser cookies, or mutate provider state.
 - Data-only reconciliation: quota-axi does publish one derived per-scope comparative selection signal (`effectiveAvailability[].selection`), computed purely from figures it already reports. That is data, not routing - the consumer does any routing or ranking. Keep this distinction in `src/skill.ts` and README wording; never claim quota-axi recommends or ranks.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,70 @@
+# Vision
+
+`quota-axi` exists so that an agent can know how much provider capacity is left before it commits to spending it.
+It serves coding agents first and the people who run them second, and it turns local credential stores and first-party usage endpoints into one normalized quota snapshot.
+It owns exactly one thing: the accurate report of local quota state.
+
+## Accuracy is the first obligation
+
+Reporting an accurate and useful number is the highest priority, and every other rule here yields to it.
+A provider that is signed in and working must never read as signed out, because being wrong about the headline fact defeats the tool.
+When a constraint would force quota-axi to publish something false, the constraint is narrowed to the smallest carve-out that restores the truth, and that carve-out is documented.
+The primary flow is unattended, so anything that needs a human present is kept out of it and never becomes the path an agent depends on.
+
+## It reports, the caller decides
+
+quota-axi publishes figures, and the consumer decides what to do with them.
+It never proxies a request, never intercepts traffic, and never mutates provider state to change an outcome.
+A derived comparative signal is welcome when it is computed only from figures already reported, is documented, and is deterministic; `spendPriority` and `models --sort runway` ship on exactly those terms.
+An opt-in surface that names a best scope is allowed on the same terms, because the alternative is every consumer reimplementing that comparison with worse handling of unknowns.
+The default report stays in declaration order and carries no preference, so no column reads as a ranking the caller did not ask for.
+
+## Least action on someone else's credentials
+
+quota-axi acts on credentials other tools own, and it takes the least action that yields a true reading.
+It never logs in, never creates an identity, and never runs anything that spends the quota being measured.
+It never drives a browser or imports browser state or cookies, because a surface built for a human page is flaky and yields numbers it cannot verify.
+Renewing a short-lived credential through its own first-party grant is allowed when that is what stands between quota-axi and an accurate report, and the renewed value is written back to the exact source it came from so later runs stay accurate too.
+Running a vendor's own read-only command to learn auth state is allowed for the same reason and under the same limit.
+A credential value leaves the process only as the bearer of the first-party request it authenticates, and is never printed, logged, cached, or written into a test fixture.
+A credential the user supplies explicitly is as legitimate a source as one discovered on disk, because people run this in more shapes than one machine with one seat.
+
+## Absent data stays absent
+
+Every number reported is a number a provider reported or a figure derived from evidence quota-axi can trust.
+It never invents a window duration, a reset deadline, a relationship between windows, or a percentage.
+A conservative rule such as taking the lowest window as the effective bound applies only where that relationship is established as a fact about that provider, never as a default where relationships are unknown.
+Uncertainty gets louder as it propagates: an unmeasurable scope publishes no row, `spendPriority` renders the literal `unknown` rather than `0`, and an unknown pace marker is omitted rather than drawn.
+A number that has stopped being true is never published as a current one, because it misleads the agent acting on it, and a failed read is reported as a failed read.
+
+## Fixes land as machinery
+
+A bug that can recur across providers is fixed once, in shared code, for every provider.
+Credential selection, effective-availability aggregation, and the selection scalar each have exactly one implementation and one spelling.
+Change is additive by default: a working path is never replaced to make a new one simpler, and a provider with a single valid credential behaves exactly as it did before.
+A published shape change is deliberate and versioned, with the schema bump and its documentation in the same change, and the shape is never frozen against a change that makes the output truer or cheaper.
+A deviation from prior behavior is named as a decision in the change that makes it, so nothing later reads as an accident.
+
+## Consent at the credential boundary
+
+Reading a secret the user has not offered requires the user's permission first.
+The macOS Keychain is never read for a value on a plain call, `--allow-keychain-prompt` is the one-time bootstrap, and a non-secret hashed marker records the grant.
+Keychain reads are pinned to the current account rather than an ambiguous service-wide query.
+When a read is blocked, the report says so with a structured reason and a runnable remedy instead of reporting the user as signed out.
+
+## The output is a budget
+
+Default output is compact because its reader is an agent that pays per token to parse it.
+Every block earns its place: consolidation that cuts output without losing a load-bearing fact is a win, and a value already published elsewhere is not published twice.
+The `--tui` surface is a convenience for a human at a terminal, not a second product; it may use plainer words than the machine contract, and it never becomes a resident service or a graphical application.
+
+## Scope
+
+quota-axi is not a router, not a proxy, not a gateway, not a login manager, not a hosted service, and not a desktop application.
+Coverage of popular agents is wanted and pursued on a best-effort basis, and it grows in this tree rather than through a third-party interface that would run unreviewed code against a user's credentials.
+Where a vendor reports money as reliably as it reports capacity, reporting money is open to it; a signal that can only be made accurate for a few providers does not ship.
+Adapter behavior is clean-room from a vendor's own observable behavior, and third-party data is attributed rather than republished.
+The repo holds itself to the standard it asks of contributors, with no exemption for the contributions it most wants: every human pull request goes through the no-mistakes pipeline, generated files are regenerated rather than hand-edited, and tests exercise the published interface rather than the source text.
+
+A change aligns when it makes a real quota fact readable that was previously unreadable or wrong, keeps every existing path working, and leaves the decision with the caller.
+A change should be resisted when it publishes a number no provider supports, holds a boundary at the cost of a false report, spends the quota it is measuring, or grows the surface into a product this is not.

--- a/VISION.md
+++ b/VISION.md
@@ -26,7 +26,7 @@ It never logs in, never creates an identity, and never runs anything that spends
 It never drives a browser or imports browser state or cookies, because a surface built for a human page is flaky and yields numbers it cannot verify.
 Renewing a short-lived credential through its own first-party grant is allowed when that is what stands between quota-axi and an accurate report, and the renewed value is written back to the exact source it came from so later runs stay accurate too.
 Running a vendor's own read-only command to learn auth state is allowed for the same reason and under the same limit.
-A credential value leaves the process only as the bearer of the first-party request it authenticates, and is never printed, logged, cached, or written into a test fixture.
+A credential value leaves the process only as the bearer of the first-party request it authenticates or as a renewed value written back to its exact source, and is never printed, logged, cached, or written into a test fixture.
 A credential the user supplies explicitly is as legitimate a source as one discovered on disk, because people run this in more shapes than one machine with one seat.
 
 ## Absent data stays absent
@@ -35,7 +35,7 @@ Every number reported is a number a provider reported or a figure derived from e
 It never invents a window duration, a reset deadline, a relationship between windows, or a percentage.
 A conservative rule such as taking the lowest window as the effective bound applies only where that relationship is established as a fact about that provider, never as a default where relationships are unknown.
 Uncertainty gets louder as it propagates: an unmeasurable scope publishes no row, `spendPriority` renders the literal `unknown` rather than `0`, and an unknown pace marker is omitted rather than drawn.
-A number that has stopped being true is never published as a current one, because it misleads the agent acting on it, and a failed read is reported as a failed read.
+A number that has stopped being true is never served, even when labelled with its age and provenance, because it misleads the agent acting on it, and a failed read is reported as a failed read.
 
 ## Fixes land as machinery
 


### PR DESCRIPTION
## Intent

Co-author this repo's first VISION.md with the repo owner (kunchenguid) using the user-level /vision skill, then ship it as a documentation-only change. Target = quota-axi; author = kunchenguid. FROM-SCRATCH mode (no VISION.md existed).

WHAT THE /vision SKILL REQUIRED, all of which was followed:
- Evidence over vibes: every principle must trace to named PRs/commits/files; never fabricate the author's values. Mined 43 merged PRs by kunchenguid (#1-#102), 9 closed-unmerged PRs, 9 issues, README, CONTRIBUTING, AGENTS.md, and read 21 full PR bodies spread across the range.
- Fixed anatomy: identity opener ('X exists so that...', who it serves, 'It owns exactly one thing: ...'), 3-6 principle sections of testable present-tense commitments and refusals, explicit non-goals named concretely, and a closing 'A change aligns when.../A change should be resisted when...' pair.
- Formatting rules, deliberate and not accidents: ONE SENTENCE PER LINE (so the file has many short lines and no wrapped paragraphs - this is the skill's house style, not a formatting error), plain hyphens and never em dashes (also the repo owner's standing global rule), no roadmap, no feature list, no marketing voice, and a hard length budget of 40-70 lines. The final file is exactly 70 lines, at the top of that budget.
- Stress-test with 8-12 hard fault-line hypotheticals where both answers are defensible, both sides steelmanned, none predictable.
- Iterate with the author on an interactive lavish-axi review board built from the skill's SHIPPED template as-is, never restyled or substituted.
- The author owns the vision: I draft, stress-test and fold; I never approve or soften.

WHAT THE AUTHOR DECIDED (17 recorded verdicts over two board rounds; this is why the document says what it says, and a reviewer reading only the diff would not know these were the author's explicit calls, not my invention):
Round 1 (12): H-1 renew an expired Claude token so a live session stops reading as signed out = IN VISION, with the author's words 'we should relax the read-only principle. reporting accurate and useful data is the highest priority'. H-2 run a vendor's own read-only auth command = IN VISION. H-3 ship an opt-in best-scope selection surface = IN VISION. H-4 third-party adapter interface for provider coverage = OFF MISSION ('the problem is our triage and review bottleneck, not that we don't want to provide better coverage'). H-5 report cost = CONDITIONAL ('only if we can achieve accuracy across most providers'). H-6 stop serving stale numbers entirely = IN VISION ('providing accurate and useful data is our vision'). H-7 lowest-window-as-bound by default = CONDITIONAL ('only for providers where we know this is accurate as a fact'). H-8 demote a provider that cannot meet the source standard = OFF MISSION ('we should do best effort to support popular agents'). H-9 freeze the published schema = OFF MISSION. H-10 exempt provider contributions from the no-mistakes gate = OFF MISSION. H-11 accept an explicitly supplied credential = IN VISION ('we should try to support diverse ways people use this'). H-12 resident/menubar report = OFF MISSION ('this is primarily for agents. the TUI is only a convenience. don't blow this into a big GUI app').
Round 2 (5, all OFF MISSION, probing the newly relaxed boundaries): H-13 device-code re-authentication ('things that require attended interaction from the human should not be a part of the primary flow of the axi'). H-14 in-memory-only renewal without write-back ('writing back will help increase the chance of getting accurate data down the road', so the write-back is REQUIRED, not optional). H-15 keep a labelled stale fallback ('a stale number is not useful for real time decision making and can mislead the agent'). H-16 make the comparison the default row order. H-17 support a popular agent via a pasted browser cookie ('operating a browser can be inefficient and flaky, not good for our vision for accurate data').
The author then approved on the board with the single word 'merge' and ended the session. The committed VISION.md is byte-identical to that approved board text - verified programmatically against the board artifact - and must not be reworded by review.

DELIBERATE CONTENT DECISIONS A REVIEWER MIGHT FLAG AS MISTAKES:
1. VISION.md deliberately DIVERGES from today's shipped behavior and from existing README/AGENTS.md wording. It sanctions credential renewal with write-back, running a vendor's own read-only auth command, an opt-in best-scope surface, and explicitly supplied credentials - none of which quota-axi does today, and some of which today's README Security Posture says it never does. This is intentional: a vision is a forward-looking ACCEPTANCE POLICY for future changes, not a description of current behavior. Do NOT 'fix' this by softening VISION.md back toward the current README, and do NOT change README/src to match VISION.md.
2. Because of that divergence, AGENTS.md gains exactly three lines: a pointer that VISION.md is the acceptance policy, an explicit note that it sits ahead of the implementation, and a note that README Security Posture remains the description of what ships today so no future agent restates vision wording as a current guarantee. That AGENTS.md edit is the intended full extent of the non-VISION.md change.
3. The old absolutes were rewritten as 'least action that yields a true reading' rather than deleted, and a new opening section 'Accuracy is the first obligation' now outranks every other rule. That reordering is the direct consequence of H-1/H-2/H-6 and is the author's call.
4. Two lines were cut purely to stay inside the skill's 40-70 line budget: a renderer-demotion line (already implied by the consolidation line) and an unrecognized-windows line (already implied by the H-7 conservative-rule line). No content was lost that the remaining lines do not already carry.

SCOPE AND CONSTRAINTS:
- Documentation only. Do NOT modify code, src/, tests, README.md, skills/quota-axi/SKILL.md, or any provider behavior. There is no behavior change to test.
- Do not hand-edit CHANGELOG.md or .release-please-manifest.json (a guard workflow blocks PRs that touch them).
- The two supporting artifacts (the 17 recorded verdicts and the value-to-PR evidence sheet) are deliberately NOT committed; they live in the gitignored .lavish/ directory because only VISION.md was approved for the tree.
- Deliver a green PR.

## What Changed

- Add the project vision defining quota-axi's identity, accuracy standard, credential boundaries, reporting principles, output constraints, and non-goals.
- Document how future agents should apply the vision while treating the README Security Posture as the description of current behavior.

## Risk Assessment

✅ Low: The documentation-only change is tightly scoped, and the two authorized corrections now clearly preserve credential write-back and prohibit all stale-number fallback without introducing new contradictions.

## Testing

Targeted documentation validation confirmed the change is limited to VISION.md plus the intended three AGENTS.md lines, satisfies the approved document contract, renders cleanly through GitHub Markdown, and leaves the worktree clean; no runtime suite was run because the change intentionally contains no behavior changes.

- Evidence: [Complete GitHub-rendered VISION.md](https://github.com/kunchenguid/quota-axi/blob/2e114fbb7d0bb3292e0ed6703f778495ca1be742/.no-mistakes/evidence/fm/vision-quota-axi-r1/vision-render.png)
<details>
<summary>Evidence: Standalone GitHub-rendered VISION.md HTML</summary>

Source: [Standalone GitHub-rendered VISION.md HTML](https://github.com/kunchenguid/quota-axi/blob/2e114fbb7d0bb3292e0ed6703f778495ca1be742/.no-mistakes/evidence/fm/vision-quota-axi-r1/vision-render-fragment.html)

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
<title>quota-axi Vision - GitHub-rendered evidence</title>
<style>
body { margin: 0; color: #1f2328; background: #f6f8fa; font: 16px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
main { box-sizing: border-box; max-width: 980px; margin: 32px auto; padding: 40px 48px; background: white; border: 1px solid #d0d7de; border-radius: 8px; }
h1,h2 { line-height: 1.25; } h1 { padding-bottom: .3em; border-bottom: 1px solid #d8dee4; } h2 { margin-top: 1.5em; padding-bottom: .3em; border-bottom: 1px solid #d8dee4; }
code { padding: .2em .4em; background: #eff1f3; border-radius: 6px; font: 85% ui-monospace,SFMono-Regular,Consolas,monospace; }
@media (max-width: 700px) { main { margin: 0; padding: 24px; border: 0; border-radius: 0; } }
</style></head><body><main><h1 dir="auto">Vision</h1>
<p dir="auto"><code class="notranslate">quota-axi</code> exists so that an agent can know how much provider capacity is left before it commits to spending it.<br>
It serves coding agents first and the people who run them second, and it turns local credential stores and first-party usage endpoints into one normalized quota snapshot.<br>
It owns exactly one thing: the accurate report of local quota state.</p>
<h2 dir="auto">Accuracy is the first obligation</h2>
<p dir="auto">Reporting an accurate and useful number is the highest priority, and every other rule here yields to it.<br>
A provider that is signed in and working must never read as signed out, because being wrong about the headline fact defeats the tool.<br>
When a constraint would force quota-axi to publish something false, the constraint is narrowed to the smallest carve-out that restores the truth, and that carve-out is documented.<br>
The primary flow is unattended, so anything that needs a human present is kept out of it and never becomes the path an agent depends on.</p>
<h2 dir="auto">It reports, the caller decides</h2>
<p dir="auto">quota-axi publishes figures, and the consumer decides what to do with them.<br>
It never proxies a request, never intercepts traffic, and never mutates provider state to change an outcome.<br>
A derived comparative signal is welcome when it is computed only from figures already reported, is documented, and is deterministic; <code class="notranslate">spendPriority</code> and <code class="notranslate">models --sort runway</code> ship on exactly those terms.<br>
An opt-in surface that names a best scope is allowed on the same terms, because the alternative is every consumer reimplementing that comparison with worse handling of unknowns.<br>
The default report stays in declaration order and carries no preference, so no column reads as a ranking the caller did not ask for.</p>
<h2 dir="auto">Least action on someone else's credentials</h2>
<p dir="auto">quota-axi acts on credentials other tools own, and it takes the least action that yields a true reading.<br>
It never logs in, never creates an identity, and never runs anything that spends the quota being measured.<br>
It never drives a browser or imports browser state or cookies, because a surface built for a human page is flaky and yields numbers it cannot verify.<br>
Renewing a short-lived credential through its own first-party grant is allowed when that is what stands between quota-axi and an accurate report, and the renewed value is written back to the exact source it came from so later runs stay accurate too.<br>
Running a vendor's own read-only command to learn auth state is allowed for the same reason and under the same limit.<br>
A credential value leaves the process only as the bearer of the first-party request it authenticates or as a renewed value written back to its exact source, and is never printed, logged, cached, or written into a test fixture.<br>
A credential the user supplies explicitly is as legitimate a source as one discovered on disk, because people run this in more shapes than one machine with one seat.</p>
<h2 dir="auto">Absent data stays absent</h2>
<p dir="auto">Every number reported is a number a provider reported or a figure derived from evidence quota-axi can trust.<br>
It never invents a window duration, a reset deadline, a relationship between windows, or a percentage.<br>
A conservative rule such as taking the lowest window as the effective bound applies only where that relationship is established as a fact about that provider, never as a default where relationships are unknown.<br>
Uncertainty gets louder as it propagates: an unmeasurable scope publishes no row, <code class="notranslate">spendPriority</code> renders the literal <code class="notranslate">unknown</code> rather than <code class="notranslate">0</code>, and an unknown pace marker is omitted rather than drawn.<br>
A number that has stopped being true is never served, even when labelled with its age and provenance, because it misleads the agent acting on it, and a failed read is reported as a failed read.</p>
<h2 dir="auto">Fixes land as machinery</h2>
<p dir="auto">A bug that can recur across providers is fixed once, in shared code, for every provider.<br>
Credential selection, effective-availability aggregation, and the selection scalar each have exactly one implementation and one spelling.<br>
Change is additive by default: a working path is never replaced to make a new one simpler, and a provider with a single valid credential behaves exactly as it did before.<br>
A published shape change is deliberate and versioned, with the schema bump and its documentation in the same change, and the shape is never frozen against a change that makes the output truer or cheaper.<br>
A deviation from prior behavior is named as a decision in the change that makes it, so nothing later reads as an accident.</p>
<h2 dir="auto">Consent at the credential boundary</h2>
<p dir="auto">Reading a secret the user has not offered requires the user's permission first.<br>
The macOS Keychain is never read for a value on a plain call, <code class="notranslate">--allow-keychain-prompt</code> is the one-time bootstrap, and a non-secret hashed marker records the grant.<br>
Keychain reads are pinned to the current account rather than an ambiguous service-wide query.<br>
When a read is blocked, the report says so with a structured reason and a runnable remedy instead of reporting the user as signed out.</p>
<h2 dir="auto">The output is a budget</h2>
<p dir="auto">Default output is compact because its reader is an agent that pays per token to parse it.<br>
Every block earns its place: consolidation that cuts output without losing a load-bearing fact is a win, and a value already published elsewhere is not published twice.<br>
The <code class="notranslate">--tui</code> surface is a convenience for a human at a terminal, not a second product; it may use plainer words than the machine contract, and it never becomes a resident service or a graphical application.</p>
<h2 dir="auto">Scope</h2>
<p dir="auto">quota-axi is not a router, not a proxy, not a gateway, not a login manager, not a hosted service, and not a desktop application.<br>
Coverage of popular agents is wanted and pursued on a best-effort basis, and it grows in this tree rather than through a third-party interface that would run unreviewed code against a user's credentials.<br>
Where a vendor reports money as reliably as it reports capacity, reporting money is open to it; a signal that can only be made accurate for a few providers does not ship.<br>
Adapter behavior is clean-room from a vendor's own observable behavior, and third-party data is attributed rather than republished.<br>
The repo holds itself to the standard it asks of contributors, with no exemption for the contributions it most wants: every human pull request goes through the no-mistakes pipeline, generated files are regenerated rather than hand-edited, and tests exercise the published interface rather than the source text.</p>
<p dir="auto">A change aligns when it makes a real quota fact readable that was previously unreadable or wrong, keeps every existing path working, and leaves the decision with the caller.<br>
A change should be resisted when it publishes a number no provider supports, holds a boundary at the cost of a false report, spends the quota it is measuring, or grows the surface into a product this is not.</p></main></body></html>
```
</details>
<details>
<summary>Evidence: Focused VISION.md acceptance-check transcript</summary>

Source: [Focused VISION.md acceptance-check transcript](https://github.com/kunchenguid/quota-axi/blob/2e114fbb7d0bb3292e0ed6703f778495ca1be742/.no-mistakes/evidence/fm/vision-quota-axi-r1/vision-acceptance-check.txt)

```text
VISION.md end-user document acceptance checks
Base: b8b1a2c39c20dff0634cdb1548eac7c170e0164d
Target: 4bdd0d86bdf3843f496f87768f9c166a3ad14181
Changed paths: AGENTS.md, VISION.md
[PASS] from-scratch baseline has no VISION.md
[PASS] worktree VISION.md is byte-identical to target commit
[PASS] documentation-only changed paths are exactly AGENTS.md and VISION.md
[PASS] VISION.md is exactly 70 lines
[PASS] plain hyphens only (no em dash)
[PASS] each prose line is one complete line-ending sentence
[PASS] identity opener uses required exists-so-that form
[PASS] identity opener names exactly one owned surface
[PASS] explicit Scope section exists
[PASS] closing align/resist pair is present at the end
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"4bdd0d86bdf3843f496f87768f9c166a3ad14181","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `VISION.md:7` - The required fixed anatomy allows 3-6 principle sections, but the document contains seven before Scope. This contradicts an explicit acceptance criterion and needs the author&#39;s resolution.
- 🚨 `VISION.md:38` - The intent requires stopping stale-number fallback entirely and explicitly rejects even a labelled stale fallback. This line only forbids presenting stale data as current, so a labelled stale fallback remains compatible with the policy.
- 🚨 `VISION.md:29` - The intent requires renewed credentials to be written back, and line 27 mandates that behavior, but this line says a credential may leave the process only as a request bearer. Writing it back to its source is another way it leaves the process, making the policy internally contradictory.

🔧 Fix: Clarify credential write-back and forbid stale fallback
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat --name-status b8b1a2c39c20dff0634cdb1548eac7c170e0164d..4bdd0d86bdf3843f496f87768f9c166a3ad14181` and `git diff ... -- AGENTS.md VISION.md` to inspect the complete change scope</code>
- `Focused Python acceptance check verifying from-scratch status, exact changed paths, target-commit byte identity, 70-line budget, sentence-per-line formatting, plain hyphens, required identity/Scope anatomy, and closing align/resist tests`
- `git diff --check b8b1a2c39c20dff0634cdb1548eac7c170e0164d..4bdd0d86bdf3843f496f87768f9c166a3ad14181`
- <code>Rendered `VISION.md` through GitHub&#39;s Markdown API, captured it in headless Chrome, and visually inspected the complete document</code>
- <code>`git status --short` to confirm testing left the worktree clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
