### PR TITLE
feat: add Kiro quota provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quota CLI for agents - designed with [AXI](https://axi.md) (Agent eXperience Int
 Agents need quota state before they choose where work can safely run.
 Vendor dashboards are not shaped for shell automation, and local CLIs expose different windows, resets, and auth sources.
 
-quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, and Antigravity (`agy`) quota windows in one [AXI](https://axi.md)-shaped call.
+quota-axi reports local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, Antigravity (`agy`), and Kiro quota windows in one [AXI](https://axi.md)-shaped call.
 It is data only: it never routes, recommends a provider, model, harness, credential, or route, proxies, intercepts, logs in, imports browser cookies, or mutates provider state. Default output has no ordering preference. The opt-in `models --sort runway` surface applies only its documented deterministic comparator to quota evidence, preserves all evidence and explicit ties, and is not a recommendation. It publishes one derived per-scope comparative selection signal, [`selection`](#per-scope-selection-signal), as data computed from figures it already reports; the consumer, not quota-axi, does any routing or ranking with it.
 
 - **Official sources** - quota-axi reads local provider auth sources and calls first-party quota, usage, billing, entitlement, local loopback, or read-only credential-liveness endpoints used by the local agents, with a read-only Codex app-server probe as fallback.
@@ -296,19 +296,19 @@ It is generated from `src/skill.ts`; update it with `pnpm run build:skill` and v
 
 ### Flags
 
-| Flag                                                       | Description                                                        |
-| ---------------------------------------------------------- | ------------------------------------------------------------------ |
-| `--provider claude,codex,cursor,copilot,grok,kimi,zai,agy` | Scope providers                                                    |
-| `--json`                                                   | Emit normalized JSON instead of TOON for quota, auth, or models    |
-| `--full`                                                   | Include audit and derivation details                               |
-| `--tui`                                                    | Render the live human terminal report instead of TOON (quota only) |
-| `--refresh 30s\|5m\|1h`                                    | Live `--tui` refresh interval, default 5m (30s-24h)                |
-| `--once`                                                   | Render one `--tui` frame and exit instead of staying live          |
-| `--allow-keychain-prompt`                                  | Permit macOS provider Keychain access that could prompt            |
-| `--intelligence high\|medium\|low`                         | Filter `models` by editorial intelligence bucket                   |
-| `--sort runway`                                            | Explicitly sort `models` by documented usable-runway evidence      |
-| `-h`, `--help`                                             | Print terse [AXI](https://axi.md) help                             |
-| `-v`, `-V`, `--version`                                    | Print version                                                      |
+| Flag                                                            | Description                                                        |
+| --------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `--provider claude,codex,cursor,copilot,grok,kimi,zai,agy,kiro` | Scope providers                                                    |
+| `--json`                                                        | Emit normalized JSON instead of TOON for quota, auth, or models    |
+| `--full`                                                        | Include audit and derivation details                               |
+| `--tui`                                                         | Render the live human terminal report instead of TOON (quota only) |
+| `--refresh 30s\|5m\|1h`                                         | Live `--tui` refresh interval, default 5m (30s-24h)                |
+| `--once`                                                        | Render one `--tui` frame and exit instead of staying live          |
+| `--allow-keychain-prompt`                                       | Permit macOS provider Keychain access that could prompt            |
+| `--intelligence high\|medium\|low`                              | Filter `models` by editorial intelligence bucket                   |
+| `--sort runway`                                                 | Explicitly sort `models` by documented usable-runway evidence      |
+| `-h`, `--help`                                                  | Print terse [AXI](https://axi.md) help                             |
+| `-v`, `-V`, `--version`                                         | Print version                                                      |
 
 ### Human terminal report (`--tui`)
 
@@ -565,6 +565,7 @@ Source attempts can include `credentialPresent` when a non-secret probe confirms
 | Grok proto3 zero       | For the exact consumer operation only, an omitted usage float is the official proto3 zero when a valid weekly or monthly current period proves the config is present; quota-axi reports `0` used and `100` remaining rather than deriving usage from money.                                                                                                                                                                                                                                                                                                                                                      |
 | Kimi                   | Reports the principal `weekly` subscription window (with trusted 604,800s duration) plus every valid self-described limit in wire order. Only a limit whose normalized duration is exactly 18,000 seconds is identified as `five_hour`; future limits remain `limit:<index>` unknown windows.                                                                                                                                                                                                                                                                                                                    |
 | Z.AI                   | Can report the Coding Plan `five_hour` and `weekly` token windows (with trusted 18,000s and 604,800s durations) plus the `mcp_month` tool window, whose duration is not invented. The two token limits are identified by the endpoint's own `unit`/`number` values rather than array position; any other limit, or a repeat of an already reported one, degrades to an untrusted `limit:<index>` unknown window named in `state.untrustedWindowIds`.                                                                                                                                                             |
+| Kiro                   | Reports the Kiro credit window from the first-party `GetUsageLimits` response, including the current plan, credits remaining, and provider reset time. It reads the local CLI token store without modifying it; use `KIRO_CLI_DB`, `KIRO_REGION`, and optional `KIRO_PROFILE_ARN` for non-default installations.                                                                                                                                                                                                                                                                                                 |
 | Antigravity (`agy`)    | On macOS and Linux, can report `gemini_5h`, `gemini_weekly`, `claude_gpt_5h`, and `claude_gpt_weekly` from an already-running Antigravity app or `agy` loopback quota summary. If only model config quota is exposed, quota-axi reports model-scoped `model:<slug>` windows instead of inventing grouped windows. Antigravity v1 snapshots do not expose enough history for honest burn-rate pace, so pace stays `unknown`.                                                                                                                                                                                      |
 
 ### Model catalog and `models`
@@ -587,10 +588,10 @@ Default model order is deterministic and non-preferential: provider, then model 
 
 Auth source entries can include `credentialPresent` when a non-secret probe confirms a credential item exists.
 
-| Name                 | Values                                                                                                                                                                                                      |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Auth source statuses | `available`, `missing`, `invalid`, `expired`, `skipped`, or `error`                                                                                                                                         |
-| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, `cli-keychain`, `cli-authfile`, `cli-rpc`, `pi:kimi-coding`, `pi:xai`, `kimi-code-cli`, `opencode:auth.json`, and `loopback` |
+| Name                 | Values                                                                                                                                                                                                                     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Auth source statuses | `available`, `missing`, `invalid`, `expired`, `skipped`, or `error`                                                                                                                                                        |
+| Auth source names    | `oauth-file`, `keychain`, `auth-json`, `auth-env`, `apps-json`, `state-vscdb`, `cli-keychain`, `cli-authfile`, `cli-rpc`, `kiro-sqlite`, `pi:kimi-coding`, `pi:xai`, `kimi-code-cli`, `opencode:auth.json`, and `loopback` |
 
 ## Security Posture
 
@@ -605,6 +606,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 | Grok           | Grok CLI session auth from `$GROK_AUTH_JSON`, inline `$GROK_AUTH`, `$GROK_AUTH_PATH`, or `$GROK_HOME/auth.json` / `~/.grok/auth.json`, plus Pi's independent `$PI_CODING_AGENT_DIR/auth.json` `xai` entry (default `~/.pi/agent/auth.json`) for OAuth or literal API-key model auth                                                                                                                                            |
 | Kimi           | Pi's `$PI_CODING_AGENT_DIR/auth.json` (default `~/.pi/agent/auth.json`) for a literal `kimi-coding` API key or unexpired OAuth access token first, then a fresh official Kimi Code CLI access token from `$KIMI_CODE_HOME/credentials/kimi-code.json` (default `$HOME/.kimi-code/credentials/kimi-code.json`)                                                                                                                  |
 | Z.AI           | opencode's `auth.json` (`$XDG_DATA_HOME/opencode/auth.json` when set, otherwise `~/.local/share/opencode/auth.json`) for a literal Coding Plan API key under `zai-coding-plan`, `zai`, `z-ai`, `z.ai`, `zhipu`, or `zhipuai`                                                                                                                                                                                                   |
+| Kiro           | The current user's Kiro CLI SQLite auth store at `$KIRO_CLI_DB` or `~/.local/share/kiro-cli/data.sqlite3`; quota-axi reads only the `kirocli:odic:token` access-token record read-only. `KIRO_REGION` overrides the token's region and `KIRO_PROFILE_ARN` optionally selects an IAM/profile account.                                                                                                                           |
 | Antigravity    | No credential files; discovers already-running Antigravity or `agy` processes and reads only their 127.0.0.1 read-only loopback endpoints                                                                                                                                                                                                                                                                                      |
 
 ### Provider notes
@@ -661,6 +663,12 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 - It never uses `refresh_token`, accepts a custom Kimi origin, launches Pi or Kimi, makes a model request, refreshes or writes credentials, creates a device ID, imports cookies, sends device identity, retains raw responses, or exposes account, plan, token, or fingerprint data.
 - Definitive credential absence or rejection retires Kimi cache data. Transient fallback drops reset-expired windows and applies five-hour or seven-day age bounds to windows without resets.
 
+**Kiro**
+
+- It opens the current user's Kiro CLI SQLite database read-only and reads only the `kirocli:odic:token` record. `KIRO_CLI_DB` overrides the default path; `KIRO_REGION` overrides the stored region; and optional `KIRO_PROFILE_ARN` is included only when configured.
+- It sends the short-lived access token only as a bearer to Kiro's first-party `AmazonCodeWhispererService.GetUsageLimits` endpoint, with a fixed read-only request body and no cookies. The response is normalized to the Kiro credit usage window, plan, balance, and reset time.
+- It never refreshes, writes, or deletes Kiro credentials; it never launches `kiro-cli`; and token, email, profile ARN, and refresh-token values are excluded from reports, cache, errors, and tests. When the access token is expired or missing, sign in with Kiro again outside quota-axi.
+
 **Z.AI**
 
 - It reads opencode's `auth.json` (`$XDG_DATA_HOME/opencode/auth.json` when set, otherwise `~/.local/share/opencode/auth.json`; `%LOCALAPPDATA%\opencode\auth.json` on Windows) and accepts only a nonempty, control-byte-free literal string key under a known Coding Plan provider id, taken from `key`, `apiKey`, `api_key`, `token`, `accessToken`, or `auth_token`, or from a bare string entry. Environment, template, and command references are not resolved or executed, so an entry that holds one is treated as no credential rather than sent as a header value. quota-axi never writes or manages opencode state.
@@ -683,7 +691,7 @@ Auth source entries can include `credentialPresent` when a non-secret probe conf
 - The user-initiated `update` command is the only outbound non-provider network surface, and it is not part of quota measurement.
 - It sends credential values only to the first-party provider request they authenticate.
 - It never prints, logs, or caches credential values.
-- It never launches the Claude, Cursor, Grok, Pi, Kimi, opencode, or Antigravity/`agy` CLIs, so it cannot spend quota or mutate provider credentials while measuring them.
+- It never launches the Claude, Cursor, Grok, Pi, Kimi, opencode, Antigravity/`agy`, or Kiro CLIs, so it cannot spend quota or mutate provider credentials while measuring them.
 - It never routes, ranks a winner, or orders providers preferentially. Derived comparative signals, including `effectiveAvailability[].selection`, are published as data for the consumer to act on.
 
 ### Cache

--- a/skills/quota-axi/SKILL.md
+++ b/skills/quota-axi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quota-axi
-description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, and Antigravity quota windows via the quota-axi CLI - remaining effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, a per-scope selection signal, and provider status read from local auth sources, with no routing, provider mutation, or default ordering preference. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
+description: "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, Antigravity, and Kiro quota windows via the quota-axi CLI - remaining effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, a per-scope selection signal, and provider status read from local auth sources, with no routing, provider mutation, or default ordering preference. Use before deciding whether it is safe to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or remaining quota, or when comparing local provider headroom."
 user-invocable: false
 author: Kun Chen (kunchenguid)
 metadata:
@@ -17,6 +17,7 @@ metadata:
       - kimi
       - zai
       - agy
+      - kiro
       - antigravity
       - cli
     category: observability
@@ -36,7 +37,7 @@ derived per-scope comparative selection signal, `effectiveAvailability[].selecti
 computed from figures it already reports; it still ranks nothing and routes nowhere, and the
 consumer decides what to do with it. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, entitlement, local loopback, or read-only credential-liveness endpoints; it never launches the
-Claude, Cursor, Grok, Pi, Kimi, opencode, or Antigravity/agy CLIs, so it cannot spend the quota it measures.
+Claude, Cursor, Grok, Pi, Kimi, opencode, Antigravity/agy, or Kiro CLIs, so it cannot spend the quota it measures.
 
 ## When to use
 
@@ -60,7 +61,7 @@ or when comparing supported local provider headroom side by side.
    unknown or stale headroom gets no `quota[]` row at all - read its `attention[]` row instead
    of inferring a number. If that scope has finite runway, the attention detail preserves the
    runway verdict and limiting window without creating an orphan `exhaustion[]` row.
-2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok,kimi,zai,agy`.
+2. Scope to one provider with `--provider claude` or to a subset with `--provider cursor,copilot,grok,kimi,zai,agy,kiro`.
 3. Pass `--json` for the normalized machine-readable model instead of TOON. Read
    `quotaSemantics.effectiveAvailability` rather than treating a model window in isolation:
    account windows can bound every model, and `boundedBy` names every window included in the
@@ -147,6 +148,13 @@ or when comparing supported local provider headroom side by side.
     `remainingFraction`/`resetTime` (or model config fallbacks). Window relationships are
     unknown, so there is no combined remaining percentage. Pace stays unknown because the
     snapshot has no honest burn-rate history.
+12. For Kiro, quota-axi reads the current user's Kiro CLI SQLite auth store in
+    `~/.local/share/kiro-cli/data.sqlite3` (override with `KIRO_CLI_DB`) without modifying it.
+    It sends the stored short-lived access token only to Kiro's first-party
+    CodeWhisperer `GetUsageLimits` endpoint, reports the returned credit usage and reset, and
+    never prints or includes token, email, profile ARN, or refresh-token values. Use
+    `KIRO_REGION` for non-default regional installs and sign in with Kiro again when the
+    stored access token is expired.
 
 ## Usage
 
@@ -157,7 +165,7 @@ commands[3]:
 output:
   Default TOON reports local quota evidence. models is a deterministic data join; --sort runway is explicit opt-in ordering. --tui renders a live human terminal report instead (q quits).
 flags[11]:
-  --provider <claude,codex,cursor,copilot,grok,kimi,zai,agy>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
+  --provider <claude,codex,cursor,copilot,grok,kimi,zai,agy,kiro>, --json, --full, --tui, --refresh <30s-24h>, --once, --allow-keychain-prompt, --intelligence <high|medium|low>, --sort <runway>, --help, -v/--version
 examples:
   quota-axi
   quota-axi --provider claude

--- a/src/interpretation.ts
+++ b/src/interpretation.ts
@@ -103,6 +103,7 @@ function semanticsFor(
       return cursorSemantics(provider.windows, generatedAt);
     case "copilot":
     case "agy":
+    case "kiro":
       return unknownSemantics(
         provider.windows,
         `quota-axi does not know whether ${provider.label ?? provider.provider}'s reported windows are independent or jointly bounding, so it does not claim an effective remaining percentage.`,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ import { copilotAdapter } from "./copilot.js";
 import { cursorAdapter } from "./cursor.js";
 import { grokAdapter } from "./grok.js";
 import { kimiAdapter } from "./kimi.js";
+import { kiroAdapter } from "./kiro.js";
 import { zaiAdapter } from "./zai.js";
 import {
   PROVIDER_IDS,
@@ -21,6 +22,7 @@ export const PROVIDERS: Record<ProviderId, ProviderAdapter> = {
   kimi: kimiAdapter,
   zai: zaiAdapter,
   agy: agyAdapter,
+  kiro: kiroAdapter,
 };
 
 export function parseProviders(value: string | undefined): ProviderId[] {

--- a/src/providers/kiro.ts
+++ b/src/providers/kiro.ts
@@ -1,0 +1,521 @@
+import { createRequire } from "node:module";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readCachedProvider } from "../cache.js";
+import { collapseHome } from "../lib/fs.js";
+import {
+  clampPercent,
+  nowIso,
+  parseEpochOrIso,
+  percentRemaining,
+  retryAfterToIso,
+} from "../lib/time.js";
+import { VERSION } from "../version.js";
+import type {
+  AuthSourceReport,
+  ProviderAdapter,
+  ProviderOptions,
+  ProviderQuota,
+  QuotaWindow,
+  SourceAttempt,
+} from "../types.js";
+import {
+  failedProvider,
+  sourceNames,
+  staleFromCache,
+  statusFromError,
+  successProvider,
+} from "./common.js";
+
+const KIRO_DB_ENV = "KIRO_CLI_DB";
+const KIRO_REGION_ENV = "KIRO_REGION";
+const KIRO_PROFILE_ARN_ENV = "KIRO_PROFILE_ARN";
+const KIRO_DB_DEFAULT = join(
+  homedir(),
+  ".local",
+  "share",
+  "kiro-cli",
+  "data.sqlite3",
+);
+const KIRO_TOKEN_KEY = "kirocli:odic:token";
+const API_TIMEOUT_MS = 15_000;
+const API_TARGET = "AmazonCodeWhispererService.GetUsageLimits";
+
+const require = createRequire(import.meta.url);
+type SqliteStatement = { get(...params: unknown[]): unknown };
+type SqliteDatabase = {
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+};
+type SqliteDatabaseConstructor = new (
+  path: string,
+  options?: { readOnly?: boolean },
+) => SqliteDatabase;
+const { DatabaseSync } = require("node:sqlite") as {
+  DatabaseSync: SqliteDatabaseConstructor;
+};
+
+type KiroCredentials = { accessToken: string; region: string };
+export type KiroCredentialState =
+  | {
+      status: "available";
+      credentials: KiroCredentials;
+      source: AuthSourceReport;
+    }
+  | {
+      status: "missing" | "invalid" | "expired";
+      source: AuthSourceReport;
+    };
+type KiroDependencies = {
+  fetch?: typeof fetch;
+  readCredentialState?: () => KiroCredentialState;
+};
+
+export const kiroAdapter: ProviderAdapter = createKiroAdapter();
+
+export function createKiroAdapter(
+  dependencies: KiroDependencies = {},
+): ProviderAdapter {
+  const readCredentials =
+    dependencies.readCredentialState ?? readCredentialState;
+  return {
+    id: "kiro",
+    label: "Kiro",
+    fetchQuota: (options) =>
+      fetchQuotaWith(
+        options,
+        dependencies.fetch ?? globalThis.fetch,
+        readCredentials,
+      ),
+    inspectAuth: async () => ({
+      provider: "kiro",
+      sources: [readCredentials().source],
+    }),
+  };
+}
+
+export async function fetchQuota(
+  options: ProviderOptions,
+): Promise<ProviderQuota> {
+  return fetchQuotaWith(options, globalThis.fetch, readCredentialState);
+}
+
+async function fetchQuotaWith(
+  _options: ProviderOptions,
+  request: typeof fetch,
+  readCredentials: () => KiroCredentialState,
+): Promise<ProviderQuota> {
+  const attempts: SourceAttempt[] = [];
+  const credentialState = readCredentials();
+  const source = "kiro-sqlite";
+
+  if (credentialState.status !== "available") {
+    attempts.push({
+      source,
+      status: "skipped",
+      error: `credentials_${credentialState.status}`,
+    });
+    const finalError = "Kiro sign-in required";
+    const cached = readCachedProvider("kiro");
+    if (cached) {
+      return staleFromCache(
+        cached,
+        finalError,
+        sourceNames(attempts),
+        attempts,
+      );
+    }
+    return failedProvider({
+      provider: "kiro",
+      label: "Kiro",
+      status: statusFromError(finalError),
+      error: finalError,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  }
+
+  attempts.push({ source, status: "failed" });
+  try {
+    const quota = await fetchKiroUsage(credentialState.credentials, request);
+    attempts[attempts.length - 1] = { source, status: "success" };
+    return successProvider({
+      provider: "kiro",
+      label: "Kiro",
+      source: "api",
+      plan: quota.plan,
+      windows: quota.windows,
+      credits: quota.credits,
+      refreshedAt: quota.refreshedAt,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  } catch (error) {
+    const finalError = errorMessage(error);
+    attempts[attempts.length - 1] = {
+      source,
+      status: "failed",
+      error: finalError,
+    };
+    const retryAfter =
+      error instanceof RateLimitError ? error.retryAfter : undefined;
+    const cached = readCachedProvider("kiro");
+    if (cached) {
+      return staleFromCache(
+        cached,
+        finalError,
+        sourceNames(attempts),
+        attempts,
+      );
+    }
+    return failedProvider({
+      provider: "kiro",
+      label: "Kiro",
+      status: retryAfter ? "rate_limited" : statusFromError(finalError),
+      error: finalError,
+      retryAfter,
+      sourcesTried: sourceNames(attempts),
+      attempts,
+    });
+  }
+}
+
+export function normalizeKiroUsage(raw: unknown):
+  | {
+      plan?: string;
+      windows: QuotaWindow[];
+      credits?: ProviderQuota["credits"];
+      refreshedAt: string;
+    }
+  | undefined {
+  const data = objectValue(raw);
+  if (!data) return undefined;
+  const resetAt = parseEpochOrIso(data.nextDateReset ?? data.next_date_reset);
+  const breakdowns = arrayValue(
+    data.usageBreakdownList ?? data.usage_breakdown_list,
+  );
+  const windows = normalizeBreakdowns(breakdowns, resetAt);
+  const fallbackWindows =
+    windows.length > 0
+      ? windows
+      : normalizeLimits(arrayValue(data.limits), resetAt);
+  const subscription = objectValue(
+    data.subscriptionInfo ?? data.subscription_info,
+  );
+  const plan =
+    stringValue(subscription?.subscriptionTitle) ??
+    stringValue(subscription?.type);
+  if (fallbackWindows.length === 0 && !plan && !subscription) return undefined;
+  const balance = creditBalance(breakdowns);
+  return {
+    plan,
+    windows: fallbackWindows,
+    credits:
+      balance === undefined
+        ? undefined
+        : { remaining: balance, unit: "credits" },
+    refreshedAt: nowIso(),
+  };
+}
+
+async function fetchKiroUsage(
+  credentials: KiroCredentials,
+  request: typeof fetch,
+): Promise<{
+  plan?: string;
+  windows: QuotaWindow[];
+  credits?: ProviderQuota["credits"];
+  refreshedAt: string;
+}> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+  try {
+    const body: Record<string, unknown> = { isEmailRequired: true };
+    const profileArn = process.env[KIRO_PROFILE_ARN_ENV]?.trim();
+    if (profileArn) body.profileArn = profileArn;
+    const response = await request(
+      `https://codewhisperer.${credentials.region}.amazonaws.com/`,
+      {
+        method: "POST",
+        redirect: "manual",
+        credentials: "omit",
+        headers: {
+          authorization: `Bearer ${credentials.accessToken}`,
+          accept: "application/json",
+          "content-type": "application/x-amz-json-1.0",
+          "user-agent": `quota-axi/${VERSION}`,
+          "x-amz-target": API_TARGET,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      },
+    );
+    rejectUnusableResponse(response);
+    const quota = normalizeKiroUsage(await response.json());
+    if (!quota) throw new Error("Kiro quota unavailable");
+    return quota;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function readCredentialState(
+  databasePath = process.env[KIRO_DB_ENV] || KIRO_DB_DEFAULT,
+): KiroCredentialState {
+  const path = collapseHome(databasePath);
+  let database: SqliteDatabase;
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true });
+  } catch (error) {
+    const missing = errorCode(error) === "ENOENT";
+    return {
+      status: missing ? "missing" : "invalid",
+      source: {
+        source: "kiro-sqlite",
+        path,
+        status: missing ? "missing" : "invalid",
+        error: missing ? undefined : "database_read_error",
+      },
+    };
+  }
+  try {
+    const row = objectValue(
+      database
+        .prepare("SELECT value FROM auth_kv WHERE key = ?")
+        .get(KIRO_TOKEN_KEY),
+    );
+    const raw = stringValue(row?.value);
+    if (!raw) {
+      return {
+        status: "missing",
+        source: { source: "kiro-sqlite", path, status: "missing" },
+      };
+    }
+    let token: Record<string, unknown>;
+    try {
+      token = objectValue(JSON.parse(raw)) ?? {};
+    } catch {
+      return {
+        status: "invalid",
+        source: {
+          source: "kiro-sqlite",
+          path,
+          status: "invalid",
+          error: "json_parse_error",
+        },
+      };
+    }
+    const accessToken = stringValue(token.access_token);
+    const region =
+      stringValue(process.env[KIRO_REGION_ENV]) ??
+      stringValue(token.region) ??
+      "us-east-1";
+    if (!accessToken || !/^[a-z0-9-]+$/.test(region)) {
+      return {
+        status: "invalid",
+        source: {
+          source: "kiro-sqlite",
+          path,
+          status: "invalid",
+          error: "credential_shape_invalid",
+        },
+      };
+    }
+    const expiresAt = epochMillis(token.expires_at);
+    if (expiresAt !== undefined && expiresAt <= Date.now()) {
+      return {
+        status: "expired",
+        source: {
+          source: "kiro-sqlite",
+          path,
+          status: "expired",
+          error: "access_token_expired",
+        },
+      };
+    }
+    return {
+      status: "available",
+      credentials: { accessToken, region },
+      source: { source: "kiro-sqlite", path, status: "available" },
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function creditBalance(values: unknown[]): number | undefined {
+  for (const value of values) {
+    const item = objectValue(value);
+    if (!item) continue;
+    const used =
+      numberValue(item.currentUsageWithPrecision) ??
+      numberValue(item.current_usage_with_precision) ??
+      numberValue(item.currentUsage) ??
+      numberValue(item.current_usage);
+    const limit =
+      numberValue(item.usageLimitWithPrecision) ??
+      numberValue(item.usage_limit_with_precision) ??
+      numberValue(item.usageLimit) ??
+      numberValue(item.usage_limit);
+    if (used !== undefined && limit !== undefined && limit > 0)
+      return Math.max(0, limit - used);
+  }
+  return undefined;
+}
+
+function normalizeBreakdowns(
+  values: unknown[],
+  fallbackReset: string | undefined,
+): QuotaWindow[] {
+  return values
+    .map((value, index): QuotaWindow | undefined => {
+      const item = objectValue(value);
+      if (!item) return undefined;
+      const used =
+        numberValue(item.currentUsageWithPrecision) ??
+        numberValue(item.current_usage_with_precision) ??
+        numberValue(item.currentUsage) ??
+        numberValue(item.current_usage);
+      const limit =
+        numberValue(item.usageLimitWithPrecision) ??
+        numberValue(item.usage_limit_with_precision) ??
+        numberValue(item.usageLimit) ??
+        numberValue(item.usage_limit);
+      if (used === undefined || limit === undefined || limit <= 0)
+        return undefined;
+      const percentUsed = clampPercent((used / limit) * 100);
+      const resource =
+        stringValue(item.resourceType) ??
+        stringValue(item.resource_type) ??
+        stringValue(item.displayName) ??
+        `credit_${index + 1}`;
+      const label =
+        stringValue(item.displayNamePlural) ??
+        stringValue(item.display_name_plural) ??
+        stringValue(item.displayName) ??
+        "Credits";
+      return {
+        id: slug(resource, index),
+        label,
+        kind: "credits" as const,
+        percentUsed,
+        percentRemaining: percentRemaining(percentUsed),
+        resetsAt:
+          parseEpochOrIso(item.nextDateReset ?? item.next_date_reset) ??
+          fallbackReset,
+      };
+    })
+    .filter((window): window is QuotaWindow => Boolean(window));
+}
+
+function normalizeLimits(
+  values: unknown[],
+  fallbackReset: string | undefined,
+): QuotaWindow[] {
+  return values
+    .map((value, index): QuotaWindow | undefined => {
+      const item = objectValue(value);
+      if (!item) return undefined;
+      const directPercent = numberValue(item.percentUsed ?? item.percent_used);
+      const used = numberValue(item.currentUsage ?? item.current_usage);
+      const limit = numberValue(item.totalUsageLimit ?? item.total_usage_limit);
+      const percentUsed =
+        directPercent !== undefined
+          ? clampPercent(directPercent)
+          : used !== undefined && limit !== undefined && limit > 0
+            ? clampPercent((used / limit) * 100)
+            : undefined;
+      if (percentUsed === undefined) return undefined;
+      const feature =
+        stringValue(item.feature) ??
+        stringValue(item.resourceType) ??
+        `limit_${index + 1}`;
+      return {
+        id: slug(feature, index),
+        label: humanize(feature),
+        kind: "credits",
+        percentUsed,
+        percentRemaining: percentRemaining(percentUsed),
+        resetsAt: fallbackReset,
+      };
+    })
+    .filter((window): window is QuotaWindow => Boolean(window));
+}
+
+function slug(value: string, index: number): string {
+  const normalized = value
+    .trim()
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase();
+  return normalized || `credit_${index + 1}`;
+}
+
+function humanize(value: string): string {
+  return value
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function rejectUnusableResponse(response: Response): void {
+  if (response.status >= 300 && response.status < 400)
+    throw new Error("redirect_rejected");
+  if (response.status === 429)
+    throw new RateLimitError(
+      retryAfterToIso(response.headers.get("retry-after")),
+    );
+  if (response.status === 401 || response.status === 403)
+    throw new Error("Kiro sign-in required");
+  if (!response.ok)
+    throw new Error(`Kiro quota unavailable (${response.status})`);
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() !== "" ? value : undefined;
+}
+function numberValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+function epochMillis(value: unknown): number | undefined {
+  const number = numberValue(value);
+  if (number !== undefined)
+    return number > 10_000_000_000 ? number : number * 1000;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+  return undefined;
+}
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    ? typeof error.code === "string"
+      ? error.code
+      : undefined
+    : undefined;
+}
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError")
+    return "Kiro quota request timed out";
+  return error instanceof Error ? error.message : "Kiro quota unavailable";
+}
+class RateLimitError extends Error {
+  constructor(readonly retryAfter: string | undefined) {
+    super("Kiro quota endpoint rate limited");
+  }
+}

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -3,7 +3,7 @@ import { DESCRIPTION, TOP_HELP } from "./cli.js";
 // Trigger string Claude Code (and other agents) match against to auto-load the skill.
 // Kept terse and outcome-focused so it fires on "check quota/rate limits" intents.
 export const SKILL_DESCRIPTION =
-  "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, and Antigravity quota windows via the quota-axi CLI - remaining " +
+  "Report local Claude, Codex, Cursor, GitHub Copilot, Grok, Kimi, Z.AI, Antigravity, and Kiro quota windows via the quota-axi CLI - remaining " +
   "effective usable runway, percentages, reset times, cycle-average pace vs the reset clock, a per-scope selection signal, and provider status read from local auth sources, " +
   "with no routing, provider mutation, or default ordering preference. Use before deciding whether it is safe " +
   "to keep spending a provider's quota, when the user asks about usage, rate limits, pace, or " +
@@ -26,6 +26,7 @@ export const HERMES_TAGS = [
   "kimi",
   "zai",
   "agy",
+  "kiro",
   "antigravity",
   "cli",
 ];
@@ -74,7 +75,7 @@ derived per-scope comparative selection signal, \`effectiveAvailability[].select
 computed from figures it already reports; it still ranks nothing and routes nowhere, and the
 consumer decides what to do with it. It reads local provider auth sources and calls
 first-party provider quota, usage, billing, entitlement, local loopback, or read-only credential-liveness endpoints; it never launches the
-Claude, Cursor, Grok, Pi, Kimi, opencode, or Antigravity/agy CLIs, so it cannot spend the quota it measures.
+Claude, Cursor, Grok, Pi, Kimi, opencode, Antigravity/agy, or Kiro CLIs, so it cannot spend the quota it measures.
 
 ## When to use
 
@@ -98,7 +99,7 @@ or when comparing supported local provider headroom side by side.
    unknown or stale headroom gets no \`quota[]\` row at all - read its \`attention[]\` row instead
    of inferring a number. If that scope has finite runway, the attention detail preserves the
    runway verdict and limiting window without creating an orphan \`exhaustion[]\` row.
-2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok,kimi,zai,agy\`.
+2. Scope to one provider with \`--provider claude\` or to a subset with \`--provider cursor,copilot,grok,kimi,zai,agy,kiro\`.
 3. Pass \`--json\` for the normalized machine-readable model instead of TOON. Read
    \`quotaSemantics.effectiveAvailability\` rather than treating a model window in isolation:
    account windows can bound every model, and \`boundedBy\` names every window included in the
@@ -185,6 +186,13 @@ or when comparing supported local provider headroom side by side.
     \`remainingFraction\`/\`resetTime\` (or model config fallbacks). Window relationships are
     unknown, so there is no combined remaining percentage. Pace stays unknown because the
     snapshot has no honest burn-rate history.
+12. For Kiro, quota-axi reads the current user's Kiro CLI SQLite auth store in
+    \`~/.local/share/kiro-cli/data.sqlite3\` (override with \`KIRO_CLI_DB\`) without modifying it.
+    It sends the stored short-lived access token only to Kiro's first-party
+    CodeWhisperer \`GetUsageLimits\` endpoint, reports the returned credit usage and reset, and
+    never prints or includes token, email, profile ARN, or refresh-token values. Use
+    \`KIRO_REGION\` for non-default regional installs and sign in with Kiro again when the
+    stored access token is expired.
 
 ## Usage
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -75,6 +75,7 @@ const ACCENTS: Record<ProviderId, StyleSpec> = {
   kimi: { rgb: [245, 194, 231], ansi16: "95", bold: true },
   zai: { rgb: [129, 216, 209], ansi16: "96", bold: true },
   agy: { rgb: [232, 184, 109], ansi16: "93", bold: true },
+  kiro: { rgb: [155, 140, 255], ansi16: "95", bold: true },
 };
 
 const STYLES: Record<Exclude<StyleName, `accent:${ProviderId}`>, StyleSpec> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,8 @@ export type ProviderId =
   | "grok"
   | "kimi"
   | "zai"
-  | "agy";
+  | "agy"
+  | "kiro";
 
 export const PROVIDER_IDS = [
   "claude",
@@ -17,6 +18,7 @@ export const PROVIDER_IDS = [
   "kimi",
   "zai",
   "agy",
+  "kiro",
 ] as const satisfies readonly ProviderId[];
 
 export type ProviderSource =

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -21,6 +21,7 @@ const originalGrokProvider = PROVIDERS.grok;
 const originalKimiProvider = PROVIDERS.kimi;
 const originalZaiProvider = PROVIDERS.zai;
 const originalAgyProvider = PROVIDERS.agy;
+const originalKiroProvider = PROVIDERS.kiro;
 const originalXdgCacheHome = process.env.XDG_CACHE_HOME;
 let tempDir: string | undefined;
 
@@ -33,6 +34,7 @@ afterEach(() => {
   PROVIDERS.kimi = originalKimiProvider;
   PROVIDERS.zai = originalZaiProvider;
   PROVIDERS.agy = originalAgyProvider;
+  PROVIDERS.kiro = originalKiroProvider;
   if (originalXdgCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
   else process.env.XDG_CACHE_HOME = originalXdgCacheHome;
   if (tempDir) rmSync(tempDir, { recursive: true, force: true });
@@ -52,6 +54,7 @@ describe("CLI flag parsing", () => {
       "kimi",
       "zai",
       "agy",
+      "kiro",
     ]);
   });
 
@@ -87,6 +90,7 @@ describe("CLI flag parsing", () => {
           "kimi",
           "zai",
           "agy",
+          "kiro",
         ],
         json: true,
         full: true,
@@ -716,6 +720,13 @@ describe("default TOON decision blocks", () => {
     PROVIDERS.kimi = providerWithQuota(rateLimitedKimiQuota());
     PROVIDERS.zai = providerWithQuota(freshZaiQuota());
     PROVIDERS.agy = providerWithQuota(unavailableAgyQuota());
+    PROVIDERS.kiro = providerWithQuota({
+      provider: "kiro",
+      label: "Kiro",
+      source: "unavailable",
+      windows: [],
+      state: { status: "unavailable", stale: false, sourcesTried: [] },
+    });
 
     const output = await capture([]);
     const named = new Set([
@@ -731,6 +742,7 @@ describe("default TOON decision blocks", () => {
       "cursor",
       "grok",
       "kimi",
+      "kiro",
       "zai",
     ]);
   });

--- a/test/providers/kiro.test.ts
+++ b/test/providers/kiro.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createKiroAdapter,
+  normalizeKiroUsage,
+  type KiroCredentialState,
+} from "../../src/providers/kiro.js";
+
+const OPTIONS = { allowKeychainPrompt: false };
+const ORIGINAL_CACHE_HOME = process.env.XDG_CACHE_HOME;
+
+beforeEach(() => {
+  process.env.XDG_CACHE_HOME = "/tmp/quota-axi-kiro-test-cache";
+});
+
+afterEach(() => {
+  if (ORIGINAL_CACHE_HOME === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = ORIGINAL_CACHE_HOME;
+});
+const ACCESS_TOKEN = "synthetic-kiro-token";
+const SOURCE = {
+  source: "kiro-sqlite",
+  path: "~/.local/share/kiro-cli/data.sqlite3",
+  status: "available" as const,
+};
+const CREDENTIALS: KiroCredentialState = {
+  status: "available",
+  credentials: { accessToken: ACCESS_TOKEN, region: "us-east-1" },
+  source: SOURCE,
+};
+const USAGE_PAYLOAD = {
+  nextDateReset: 1_788_220_800,
+  subscriptionInfo: {
+    subscriptionTitle: "KIRO PRO+",
+    type: "Q_DEVELOPER_STANDALONE_PRO_PLUS",
+  },
+  usageBreakdownList: [
+    {
+      currentUsageWithPrecision: 500,
+      usageLimitWithPrecision: 2000,
+      displayName: "Credit",
+      displayNamePlural: "Credits",
+      resourceType: "CREDIT",
+    },
+  ],
+};
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers?: HeadersInit,
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+describe("Kiro quota normalization", () => {
+  it("normalizes credit usage, plan, balance, and reset", () => {
+    expect(normalizeKiroUsage(USAGE_PAYLOAD)).toMatchObject({
+      plan: "KIRO PRO+",
+      credits: { remaining: 1500, unit: "credits" },
+      windows: [
+        {
+          id: "credit",
+          label: "Credits",
+          kind: "credits",
+          percentUsed: 25,
+          percentRemaining: 75,
+          resetsAt: "2026-09-01T00:00:00.000Z",
+        },
+      ],
+    });
+  });
+
+  it("accepts the compact limits shape when usage breakdowns are absent", () => {
+    expect(
+      normalizeKiroUsage({
+        limits: [{ feature: "AGENTIC_REQUEST", percentUsed: 30 }],
+      }),
+    ).toMatchObject({
+      windows: [
+        {
+          id: "agentic_request",
+          label: "Agentic Request",
+          percentUsed: 30,
+          percentRemaining: 70,
+        },
+      ],
+    });
+  });
+
+  it("rejects empty responses instead of inventing quota", () => {
+    expect(normalizeKiroUsage({})).toBeUndefined();
+    expect(normalizeKiroUsage(null)).toBeUndefined();
+  });
+});
+
+describe("Kiro quota transport", () => {
+  it("calls the first-party usage endpoint with a read-only bearer request", async () => {
+    const request = vi.fn(async () => jsonResponse(USAGE_PAYLOAD));
+    const adapter = createKiroAdapter({
+      fetch: request,
+      readCredentialState: () => CREDENTIALS,
+    });
+    const report = await adapter.fetchQuota(OPTIONS);
+    expect(request).toHaveBeenCalledOnce();
+    const [input, init] = request.mock.calls[0];
+    expect(String(input)).toBe(
+      "https://codewhisperer.us-east-1.amazonaws.com/",
+    );
+    expect(init).toMatchObject({
+      method: "POST",
+      redirect: "manual",
+      credentials: "omit",
+      body: JSON.stringify({ isEmailRequired: true }),
+    });
+    const headers = new Headers(init?.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${ACCESS_TOKEN}`);
+    expect(headers.get("x-amz-target")).toBe(
+      "AmazonCodeWhispererService.GetUsageLimits",
+    );
+    expect(headers.get("content-type")).toBe("application/x-amz-json-1.0");
+    expect(headers.get("cookie")).toBeNull();
+    expect(report).toMatchObject({
+      provider: "kiro",
+      label: "Kiro",
+      source: "api",
+      state: { status: "fresh", sourcesTried: ["kiro-sqlite"] },
+      attempts: [{ source: "kiro-sqlite", status: "success" }],
+      plan: "KIRO PRO+",
+    });
+    expect(JSON.stringify(report)).not.toContain(ACCESS_TOKEN);
+  });
+
+  it("reports missing credentials without making a request", async () => {
+    const request = vi.fn();
+    const missing: KiroCredentialState = {
+      status: "missing",
+      source: {
+        source: "kiro-sqlite",
+        path: "~/.local/share/kiro-cli/data.sqlite3",
+        status: "missing",
+      },
+    };
+    const report = await createKiroAdapter({
+      fetch: request,
+      readCredentialState: () => missing,
+    }).fetchQuota(OPTIONS);
+    expect(request).not.toHaveBeenCalled();
+    expect(report.state.status).toBe("auth_required");
+    expect(report.attempts).toEqual([
+      {
+        source: "kiro-sqlite",
+        status: "skipped",
+        error: "credentials_missing",
+      },
+    ]);
+  });
+
+  it("classifies throttling and preserves retry-after", async () => {
+    const request = vi.fn(
+      async () =>
+        new Response(null, { status: 429, headers: { "retry-after": "120" } }),
+    );
+    const report = await createKiroAdapter({
+      fetch: request,
+      readCredentialState: () => CREDENTIALS,
+    }).fetchQuota(OPTIONS);
+    expect(report.state.status).toBe("rate_limited");
+    expect(report.state.retryAfter).toBeDefined();
+    expect(report.state.error).toBe("Kiro quota endpoint rate limited");
+  });
+});


### PR DESCRIPTION
## Summary
- add a real Kiro provider using the first-party `AmazonCodeWhispererService.GetUsageLimits` endpoint
- read Kiro CLI auth from SQLite in read-only mode, with `KIRO_CLI_DB`, `KIRO_REGION`, and optional `KIRO_PROFILE_ARN` overrides
- normalize Kiro credit usage, plan, balance, reset data, auth reporting, CLI/TUI/skill/docs integration, and redacted error/cache behavior

## Safety
- never writes or refreshes Kiro credentials
- never launches `kiro-cli`
- never emits token, email, profile ARN, or refresh-token values

## Validation
- `pnpm test` (608 tests)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build:skill -- --check`
- live `node dist/bin/quota-axi.js --provider kiro --json` returned fresh KIRO PRO+ usage
- live quota-dash `/api/health` and `/api/quota?force=1` smoke test passed against the built binary