### PR TITLE
fix: upgrade undici to 6.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@toon-format/toon": "2.1.0",
     "axi-sdk-js": "^0.1.10",
     "proxy-from-env": "2.1.0",
-    "undici": "6.24.1"
+    "undici": "6.28.0"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       undici:
-        specifier: 6.24.1
-        version: 6.24.1
+        specifier: 6.28.0
+        version: 6.28.0
     devDependencies:
       "@eslint/js":
         specifier: 10.0.1
@@ -1694,10 +1694,10 @@ packages:
         integrity: sha512-mIDEX2ek50x0OlRgxryxsenE5XaQD4on5U2inY7RApK3SOJpofyw7uW2AyfMKkhAxXIceo2DeWGVGwyvng1GNQ==,
       }
 
-  undici@6.24.1:
+  undici@6.28.0:
     resolution:
       {
-        integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==,
+        integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==,
       }
     engines: { node: ">=18.17" }
 
@@ -2660,7 +2660,7 @@ snapshots:
 
   undici-types@6.11.1: {}
 
-  undici@6.24.1: {}
+  undici@6.28.0: {}
 
   uri-js@4.4.1:
     dependencies:


### PR DESCRIPTION
## Intent

The developer wanted the two high-severity dependency findings from quota-axi's audit investigated and fixed in separate pull requests, with this change limited to undici. They required upgrading the exact undici pin from 6.24.1 to the lowest 6.x release that clears all seven advisories, 6.28.0, and updating the Prettier-formatted lockfile without changing other dependencies. They wanted compatibility checked against the project's actual undici use and confirmation that the undici advisories were cleared. Delivery required a concise, factual pull request through the repository's no-mistakes gate, with all required checks green; the authorised fork was AgardnerAU/quota-axi, and merging remained the upstream author's decision.

## What Changed

- Upgrade the exact undici dependency pin from 6.24.1 to 6.28.0.
- Update the matching lockfile resolution and integrity hash, with no other dependency changes.

## Risk Assessment

✅ Low: The change updates only the exact undici pin and matching lockfile entries, with no identified compatibility defect or unnecessary scope.

## Testing

Frozen-lockfile installation, focused HTTP and Copilot tests, registry audit comparison, and CLI proxy checks passed. An initial manual TOON assertion was corrected to match its documented output contract. CLI and audit evidence were saved; temporary files were removed.

<details>
<summary>Evidence: CLI output through a local HTTPS proxy</summary>

```text
End-to-end CLI verification with undici 6.28.0
Local CONNECT proxy and locally trusted TLS fixture for api.github.com. No vendor calls or real credentials.

$ node --import tsx bin/quota-axi.ts --provider copilot --no-credential-refresh
bin: ~/.no-mistakes/worktrees/aebc5b9f0f97/01M1YXJJ9P6EH4ZTRP4HVRTWS7/bin/quota-axi.ts
description: Report local agent-provider quota windows for routing-aware agents
generatedAt: "2026-09-07T21:53:20.900Z"
quota[0]:
exhaustion[0]:
attention[1]{provider,scope,kind,detail,remedy}:
  copilot,all,unresolved_windows,premium_interactions,none
help[1]:
  Run `quota-axi --full` for windows, pace, reserve, and account evidence
Exit status: 0

$ node --import tsx bin/quota-axi.ts --provider copilot --no-credential-refresh --json
{
  "generatedAt": "2026-09-07T21:53:21.055Z",
  "schemaVersion": 5,
  "providers": [
    {
      "provider": "copilot",
      "plan": "individual",
      "windows": [
        {
          "id": "premium_interactions",
          "label": "premium interactions",
          "kind": "monthly",
          "percentRemaining": 75,
          "resetsAt": "2026-10-01T00:00:00.000Z",
          "pace": {
            "status": "unknown",
            "reason": "missing_cycle"
          }
        }
      ],
      "state": {
        "status": "fresh",
        "stale": false
      },
      "quotaSemantics": {
        "status": "unknown",
        "effectiveAvailability": [],
        "unresolvedWindowIds": [
          "premium_interactions"
        ]
      }
    }
  ]
}
Exit status: 0

Proxy observations: CONNECT api.github.com:443; CONNECT api.github.com:443
GET /copilot_internal/user -> 200 (synthetic fixture)
GET /copilot_internal/user -> 200 (synthetic fixture)
```
</details>
<details>
<summary>Evidence: Undici audit comparison</summary>

```text
{
  "registry": "https://registry.npmjs.org/-/npm/v1/security/advisories/bulk",
  "checkedAt": "2026-09-07T21:53:07.063Z",
  "results": {
    "6.24.1": {
      "undici": [
        {
          "id": 1130716,
          "url": "https://github.com/advisories/GHSA-8xcm-r25x-g524",
          "title": "undici vulnerable to downstream response desynchronization via retry interceptor",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-444"
          ],
          "cvss": {
            "score": 4.8,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
          }
        },
        {
          "id": 1130727,
          "url": "https://github.com/advisories/GHSA-m8rv-5g2x-5cg5",
          "title": "undici vulnerable to CRLF Injection via blob-like body 'type' property",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-93"
          ],
          "cvss": {
            "score": 4.2,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
          }
        },
        {
          "id": 1130732,
          "url": "https://github.com/advisories/GHSA-v3r7-h72x-cjcm",
          "title": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-74"
          ],
          "cvss": {
            "score": 4.8,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
          }
        },
        {
          "id": 1121242,
          "url": "https://github.com/advisories/GHSA-p88m-4jfj-68fv",
          "title": "undici vulnerable to HTTP header injection via Set-Cookie percent-decoding",
          "severity": "moderate",
          "vulnerable_versions": "<6.27.0",
          "cwe": [
            "CWE-93"
          ],
          "cvss": {
            "score": 5.9,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N"
          }
        },
        {
          "id": 1121245,
          "url": "https://github.com/advisories/GHSA-vxpw-j846-p89q",
          "title": "undici WebSocket client vulnerable to denial of service via fragment count bypass",
          "severity": "high",
          "vulnerable_versions": "<6.27.0",
          "cwe": [
            "CWE-400",
            "CWE-770"
          ],
          "cvss": {
            "score": 7.5,
            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
          }
        },
        {
          "id": 1121255,
          "url": "https://github.com/advisories/GHSA-g8m3-5g58-fq7m",
          "title": "undici vulnerable to Set-Cookie SameSite attribute downgrade via permissive substring matching",
          "severity": "low",
          "vulnerable_versions": "<6.27.0",
          "cwe": [
            "CWE-183"
          ],
          "cvss": {
            "score": 3.7,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
          }
        },
        {
          "id": 1137243,
          "url": "https://github.com/advisories/GHSA-35p6-xmwp-9g52",
          "title": "undici vulnerable to HTTP response queue poisoning via keep-alive socket reuse",
          "severity": "low",
          "vulnerable_versions": "<6.27.0",
          "cwe": [
            "CWE-367"
          ],
          "cvss": {
            "score": 3.7,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
          }
        }
      ]
    },
    "6.27.0": {
      "undici": [
        {
          "id": 1130716,
          "url": "https://github.com/advisories/GHSA-8xcm-r25x-g524",
          "title": "undici vulnerable to downstream response desynchronization via retry interceptor",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-444"
          ],
          "cvss": {
            "score": 4.8,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
          }
        },
        {
          "id": 1130727,
          "url": "https://github.com/advisories/GHSA-m8rv-5g2x-5cg5",
          "title": "undici vulnerable to CRLF Injection via blob-like body 'type' property",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-93"
          ],
          "cvss": {
            "score": 4.2,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
          }
        },
        {
          "id": 1130732,
          "url": "https://github.com/advisories/GHSA-v3r7-h72x-cjcm",
          "title": "undici vulnerable to cookie attribute injection via unsanitized domain and unparsed setCookie fields",
          "severity": "moderate",
          "vulnerable_versions": "<6.28.0",
          "cwe": [
            "CWE-74"
          ],
          "cvss": {
            "score": 4.8,
            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
          }
        }
      ]
    },
    "6.28.0": {}
  },
  "summary": {
    "6.24.1": 7,
    "6.27.0": 3,
    "6.28.0": 0
  },
  "targetAudit": {
    "undiciAdvisories": 0,
    "otherAdvisories": 12
  }
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"be78167c3c3ffce0f195065329b34466c3218b76","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile`
- `pnpm exec vitest run test/lib/http.test.ts test/providers/copilot.test.ts`
- <code>`pnpm audit --json` - no undici findings; unrelated dependency findings remain.</code>
- <code>`node .test-undici/audit.mjs` - npm registry comparison: seven advisories for 6.24.1, three for 6.27.0, none for 6.28.0.</code>
- <code>`node .test-undici/cli-proxy.mjs` - CLI TOON and JSON through a local CONNECT proxy and trusted TLS fixture; asserted fresh quota data using synthetic credentials.</code>
- `Removed temporary fixtures and installed dependencies; verified clean working tree.`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
